### PR TITLE
Restore foreign key enforcement

### DIFF
--- a/db/migrate/20151117162316_restore_foreign_keys.rb
+++ b/db/migrate/20151117162316_restore_foreign_keys.rb
@@ -1,0 +1,6 @@
+class RestoreForeignKeys < ActiveRecord::Migration
+  def change
+    add_foreign_key "additional_visitors", "visits"
+    add_foreign_key "visits", "prisons"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151112112210) do
+ActiveRecord::Schema.define(version: 20151117162316) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,4 +64,6 @@ ActiveRecord::Schema.define(version: 20151112112210) do
 
   add_index "visits", ["prison_id"], name: "index_visits_on_prison_id", using: :btree
 
+  add_foreign_key "additional_visitors", "visits"
+  add_foreign_key "visits", "prisons"
 end


### PR DESCRIPTION
Data integrity is your friend.

This was inadvertently lost in the move to UUID table IDs.