### PR TITLE
Configuration of shoulda-matchers Gem

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -39,3 +39,10 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
We added and configures the shoulda-matchers Gem because it provides
RSpec-compatible one-liners that test common Rails functionality.
These tests would otherwise be much longer, more complex, and
error-prone.