### PR TITLE
Add reference number to visit

### DIFF
--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -11,6 +11,8 @@ class Visit < ActiveRecord::Base
 
   delegate :email_address, to: :prison, prefix: true
 
+  before_create :set_reference_number
+
   def prisoner_full_name
     [prisoner_first_name, prisoner_last_name].join(' ')
   end
@@ -30,5 +32,11 @@ class Visit < ActiveRecord::Base
   def slots
     [slot_option_1, slot_option_2, slot_option_3].
       select(&:present?).map { |s| ConcreteSlot.parse(s) }
+  end
+
+private
+
+  def set_reference_number
+    self.reference_number = SecureRandom.uuid
   end
 end

--- a/db/migrate/20151110102448_alter_visits_add_reference_number.rb
+++ b/db/migrate/20151110102448_alter_visits_add_reference_number.rb
@@ -1,0 +1,5 @@
+class AlterVisitsAddReferenceNumber < ActiveRecord::Migration
+  def change
+    add_column :visits, :reference_number, :string, null: false, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151027171043) do
+ActiveRecord::Schema.define(version: 20151110102448) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 20151027171043) do
     t.string   "processing_state",       default: "requested", null: false
     t.datetime "created_at",                                   null: false
     t.datetime "updated_at",                                   null: false
+    t.string   "reference_number",                             null: false
   end
 
   add_index "visits", ["prison_id"], name: "index_visits_on_prison_id", using: :btree

--- a/spec/factories/visits.rb
+++ b/spec/factories/visits.rb
@@ -10,7 +10,8 @@ FactoryGirl.define do
     end
 
     prisoner_date_of_birth '1970-01-01'
-    prisoner_number do |n|
+
+    sequence(:prisoner_number) do |n|
       'ABC%04d' % n
     end
 
@@ -35,6 +36,9 @@ FactoryGirl.define do
     slot_option_1 do |v|
       v.prison.available_slots.first.iso8601
     end
+
     processing_state 'start'
+
+    reference_number { SecureRandom.uuid }
   end
 end

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -1,6 +1,23 @@
 require 'rails_helper'
 
-RSpec.describe Visit do
+RSpec.describe Visit, type: :model do
+  subject { build(:visit) }
+
+  specify do
+    expect(subject.valid?).to be_truthy
+  end
+
+  describe '.reference_number' do
+    before do
+      subject.reference_number = nil
+      allow(SecureRandom).to receive(:uuid).and_return('some-uuid')
+    end
+
+    it 'is generated automatically when visit is created' do
+      expect { subject.save }.to change { subject.reference_number }.from(nil).to('some-uuid')
+    end
+  end
+
   describe 'prisoner_age' do
     it 'calculates age' do
       subject.prisoner_date_of_birth = Date.new(1995, 10, 8)


### PR DESCRIPTION

    We were going to use Base32 for this, but then decided to use v4 UUIDs
    instead.  A Base32 long enough to prevent collisions would only be
    slightly shorter than a UUID, would require further explanation and
    additional gems.