### PR TITLE
Remove impossible and useless migration

### DIFF
--- a/db/migrate/20151110102448_alter_visits_add_reference_number.rb
+++ b/db/migrate/20151110102448_alter_visits_add_reference_number.rb
@@ -1,5 +1,0 @@
-class AlterVisitsAddReferenceNumber < ActiveRecord::Migration
-  def change
-    add_column :visits, :reference_number, :string, null: false, index: true
-  end
-end


### PR DESCRIPTION
Adding a non-null field with no default in one step does not work unless the database is empty. The normal solution to this would be to perform the operation in two steps. However, in this case, the next migration will delete the table entirely (because we do not yet have any useful data) so it's effectively useless.