### PR TITLE
Send copy of booking email to prison

### DIFF
--- a/app/mailers/prison_mailer.rb
+++ b/app/mailers/prison_mailer.rb
@@ -15,4 +15,13 @@ class PrisonMailer < ActionMailer::Base
            request_date: format_date_of_visit(visit.slots.first.begin_at)
          )
   end
+
+  def booked(visit)
+    @visit = visit
+
+    mail to: visit.prison_email_address,
+         subject: default_i18n_subject(
+           prisoner: visit.prisoner_full_name
+         )
+  end
 end

--- a/app/services/booking_responder.rb
+++ b/app/services/booking_responder.rb
@@ -46,5 +46,6 @@ private
 
   def notify_accepted(visit)
     VisitorMailer.booked(visit).deliver_later
+    PrisonMailer.booked(visit).deliver_later
   end
 end

--- a/app/views/layouts/email.html.erb
+++ b/app/views/layouts/email.html.erb
@@ -9,14 +9,6 @@
         <%= image_tag(attachments['govuk-header-logo.png'].url) %>
       </div>
       <div class="content">
-        <% if content_for? :copy_notice %>
-          <p class="copy-notice">
-            <strong>
-              <%= yield :copy_notice %>
-            </strong>
-          </p>
-        <% end %>
-
         <%= yield %>
       </div>
     </div>

--- a/app/views/prison_mailer/booked.html.erb
+++ b/app/views/prison_mailer/booked.html.erb
@@ -1,0 +1,5 @@
+<p class="copy-notice">
+  <strong><%= t('.copy_of_booking') %></strong>
+</p>
+
+<%= render(template: 'visitor_mailer/booked') %>

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -17,6 +17,11 @@ en:
         If you cannot click on the link above, copy the entire link and paste
         it into the address bar of your browser.
       visit_id: 'Visit ID:'
+    booked:
+      subject: >
+        COPY of booking confirmation for %{prisoner}
+      copy_of_booking: >
+        This is a copy of the booking confirmation email sent to the visitor
   visitor_mailer:
     booked:
       subject: >

--- a/spec/features/process_a_request_spec.rb
+++ b/spec/features/process_a_request_spec.rb
@@ -3,13 +3,22 @@ require 'rails_helper'
 RSpec.feature 'Processing a request', js: true do
   include ActiveJobHelper
 
-  let(:prison) { create(:prison, name: 'Reading Gaol') }
-  let(:email_address) { 'visitor@test.example.com' }
+  let(:visitor_email_address) { 'visitor@test.example.com' }
+  let(:prison_email_address) { 'prison@test.example.com' }
+  let(:prison) {
+    create(
+      :prison,
+      name: 'Reading Gaol',
+      email_address: prison_email_address
+    )
+  }
   let(:vst) {
     create(
       :visit,
       prison: prison,
-      visitor_email_address: email_address
+      visitor_email_address: visitor_email_address,
+      prisoner_first_name: 'Oscar',
+      prisoner_last_name: 'Wilde'
     )
   }
 
@@ -27,10 +36,14 @@ RSpec.feature 'Processing a request', js: true do
     expect(vst).to be_booked
     expect(vst.reference_no).to eq('12345678')
 
-    expect(email_address).
+    expect(visitor_email_address).
       to receive_email.
       with_subject(/Visit confirmed: your visit for \w+ \d+ \w+ has been confirmed/).
       and_body(/Your visit to Reading Gaol is now successfully confirmed/)
+    expect(prison_email_address).
+      to receive_email.
+      with_subject(/COPY of booking confirmation for Oscar Wilde/).
+      and_body(/This is a copy of the booking confirmation email sent to the visitor/)
   end
 
   scenario 'rejecting a booking with no available slot' do

--- a/spec/services/booking_responder_spec.rb
+++ b/spec/services/booking_responder_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe BookingResponder do
 
   before do
     allow(VisitorMailer).to receive(:booked).and_return(mailing)
+    allow(PrisonMailer).to receive(:booked).and_return(mailing)
   end
 
   context 'accepting a request' do
@@ -54,11 +55,18 @@ RSpec.describe BookingResponder do
         expect(visit_after_responding).not_to be_closed
       end
 
-      it 'emails the prison' do
+      it 'emails the visitor' do
         expect(VisitorMailer).to receive(:booked).with(visit).
           and_return(mailing)
         expect(mailing).to receive(:deliver_later)
-        visit_after_responding
+        subject.respond!
+      end
+
+      it 'emails the prison' do
+        expect(PrisonMailer).to receive(:booked).with(visit).
+          and_return(mailing)
+        expect(mailing).to receive(:deliver_later)
+        subject.respond!
       end
     end
 

--- a/spec/support/matchers/email_matchers.rb
+++ b/spec/support/matchers/email_matchers.rb
@@ -4,11 +4,15 @@ RSpec::Matchers.define :receive_email do
       ActionMailer::Base.deliveries.select { |e| e.to.include?(address) }
 
     emails.select! { |e| e.subject.match(subject) } if subject
-    emails.select! { |e| e.text_part.body.match(body) } if body
+    emails.select! { |e| body_matches?(e, body) } if body
     emails.any?
   end
 
   chain :with_subject, :subject
   chain :with_body, :body
   chain :and_body, :body
+
+  def body_matches?(email, pattern)
+    email.text_part.body.to_s.gsub(/\s+/, ' ').match(pattern)
+  end
 end


### PR DESCRIPTION
It is useful for the prison to have a copy of the information sent in order to resolve disputes (especially around what was or was not communicated to the visitor).