### PR TITLE
Replace hand-built Prison fixture with factory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ end
 group :test do
   gem 'capybara'
   gem 'database_cleaner'
+  gem 'factory_girl_rails'
   gem 'launchy'
   gem 'poltergeist'
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,11 @@ GEM
     equalizer (0.0.11)
     erubis (2.7.0)
     execjs (2.5.2)
+    factory_girl (4.5.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.5.0)
+      factory_girl (~> 4.5.0)
+      railties (>= 3.0.0)
     fastercsv (1.5.5)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
@@ -231,6 +236,7 @@ DEPENDENCIES
   byebug
   capybara
   database_cleaner
+  factory_girl_rails
   govuk_frontend_toolkit (= 2.0.1)
   launchy
   moj_template (= 0.21.0)

--- a/spec/factories/prisons.rb
+++ b/spec/factories/prisons.rb
@@ -1,0 +1,15 @@
+FactoryGirl.define do
+  factory :prison do
+    name 'Reading Gaol'
+    nomis_id 'XYZ'
+    enabled true
+    estate 'Reading'
+    address '1 High Street'
+    email_address 'reading.gaol@test.example.com'
+    phone_no '01154960123'
+    slot_details recurring: {
+      mon: ['1400-1610'],
+      tue: ['0900-1000', '1400-1610']
+    }
+  end
+end

--- a/spec/features/request_a_visit_spec.rb
+++ b/spec/features/request_a_visit_spec.rb
@@ -2,21 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Booking a visit', js: true do
   before do
-    Prison.create!(
-      name: 'Reading Gaol',
-      nomis_id: 'XYZ',
-      enabled: true,
-      estate: 'Reading',
-      address: '1 High Street',
-      email_address: 'reading.gaol@test.example.com',
-      phone_no: '01154960123',
-      slot_details: {
-        'recurring' => {
-          'mon' => ['1400-1610'],
-          'tue' => ['0900-1000', '1400-1610']
-        }
-      }
-    )
+    create(:prison)
   end
 
   scenario 'happy path' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,6 +15,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = false
+  config.include FactoryGirl::Syntax::Methods
 
   config.infer_spec_type_from_file_location!
 


### PR DESCRIPTION
I was going to leave Prison.create!(...) in the before block in
`request_a_visit_spec.rb` alone.  It seemed the simplest possible
soluiton.  However, when I went to to port `visit_mailer_spec.rb` from
the old app, I realised I was going to have to either abstract or
duplicate Prison.create!(...). Neither solution seemed ideal, so I
decided it was time to go ahead and add factories using factory_girl. I
chose factory_girl as it is the most commonly used and best understood
of the fixture replacments.