### PR TITLE
Make SimpleCov gem exclusion more general

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ RSpec.configure do |config|
     config.default_formatter = 'doc'
   else
     SimpleCov.start 'rails' do
-      add_filter '/gem/'
+      add_filter '/gems/'
     end
   end
 


### PR DESCRIPTION
If you bundle into `vendor`, SimpleCov will ignore gems anyway. If you bundle into `.bundle/gem`, the previous configuration would work. But no matter where you bundle, the gems will have `/gems/` somewhere in the path, making this a solution that should just work for everybody.