### PR TITLE
Add log metadata

### DIFF
--- a/app/services/booking_request_creator.rb
+++ b/app/services/booking_request_creator.rb
@@ -3,10 +3,15 @@ class BookingRequestCreator
     params = build_params(prisoner_step, visitors_step, slots_step)
     Visit.create!(params).tap { |visit|
       PrisonMailer.request_received(visit).deliver_later
+      add_log_metadata visit_id: visit.id
     }
   end
 
 private
+
+  def add_log_metadata(hash)
+    LogStasher.request_context.merge!(hash)
+  end
 
   def build_params(prisoner_step, visitors_step, slots_step)
     [

--- a/spec/services/booking_request_creator_spec.rb
+++ b/spec/services/booking_request_creator_spec.rb
@@ -54,27 +54,29 @@ RSpec.describe BookingRequestCreator do
         slot_option_1: '2015-01-02T09:00/10:00',
         slot_option_2: '2015-01-03T09:00/10:00',
         slot_option_3: '2015-01-04T09:00/10:00'
-      ).and_return double(Visit, id: 2)
+      ).and_return instance_double(Visit, id: 2)
 
-    described_class.new.create! prisoner_step, visitors_step, slots_step
+    subject.create! prisoner_step, visitors_step, slots_step
   end
 
-  it 'emails the prison' do
-    visit = double(Visit, id: 2)
-    allow(Visit).to receive(:create!).and_return(visit)
-    expect(PrisonMailer).to receive(:request_received).with(visit).
-      and_return(mailing)
-    expect(mailing).to receive(:deliver_later)
+  context 'emailing and logging' do
+    let(:visit) { instance_double(Visit, id: 2) }
 
-    described_class.new.create! prisoner_step, visitors_step, slots_step
-  end
+    before do
+      LogStasher.request_context.replace({})
+      allow(Visit).to receive(:create!).and_return(visit)
+    end
 
-  it 'logs the visit id' do
-    visit = double(Visit, id: 2)
-    allow(Visit).to receive(:create!).and_return(visit)
+    it 'emails the prison' do
+      expect(PrisonMailer).to receive(:request_received).with(visit).
+        and_return(mailing)
+      expect(mailing).to receive(:deliver_later)
+      subject.create! prisoner_step, visitors_step, slots_step
+    end
 
-    expect(LogStasher.request_context).to match(visit_id: 2)
-
-    described_class.new.create! prisoner_step, visitors_step, slots_step
+    it 'logs the visit id' do
+      subject.create! prisoner_step, visitors_step, slots_step
+      expect(LogStasher.request_context).to match(visit_id: 2)
+    end
   end
 end

--- a/spec/services/booking_request_creator_spec.rb
+++ b/spec/services/booking_request_creator_spec.rb
@@ -54,13 +54,13 @@ RSpec.describe BookingRequestCreator do
         slot_option_1: '2015-01-02T09:00/10:00',
         slot_option_2: '2015-01-03T09:00/10:00',
         slot_option_3: '2015-01-04T09:00/10:00'
-      )
+      ).and_return double(Visit, id: 2)
 
     described_class.new.create! prisoner_step, visitors_step, slots_step
   end
 
   it 'emails the prison' do
-    visit = double(Visit)
+    visit = double(Visit, id: 2)
     allow(Visit).to receive(:create!).and_return(visit)
     expect(PrisonMailer).to receive(:request_received).with(visit).
       and_return(mailing)

--- a/spec/services/booking_request_creator_spec.rb
+++ b/spec/services/booking_request_creator_spec.rb
@@ -68,4 +68,13 @@ RSpec.describe BookingRequestCreator do
 
     described_class.new.create! prisoner_step, visitors_step, slots_step
   end
+
+  it 'logs the visit id' do
+    visit = double(Visit, id: 2)
+    allow(Visit).to receive(:create!).and_return(visit)
+
+    expect(LogStasher.request_context).to match(visit_id: 2)
+
+    described_class.new.create! prisoner_step, visitors_step, slots_step
+  end
 end


### PR DESCRIPTION
We added log metadata method to ensure that we'll be able to see
the visit_id throughout the Booking Request Creator process.