### PR TITLE
Explain to the user why they received this email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby '2.2.3'
 gem 'rails', '~> 4.2.3'
 
 gem 'govuk_frontend_toolkit', '2.0.1'
+gem 'high_voltage'
 gem 'logstasher'
 gem 'moj_template', '0.21.0'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
     haml (4.0.6)
       tilt
     hashdiff (0.2.2)
+    high_voltage (2.4.0)
     highline (1.6.21)
     htmlentities (4.3.4)
     httparty (0.13.7)
@@ -296,6 +297,7 @@ DEPENDENCIES
   ffaker
   fuubar
   govuk_frontend_toolkit (= 2.0.1)
+  high_voltage
   launchy
   logstasher
   moj_template (= 0.21.0)

--- a/app/views/pages/unsubscribe.html.erb
+++ b/app/views/pages/unsubscribe.html.erb
@@ -1,0 +1,11 @@
+<% content_for :header, "Why did I receive this email?" %>
+<p>
+<%= t('.you_received_an_email',
+      email: 'no-reply@email.prisonvisits.service.gov.uk') %>
+</p>
+<p>
+  <%= t('.why') %>
+</p>
+<p>
+  <%= t('.confirmation') %>
+</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,5 @@ module PrisonVisits
     config.time_zone = 'London'
 
     config.active_record.raise_in_transactional_callbacks = true
-    config.unsubscribe_url =
-      '<https://www.prisonvisits.service.gov.uk/unsubscribe>'
   end
 end

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -1,0 +1,9 @@
+en:
+  pages:
+    unsubscribe:
+      you_received_an_email: You’ve received an email from %{email}
+      why: This is probably because you requested a prison visit.
+      confirmation: >
+        We’ll confirm your visit by email, so make sure you add this email
+        address to your address book or safe senders list.
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,6 @@ Rails.application.routes.draw do
   namespace :prison do
     resources :visits, only: %i[ edit update ]
   end
+
+  get 'unsubscribe' => 'high_voltage/pages#show', id: 'unsubscribe'
 end

--- a/spec/features/unsubscribe_spec.rb
+++ b/spec/features/unsubscribe_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.feature 'Booking a visit', js: true do
+  include ActiveJobHelper
+
+  scenario 'happy path' do
+    visit unsubscribe_path
+    expect(page).to have_text('Why did I receive this email?')
+    expect(page).to have_text('because you requested a prison visit.')
+  end
+end


### PR DESCRIPTION
After discussion, we decided `unsubscribe` was likely a bad name for
this page.  However, this is the from in which it exists on the current
app, so I am porting it as-is.  That said, there is an outstanding
ticket for the wording and intent to be reveiwed.