### PR TITLE
Send emails to visitors and prisons when a booking is rejected

### DIFF
--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -24,8 +24,9 @@ private
     params.
       require(:booking_response).
       permit(
-        :selection, :reference_no, :closed_visit, :vo_will_be_renewed,
-        :vo_renewed_on, :pvo_possible, :pvo_expires_on,
+        :selection, :reference_no, :closed_visit,
+        :allowance_will_renew, :allowance_renews_on,
+        :privileged_allowance_available, :privileged_allowance_expires_on,
         :visitor_not_on_list, :visitor_banned
       ).
       merge(visit: visit)

--- a/app/mailers/prison_mailer.rb
+++ b/app/mailers/prison_mailer.rb
@@ -24,4 +24,13 @@ class PrisonMailer < ActionMailer::Base
            prisoner: visit.prisoner_full_name
          )
   end
+
+  def rejected(visit)
+    @visit = visit
+
+    mail to: visit.prison_email_address,
+         subject: default_i18n_subject(
+           prisoner: visit.prisoner_full_name
+         )
+  end
 end

--- a/app/mailers/visitor_mailer.rb
+++ b/app/mailers/visitor_mailer.rb
@@ -31,4 +31,16 @@ class VisitorMailer < ActionMailer::Base
       )
     )
   end
+
+  def rejected(visit)
+    @visit = visit
+
+    mail(
+      reply_to: visit.prison_email_address,
+      to: visit.recipient,
+      subject: default_i18n_subject(
+        date: format_date_of_visit(visit.first_date)
+      )
+    )
+  end
 end

--- a/app/models/booking_response.rb
+++ b/app/models/booking_response.rb
@@ -12,12 +12,17 @@ class BookingResponse
   validates :reference_no, presence: true, if: :slot_selected?
   attribute :closed_visit, Virtus::Attribute::Boolean
 
-  attribute :vo_will_be_renewed, Virtus::Attribute::Boolean
-  attribute :vo_renewed_on, Date
-  validates :vo_renewed_on, presence: true, if: :vo_will_be_renewed
-  attribute :pvo_possible, Virtus::Attribute::Boolean
-  attribute :pvo_expires_on, Date
-  validates :pvo_expires_on, presence: true, if: :pvo_possible
+  attribute :allowance_will_renew, Virtus::Attribute::Boolean
+  attribute :allowance_renews_on, Date
+  validates :allowance_renews_on,
+    presence: true,
+    if: :allowance_will_renew
+
+  attribute :privileged_allowance_available, Virtus::Attribute::Boolean
+  attribute :privileged_allowance_expires_on, Date
+  validates :privileged_allowance_expires_on,
+    presence: true,
+    if: :privileged_allowance_available
 
   delegate :slots, :prison, :to_param,
     :prisoner_full_name, :prisoner_number, :prisoner_date_of_birth,

--- a/app/models/rejection.rb
+++ b/app/models/rejection.rb
@@ -11,4 +11,12 @@ class Rejection < ActiveRecord::Base
   belongs_to :visit
 
   validates :reason, inclusion: { in: REASONS }
+
+  def pvo_possible?
+    pvo_expires_on.present?
+  end
+
+  def vo_will_be_renewed?
+    vo_renewed_on.present?
+  end
 end

--- a/app/models/rejection.rb
+++ b/app/models/rejection.rb
@@ -12,11 +12,11 @@ class Rejection < ActiveRecord::Base
 
   validates :reason, inclusion: { in: REASONS }
 
-  def pvo_possible?
-    pvo_expires_on.present?
+  def privileged_allowance_available?
+    privileged_allowance_expires_on.present?
   end
 
-  def vo_will_be_renewed?
-    vo_renewed_on.present?
+  def allowance_will_renew?
+    allowance_renews_on.present?
   end
 end

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -23,8 +23,8 @@ class Visit < ActiveRecord::Base
   end
 
   delegate :reason, to: :rejection, prefix: true
-  delegate :pvo_possible?, :pvo_expires_on,
-    :vo_will_be_renewed?,  :vo_renewed_on,
+  delegate :privileged_allowance_available?, :privileged_allowance_expires_on,
+    :allowance_will_renew?,  :allowance_renews_on,
     to: :rejection
 
   state_machine :processing_state, initial: :requested do

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -23,6 +23,9 @@ class Visit < ActiveRecord::Base
   end
 
   delegate :reason, to: :rejection, prefix: true
+  delegate :pvo_possible?, :pvo_expires_on,
+    :vo_will_be_renewed?,  :vo_renewed_on,
+    to: :rejection
 
   state_machine :processing_state, initial: :requested do
     event :accept do

--- a/app/services/booking_responder.rb
+++ b/app/services/booking_responder.rb
@@ -52,5 +52,6 @@ private
 
   def notify_rejected(visit)
     VisitorMailer.rejected(visit).deliver_later
+    PrisonMailer.rejected(visit).deliver_later
   end
 end

--- a/app/services/booking_responder.rb
+++ b/app/services/booking_responder.rb
@@ -32,6 +32,7 @@ private
     rejection = Rejection.new(visit: visit, reason: booking_response.selection)
     copy_no_allowance_parameters rejection if booking_response.no_allowance?
     rejection.save!
+    notify_rejected visit
   end
 
   def copy_no_allowance_parameters(rejection)
@@ -47,5 +48,9 @@ private
   def notify_accepted(visit)
     VisitorMailer.booked(visit).deliver_later
     PrisonMailer.booked(visit).deliver_later
+  end
+
+  def notify_rejected(visit)
+    VisitorMailer.rejected(visit).deliver_later
   end
 end

--- a/app/services/booking_responder.rb
+++ b/app/services/booking_responder.rb
@@ -36,12 +36,13 @@ private
   end
 
   def copy_no_allowance_parameters(rejection)
-    if booking_response.vo_will_be_renewed?
-      rejection.vo_renewed_on = booking_response.vo_renewed_on
+    if booking_response.allowance_will_renew?
+      rejection.allowance_renews_on = booking_response.allowance_renews_on
     end
 
-    if booking_response.pvo_possible?
-      rejection.pvo_expires_on = booking_response.pvo_expires_on
+    if booking_response.privileged_allowance_available?
+      rejection.privileged_allowance_expires_on =
+        booking_response.privileged_allowance_expires_on
     end
   end
 

--- a/app/views/prison/visits/_visiting_allowance_section.html.erb
+++ b/app/views/prison/visits/_visiting_allowance_section.html.erb
@@ -17,26 +17,26 @@
   <h3><%= t('prison.visits.shared.what_we_will_tell') %></h3>
 
   <blockquote>
-    <%= t('.no_vo_wording_html') %>
+    <%= t('.no_allowance_wording_html') %>
   </blockquote>
 
-  <p><%= t('.no_vo_tell_more') %></p>
+  <p><%= t('.no_allowance_tell_more') %></p>
 
   <%=
     single_field(
-      f, :vo_will_be_renewed, :check_box,
+      f, :allowance_will_renew, :check_box,
       class: 'js-Conditional',
-      data: { 'conditional-el': 'vo_will_be_renewed_details' }
+      data: { 'conditional-el': 'allowance_will_renew_details' }
     )
   %>
 
-  <div id="vo_will_be_renewed_details">
-    <%= error_container(f, :vo_renewed_on) do %>
+  <div id="allowance_will_renew_details">
+    <%= error_container(f, :allowance_renews_on) do %>
       <%=
         render(
           'calendar',
           prison: f.object.prison,
-          name: 'booking_response[vo_renewed_on]'
+          name: 'booking_response[allowance_renews_on]'
         )
       %>
     <% end %>
@@ -46,7 +46,7 @@
     <blockquote>
       <%=
         t(
-          '.vo_will_be_renewed_wording_html',
+          '.allowance_will_renew_wording_html',
           prisoner: f.object.prisoner_full_name
         )
       %>
@@ -55,19 +55,19 @@
 
   <%=
     single_field(
-      f, :pvo_possible, :check_box,
+      f, :privileged_allowance_available, :check_box,
       class: 'js-Conditional',
-      data: { 'conditional-el': 'pvo_possible_details' }
+      data: { 'conditional-el': 'privileged_allowance_available_details' }
     )
   %>
 
-  <div id="pvo_possible_details">
-    <%= error_container(f, :pvo_expires_on) do %>
+  <div id="privileged_allowance_available_details">
+    <%= error_container(f, :privileged_allowance_expires_on) do %>
       <%=
         render(
           'calendar',
           prison: f.object.prison,
-          name: 'booking_response[pvo_expires_on]'
+          name: 'booking_response[privileged_allowance_expires_on]'
         )
       %>
     <% end %>
@@ -75,7 +75,7 @@
     <h3><%= t('prison.visits.shared.what_we_will_tell') %></h3>
 
     <blockquote>
-      <%= t('.pvo_possible_wording_html') %>
+      <%= t('.privileged_allowance_available_wording_html') %>
     </blockquote>
   </div>
 </div>

--- a/app/views/prison_mailer/rejected.html.erb
+++ b/app/views/prison_mailer/rejected.html.erb
@@ -1,0 +1,5 @@
+<p class="copy-notice">
+  <strong><%= t('.copy_of_rejection') %></strong>
+</p>
+
+<%= render(template: 'visitor_mailer/rejected') %>

--- a/app/views/visitor_mailer/rejected.html.erb
+++ b/app/views/visitor_mailer/rejected.html.erb
@@ -1,0 +1,53 @@
+<p><%= t('.salutation', name: @visit.visitor_first_name) %></p>
+
+<% case @visit.rejection_reason %>
+<% when 'slot_unavailable' %>
+
+  <p><%= t('.slot_unavailable_html',
+           prisoner: @visit.prisoner_anonymized_name,
+           prison: @visit.prison_name) %>
+  <p><%= t('.alternatives_html') %></p>
+
+<% when 'no_allowance' %>
+
+  <p><%= t('.no_allowance') %></p>
+
+  <% if @visit.pvo_possible? %>
+    <p><%= t('.pvo_possible',
+             date: format_date_of_visit(@visit.pvo_expires_on)) %></p>
+  <% end %>
+
+  <% if @visit.vo_will_be_renewed? %>
+    <p><%= t('.vo_renewal',
+             prisoner: @visit.prisoner_anonymized_name,
+             date: format_date_of_visit(@visit.vo_renewed_on)) %></p>
+  <% end %>
+
+<% when 'prisoner_details_incorrect' %>
+
+  <p><%= t('.prisoner_details_incorrect') %></p>
+
+<% when 'prisoner_moved' %>
+
+  <p><%= t('.prisoner_moved_html') %></p>
+
+<% when 'visitor_banned' %>
+
+  <p><%= t('.visitor_banned',
+           visitor: @visit.visitor_anonymized_name) %></p>
+
+<% when 'visitor_not_on_list' %>
+
+  <p><%= t('.visitor_not_on_list',
+           visitor: @visit.visitor_anonymized_name) %></p>
+
+  <p><%= t('.update_list') %></p>
+
+  <p><%= t('.first_visit') %></p>
+
+<% end %>
+
+<p><%= t('.any_questions_html',
+         url: '/TODO-prison-finder-url',
+         phone_no: @visit.prison_phone_no) %></p>
+<p><%= t('.visit_id') %></p>

--- a/app/views/visitor_mailer/rejected.html.erb
+++ b/app/views/visitor_mailer/rejected.html.erb
@@ -12,15 +12,15 @@
 
   <p><%= t('.no_allowance') %></p>
 
-  <% if @visit.pvo_possible? %>
-    <p><%= t('.pvo_possible',
-             date: format_date_of_visit(@visit.pvo_expires_on)) %></p>
+  <% if @visit.privileged_allowance_available? %>
+    <p><%= t('.privileged_allowance_available',
+             date: format_date_of_visit(@visit.privileged_allowance_expires_on)) %></p>
   <% end %>
 
-  <% if @visit.vo_will_be_renewed? %>
-    <p><%= t('.vo_renewal',
+  <% if @visit.allowance_will_renew? %>
+    <p><%= t('.allowance_will_renew',
              prisoner: @visit.prisoner_anonymized_name,
-             date: format_date_of_visit(@visit.vo_renewed_on)) %></p>
+             date: format_date_of_visit(@visit.allowance_renews_on)) %></p>
   <% end %>
 
 <% when 'prisoner_details_incorrect' %>

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -148,6 +148,55 @@ en:
         If you have a question or need any help with the online visits service,
         please <a href="%{url}">contact us</a>.
       visit_id: "Visit ID:"
+    rejected:
+      subject: >
+        Visit cannot take place: your visit for %{date} could not be booked
+      salutation: Dear %{name}
+      slot_unavailable_html: >
+        We’re sorry but none of the dates and times you chose to visit
+        <strong>%{prisoner}</strong> at <strong>%{prison}</strong>
+        were available.
+      alternatives_html: >
+        Please visit
+        <a href="https://www.gov.uk/prison-visits">www.gov.uk/prison-visits</a>
+        to choose some alternative dates.
+      no_allowance: >
+        We’re sorry, but the prisoner you want to visit has not got any
+        visiting allowance left for the dates you’ve chosen.
+      pvo_possible: >
+        However, you can book a weekday visit with visiting allowance valid
+        until %{date}. The visit must be taken before the allowance expires.
+      vo_renewal: >
+        %{prisoner} will have their full visiting allowance (VO) renewed on
+        %{date}.
+      prisoner_details_incorrect: >
+        Your visit cannot take place as you haven’t given correct information
+        for the prisoner. Eg, the prisoner’s name, number or date of birth is
+        incorrect. Contact the prisoner to get up-to-date information.
+      prisoner_moved_html: >
+        Your visit cannot take place as the prisoner you want to visit has
+        moved prison. They should contact you about where they are now. You can
+        also use the
+        <a href="http://www.gov.uk/find-prisoner">find a prisoner service</a>.
+      visitor_banned:
+        Your visit cannot take place. %{visitor} should have received a letter
+        to say that they’re banned from visiting the prison at the moment. Get
+        in touch with the prison for more information.
+      visitor_not_on_list:
+        Your visit cannot take place as details for %{visitor} don’t match our
+        records or they aren’t on the prisoner’s contact list.
+      update_list:
+        Please contact the prisoner and ask them to update their contact list
+        with correct details, making sure that names appear exactly the same as
+        on ID documents.
+      first_visit:
+        If this is the prisoner’s first visit (reception visit), then you need
+        to contact the prison to book.
+      any_questions_html:
+        If you have any questions, visit the
+        <a href="%{url}">prison website</a> or call the prison on
+        <strong>%{phone_no}</strong>.
+      visit_id: "Visit ID:"
     request_acknowledged:
       subject: "Not booked yet: we’ve received your visit request for %{receipt_date}"
       add_address: >

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -22,6 +22,11 @@ en:
         COPY of booking confirmation for %{prisoner}
       copy_of_booking: >
         This is a copy of the booking confirmation email sent to the visitor
+    rejected:
+      subject: >
+        COPY of booking rejection for %{prisoner}
+      copy_of_rejection: >
+        This is a copy of the booking rejection email sent to the visitor
   visitor_mailer:
     booked:
       subject: >

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -149,6 +149,7 @@ en:
         please <a href="%{url}">contact us</a>.
       visit_id: "Visit ID:"
     request_acknowledged:
+      subject: "Not booked yet: we’ve received your visit request for %{receipt_date}"
       add_address: >
         To stop visit confirmation emails going to your spam or junk folder
         please add %{email} to your address book or safe senders list.
@@ -169,7 +170,6 @@ en:
         other: You have requested a visit to %{prison} for %{count} people
       salutation: "Dear %{visitor_full_name}"
       status: "Your visit is not booked yet"
-      subject: "Not booked yet: we’ve received your visit request for %{receipt_date}"
       phone_no: "Phone:"
       email_address: "Email:"
       when_to_check_spam: >

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -1,22 +1,22 @@
 en:
   mailer:
-    noreply: 'Prison Visits Booking (Unattended) <noreply@%{domain}>'
+    noreply: "Prison Visits Booking (Unattended) <noreply@%{domain}>"
   prison_mailer:
     request_received:
-      subject: 'Visit request for %{full_name} on %{request_date}'
-      prisoner: 'Prisoner:'
-      number: 'Number:'
-      date_of_birth: 'Date of birth:'
-      choice: 'Choice %{n}'
-      visitor: 'Visitor %{n}'
-      age: 'Age:'
-      email_address: 'Email:'
-      phone_no: 'Phone:'
-      process_booking: 'Process the booking'
+      subject: "Visit request for %{full_name} on %{request_date}"
+      prisoner: "Prisoner:"
+      number: "Number:"
+      date_of_birth: "Date of birth:"
+      choice: "Choice %{n}"
+      visitor: "Visitor %{n}"
+      age: "Age:"
+      email_address: "Email:"
+      phone_no: "Phone:"
+      process_booking: "Process the booking"
       copy_paste_explanation: >
         If you cannot click on the link above, copy the entire link and paste
         it into the address bar of your browser.
-      visit_id: 'Visit ID:'
+      visit_id: "Visit ID:"
     booked:
       subject: >
         COPY of booking confirmation for %{prisoner}
@@ -29,10 +29,10 @@ en:
       salutation: Dear %{name},
       visit_confirmed: Your visit to %{prison} is now successfully confirmed.
       please_arrive: Please arrive 45 minutes before your visit starts.
-      prisoner: 'Prisoner:'
-      number: 'Number:'
-      visitor: 'Visitor %{n}:'
-      reference_no: 'Your reference number is:'
+      prisoner: "Prisoner:"
+      number: "Number:"
+      visitor: "Visitor %{n}:"
+      reference_no: "Your reference number is:"
       this_is_a_closed_visit_html: >
         <strong>This is a closed visit:</strong>
         the prisoner will be behind a glass screen in a separate area rather
@@ -42,10 +42,10 @@ en:
         coming, contact the prison.
       questions_about_your_visit: Questions about your visit
       dont_reply: >
-        Please don't reply to this email if you have any other questions about
+        Please don’t reply to this email if you have any other questions about
         your visit. Instead you must contact us directly.
-      phone_no: 'Phone:'
-      email_address: 'Email:'
+      phone_no: "Phone:"
+      email_address: "Email:"
       add_to_address_book_title: Add this email to your address book
       add_to_address_book_body: >
         To stop visit confirmation emails going to your spam or junk folder
@@ -73,18 +73,18 @@ en:
             benefits book
           </li>
           <li>
-            senior citizen's public transport photo pass issued by a local
+            senior citizen’s public transport photo pass issued by a local
             authority
           </li>
           <li>
-            employer's or student ID card but only if this has a photo and
+            employer’s or student ID card but only if this has a photo and
             clearly shows your name and the issuing employer or educational
             establishment
           </li>
         </ul>
 
         <p>
-          If you don't have one of these forms of ID, you can bring TWO of
+          If you don’t have one of these forms of ID, you can bring TWO of
           the following:
         </p>
 
@@ -96,19 +96,19 @@ en:
             cheque book or credit or debit card
           </li>
           <li>
-            employer's pass or ID or student ID card without photo
+            employer’s pass or ID or student ID card without photo
           </li>
           <li>
-            young person's 'proof of age' card
+            young person’s ‘proof of age’ card
           </li>
           <li>
-            trade union or National Students' Union membership card
+            trade union or National Students’ Union membership card
           </li>
           <li>
             rent book
           </li>
           <li>
-            foreign identity or residents' card
+            foreign identity or residents’ card
           </li>
         </ul>
       any_questions: >
@@ -147,31 +147,31 @@ en:
       need_help_body_html: >
         If you have a question or need any help with the online visits service,
         please <a href="%{url}">contact us</a>.
-      visit_id: 'Visit ID:'
+      visit_id: "Visit ID:"
     request_acknowledged:
       add_address: >
         To stop visit confirmation emails going to your spam or junk folder
         please add %{email} to your address book or safe senders list.
-      add_to_address_book: 'Add this email to your address book'
-      cancel: 'If you no longer want to visit on this date'
-      cancellation_title: 'Cancel this visit request'
-      choice: 'Choice %{n}'
-      details: 'Visit request details'
-      email: 'email:'
+      add_to_address_book: "Add this email to your address book"
+      cancel: "If you no longer want to visit on this date"
+      cancellation_title: "Cancel this visit request"
+      choice: "Choice %{n}"
+      details: "Visit request details"
+      email: "email:"
       feedback_html: >
         Need help or want to make a complaint? If you have a question or need
         any help with the online visits service, please
         <a href="%{url}">contact us</a>.
-      prisoner: 'Prisoner:'
-      prisoner_number: 'Prisoner number:'
+      prisoner: "Prisoner:"
+      prisoner_number: "Prisoner number:"
       request:
         one: You have requested a visit to %{prison} for %{count} person
         other: You have requested a visit to %{prison} for %{count} people
-      salutation: 'Dear %{visitor_full_name}'
-      status: 'Your visit is not booked yet'
-      subject: 'Not booked yet: we’ve received your visit request for %{receipt_date}'
-      phone_no: 'Phone:'
-      email_address: 'Email:'
+      salutation: "Dear %{visitor_full_name}"
+      status: "Your visit is not booked yet"
+      subject: "Not booked yet: we’ve received your visit request for %{receipt_date}"
+      phone_no: "Phone:"
+      email_address: "Email:"
       when_to_check_spam: >
         If you don’t receive a confirmation email by %{when}, please check
         your spam or junk folder for it. You need to do this on a computer or

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -168,10 +168,10 @@ en:
       no_allowance: >
         We’re sorry, but the prisoner you want to visit has not got any
         visiting allowance left for the dates you’ve chosen.
-      pvo_possible: >
+      privileged_allowance_available: >
         However, you can book a weekday visit with visiting allowance valid
         until %{date}. The visit must be taken before the allowance expires.
-      vo_renewal: >
+      allowance_will_renew: >
         %{prisoner} will have their full visiting allowance (VO) renewed on
         %{date}.
       prisoner_details_incorrect: >

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -212,7 +212,6 @@ en:
       cancellation_title: "Cancel this visit request"
       choice: "Choice %{n}"
       details: "Visit request details"
-      email: "email:"
       feedback_html: >
         Need help or want to make a complaint? If you have a question or need
         any help with the online visits service, please

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -155,25 +155,25 @@ en:
       visiting_allowance_section:
         title: Visiting allowance
         no_allowance: The prisoner does not have any visiting allowance (VO)
-        no_vo_wording_html: >
+        no_allowance_wording_html: >
           <p>
             We’re sorry, but the prisoner you want to visit has not got any
             visiting allowance left for the dates you’ve chosen.
           </p>
-        no_vo_tell_more: >
+        no_allowance_tell_more: >
           You can also tell the visitor more about the VO and PVO status:
-        vo_will_be_renewed: >
+        allowance_will_renew: >
           Visiting allowance (weekends and weekday visits) (VO) will
           be renewed:
-        vo_will_be_renewed_wording_html: >
+        allowance_will_renew_wording_html: >
           <p>
             %{prisoner} will have their full visiting allowance (VO) renewed on
             <span class="date">[DATE NOT CHOSEN]</span>.
           </p>
-        pvo_possible: >
+        privileged_allowance_available: >
           If weekday visit (PVO) is possible instead, choose the date
           PVO expires:
-        pvo_possible_wording_html: >
+        privileged_allowance_available_wording_html: >
           <p>
             However, you can book a weekday visit with visiting allowance valid
             until <span class="date">[DATE NOT CHOSEN]</date>.

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -31,8 +31,8 @@ en:
       prison_id_prompt: select a prison
       note_header: Please note
       note: >
-        If you don't enter any information for more than 20 minutes, then your
-        session will time out and you'll need to start again.
+        If you don’t enter any information for more than 20 minutes, then your
+        session will time out and you’ll need to start again.
       next_step: Continue
     visitors_step:
       title: Visitor 1
@@ -56,20 +56,20 @@ en:
     confirmation_step:
       title: Check your request
       prisoner_details: Prisoner details
-      date_of_birth: 'Date of birth:'
-      prisoner_number: 'Prisoner number:'
-      prison: 'Prison:'
+      date_of_birth: "Date of birth:"
+      prisoner_number: "Prisoner number:"
+      prison: "Prison:"
       change_prisoner_details: Change prisoner details
       visitor_details: Visitor details
-      confirmation_email_address: 'Confirmation email:'
-      visitor_n: 'Visitor %{n}:'
+      confirmation_email_address: "Confirmation email:"
+      visitor_n: "Visitor %{n}:"
       change_visitor_details: Change visitor details
       your_visit: Your visit
       options_available: >
         You can choose up to 2 alternative dates if your first choice isn’t
         available.
-      first_choice: 'First choice:'
-      alternatives: 'Alternatives:'
+      first_choice: "First choice:"
+      alternatives: "Alternatives:"
       change_visit_details: Change visit details
       ts_and_cs: Terms & conditions
       next_step: Send request
@@ -107,18 +107,18 @@ en:
           </ul>
         submit: Send email
       people_box:
-        prisoner: 'Prisoner:'
-        number: 'Number:'
-        date_of_birth: 'Date of birth:'
-        visitor: 'Visitor %{n}:'
-        age: 'Age:'
-        email_address: 'Email:'
-        phone_no: 'Phone:'
+        prisoner: "Prisoner:"
+        number: "Number:"
+        date_of_birth: "Date of birth:"
+        visitor: "Visitor %{n}:"
+        age: "Age:"
+        email_address: "Email:"
+        phone_no: "Phone:"
       shared:
         what_we_will_tell: What we’ll tell the visitor
       visit_date_section:
         title: Visit date
-        choice_html: 'Choice %{n}: <strong>%{date}</strong>'
+        choice_html: "Choice %{n}: <strong>%{date}</strong>"
         reference_no: Reference number
         reference_no_hint: eg Last 8 digits of VO number or “none” for remand
         closed_visit: This is a closed visit

--- a/db/migrate/20151124154246_rename_vo_and_pvo.rb
+++ b/db/migrate/20151124154246_rename_vo_and_pvo.rb
@@ -1,0 +1,6 @@
+class RenameVoAndPvo < ActiveRecord::Migration
+  def change
+    rename_column :rejections, :vo_renewed_on, :allowance_renews_on
+    rename_column :rejections, :pvo_expires_on, :privileged_allowance_expires_on
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151124095301) do
+ActiveRecord::Schema.define(version: 20151124154246) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,10 +45,10 @@ ActiveRecord::Schema.define(version: 20151124095301) do
   end
 
   create_table "rejections", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
-    t.uuid   "visit_id",       null: false
-    t.date   "vo_renewed_on"
-    t.date   "pvo_expires_on"
-    t.string "reason",         null: false
+    t.uuid   "visit_id",                        null: false
+    t.date   "allowance_renews_on"
+    t.date   "privileged_allowance_expires_on"
+    t.string "reason",                          null: false
   end
 
   add_index "rejections", ["visit_id"], name: "index_rejections_on_visit_id", unique: true, using: :btree

--- a/spec/features/process_a_request_spec.rb
+++ b/spec/features/process_a_request_spec.rb
@@ -54,6 +54,11 @@ RSpec.feature 'Processing a request', js: true do
     vst.reload
     expect(vst).to be_rejected
     expect(vst.rejection_reason).to eq('slot_unavailable')
+
+    expect(visitor_email_address).
+      to receive_email.
+      with_subject(/Visit cannot take place: your visit for \w+ \d+ \w+ could not be booked/).
+      and_body(/none of the dates and times/)
   end
 
   scenario 'rejecting a booking when the prisoner has no visiting allowance' do
@@ -70,6 +75,11 @@ RSpec.feature 'Processing a request', js: true do
     expect(vst.rejection_reason).to eq('no_allowance')
     expect(vst.rejection.vo_renewed_on).to eq(Time.zone.today + 1)
     expect(vst.rejection.vo_renewed_on).to eq(Time.zone.today + 1)
+
+    expect(visitor_email_address).
+      to receive_email.
+      with_subject(/Visit cannot take place: your visit for \w+ \d+ \w+ could not be booked/).
+      and_body(/not got any visiting allowance/)
   end
 
   scenario 'rejecting a booking with incorrect prisoner details' do
@@ -80,6 +90,11 @@ RSpec.feature 'Processing a request', js: true do
     vst.reload
     expect(vst.rejection_reason).to eq('prisoner_details_incorrect')
     expect(vst).to be_rejected
+
+    expect(visitor_email_address).
+      to receive_email.
+      with_subject(/Visit cannot take place: your visit for \w+ \d+ \w+ could not be booked/).
+      and_body(/correct information for the prisoner/)
   end
 
   scenario 'rejecting a booking when the prisoner has moved' do
@@ -90,6 +105,11 @@ RSpec.feature 'Processing a request', js: true do
     vst.reload
     expect(vst.rejection_reason).to eq('prisoner_moved')
     expect(vst).to be_rejected
+
+    expect(visitor_email_address).
+      to receive_email.
+      with_subject(/Visit cannot take place: your visit for \w+ \d+ \w+ could not be booked/).
+      and_body(/has moved prison/)
   end
 
   scenario 'rejecting a booking when the visitor is not on the contact list' do
@@ -100,6 +120,11 @@ RSpec.feature 'Processing a request', js: true do
     vst.reload
     expect(vst.rejection_reason).to eq('visitor_not_on_list')
     expect(vst).to be_rejected
+
+    expect(visitor_email_address).
+      to receive_email.
+      with_subject(/Visit cannot take place: your visit for \w+ \d+ \w+ could not be booked/).
+      and_body(/prisoner’s contact list/)
   end
 
   scenario 'rejecting a booking when the visitor is banned' do
@@ -110,5 +135,10 @@ RSpec.feature 'Processing a request', js: true do
     vst.reload
     expect(vst.rejection_reason).to eq('visitor_banned')
     expect(vst).to be_rejected
+
+    expect(visitor_email_address).
+      to receive_email.
+      with_subject(/Visit cannot take place: your visit for \w+ \d+ \w+ could not be booked/).
+      and_body(/banned from visiting/)
   end
 end

--- a/spec/features/process_a_request_spec.rb
+++ b/spec/features/process_a_request_spec.rb
@@ -59,6 +59,10 @@ RSpec.feature 'Processing a request', js: true do
       to receive_email.
       with_subject(/Visit cannot take place: your visit for \w+ \d+ \w+ could not be booked/).
       and_body(/none of the dates and times/)
+    expect(prison_email_address).
+      to receive_email.
+      with_subject(/COPY of booking rejection for Oscar Wilde/).
+      and_body(/This is a copy of the booking rejection email sent to the visitor/)
   end
 
   scenario 'rejecting a booking when the prisoner has no visiting allowance' do
@@ -80,6 +84,10 @@ RSpec.feature 'Processing a request', js: true do
       to receive_email.
       with_subject(/Visit cannot take place: your visit for \w+ \d+ \w+ could not be booked/).
       and_body(/not got any visiting allowance/)
+    expect(prison_email_address).
+      to receive_email.
+      with_subject(/COPY of booking rejection for Oscar Wilde/).
+      and_body(/This is a copy of the booking rejection email sent to the visitor/)
   end
 
   scenario 'rejecting a booking with incorrect prisoner details' do
@@ -95,6 +103,10 @@ RSpec.feature 'Processing a request', js: true do
       to receive_email.
       with_subject(/Visit cannot take place: your visit for \w+ \d+ \w+ could not be booked/).
       and_body(/correct information for the prisoner/)
+    expect(prison_email_address).
+      to receive_email.
+      with_subject(/COPY of booking rejection for Oscar Wilde/).
+      and_body(/This is a copy of the booking rejection email sent to the visitor/)
   end
 
   scenario 'rejecting a booking when the prisoner has moved' do
@@ -110,6 +122,10 @@ RSpec.feature 'Processing a request', js: true do
       to receive_email.
       with_subject(/Visit cannot take place: your visit for \w+ \d+ \w+ could not be booked/).
       and_body(/has moved prison/)
+    expect(prison_email_address).
+      to receive_email.
+      with_subject(/COPY of booking rejection for Oscar Wilde/).
+      and_body(/This is a copy of the booking rejection email sent to the visitor/)
   end
 
   scenario 'rejecting a booking when the visitor is not on the contact list' do
@@ -125,6 +141,10 @@ RSpec.feature 'Processing a request', js: true do
       to receive_email.
       with_subject(/Visit cannot take place: your visit for \w+ \d+ \w+ could not be booked/).
       and_body(/prisoner’s contact list/)
+    expect(prison_email_address).
+      to receive_email.
+      with_subject(/COPY of booking rejection for Oscar Wilde/).
+      and_body(/This is a copy of the booking rejection email sent to the visitor/)
   end
 
   scenario 'rejecting a booking when the visitor is banned' do
@@ -140,5 +160,9 @@ RSpec.feature 'Processing a request', js: true do
       to receive_email.
       with_subject(/Visit cannot take place: your visit for \w+ \d+ \w+ could not be booked/).
       and_body(/banned from visiting/)
+    expect(prison_email_address).
+      to receive_email.
+      with_subject(/COPY of booking rejection for Oscar Wilde/).
+      and_body(/This is a copy of the booking rejection email sent to the visitor/)
   end
 end

--- a/spec/features/process_a_request_spec.rb
+++ b/spec/features/process_a_request_spec.rb
@@ -68,17 +68,17 @@ RSpec.feature 'Processing a request', js: true do
   scenario 'rejecting a booking when the prisoner has no visiting allowance' do
     choose 'The prisoner does not have any visiting allowance (VO)'
     check 'Visiting allowance (weekends and weekday visits) (VO) will be renewed:'
-    first('input[name="booking_response[vo_renewed_on]"]').click
+    first('input[name="booking_response[allowance_renews_on]"]').click
     check 'If weekday visit (PVO) is possible instead, choose the date PVO expires:'
-    first('input[name="booking_response[pvo_expires_on]"]').click
+    first('input[name="booking_response[privileged_allowance_expires_on]"]').click
 
     click_button 'Send email'
 
     vst.reload
     expect(vst).to be_rejected
     expect(vst.rejection_reason).to eq('no_allowance')
-    expect(vst.rejection.vo_renewed_on).to eq(Time.zone.today + 1)
-    expect(vst.rejection.vo_renewed_on).to eq(Time.zone.today + 1)
+    expect(vst.rejection.allowance_renews_on).to eq(Time.zone.today + 1)
+    expect(vst.rejection.allowance_renews_on).to eq(Time.zone.today + 1)
 
     expect(visitor_email_address).
       to receive_email.

--- a/spec/models/rejection_spec.rb
+++ b/spec/models/rejection_spec.rb
@@ -1,17 +1,43 @@
 require 'rails_helper'
 
 RSpec.describe Rejection, model: true do
-  it 'enforces no more than one per visit' do
-    visit = create(:visit)
-    create(:rejection, visit: visit)
-    expect {
+  describe 'validation' do
+    it 'enforces no more than one per visit' do
+      visit = create(:visit)
       create(:rejection, visit: visit)
-    }.to raise_exception(ActiveRecord::RecordNotUnique)
+      expect {
+        create(:rejection, visit: visit)
+      }.to raise_exception(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'enforces the foreign key constraint' do
+      expect {
+        create(:rejection, visit_id: SecureRandom.uuid)
+      }.to raise_exception(ActiveRecord::InvalidForeignKey)
+    end
   end
 
-  it 'enforces the foreign key constraint' do
-    expect {
-      create(:rejection, visit_id: SecureRandom.uuid)
-    }.to raise_exception(ActiveRecord::InvalidForeignKey)
+  describe 'pvo_possible?' do
+    it 'is true if there is a pvo_expires_on date' do
+      subject.pvo_expires_on = Time.zone.today + 1
+      expect(subject).to be_pvo_possible
+    end
+
+    it 'is false if these is no pvo_expires_on date' do
+      subject.pvo_expires_on = ''
+      expect(subject).not_to be_pvo_possible
+    end
+  end
+
+  describe 'vo_will_be_renewed?' do
+    it 'is true if there is a vo_renewed_on date' do
+      subject.vo_renewed_on = Time.zone.today + 1
+      expect(subject).to be_vo_will_be_renewed
+    end
+
+    it 'is false if these is no vo_renewed_on date' do
+      subject.vo_renewed_on = ''
+      expect(subject).not_to be_vo_will_be_renewed
+    end
   end
 end

--- a/spec/models/rejection_spec.rb
+++ b/spec/models/rejection_spec.rb
@@ -17,27 +17,27 @@ RSpec.describe Rejection, model: true do
     end
   end
 
-  describe 'pvo_possible?' do
-    it 'is true if there is a pvo_expires_on date' do
-      subject.pvo_expires_on = Time.zone.today + 1
-      expect(subject).to be_pvo_possible
+  describe 'privileged_allowance_available?' do
+    it 'is true if there is a privileged_allowance_expires_on date' do
+      subject.privileged_allowance_expires_on = Time.zone.today + 1
+      expect(subject).to be_privileged_allowance_available
     end
 
-    it 'is false if these is no pvo_expires_on date' do
-      subject.pvo_expires_on = ''
-      expect(subject).not_to be_pvo_possible
+    it 'is false if these is no privileged_allowance_expires_on date' do
+      subject.privileged_allowance_expires_on = ''
+      expect(subject).not_to be_privileged_allowance_available
     end
   end
 
-  describe 'vo_will_be_renewed?' do
-    it 'is true if there is a vo_renewed_on date' do
-      subject.vo_renewed_on = Time.zone.today + 1
-      expect(subject).to be_vo_will_be_renewed
+  describe 'allowance_will_renew?' do
+    it 'is true if there is an allowance_renews_on date' do
+      subject.allowance_renews_on = Time.zone.today + 1
+      expect(subject).to be_allowance_will_renew
     end
 
-    it 'is false if these is no vo_renewed_on date' do
-      subject.vo_renewed_on = ''
-      expect(subject).not_to be_vo_will_be_renewed
+    it 'is false if these is no allowance_renews_on date' do
+      subject.allowance_renews_on = ''
+      expect(subject).not_to be_allowance_will_renew
     end
   end
 end

--- a/spec/services/booking_responder_spec.rb
+++ b/spec/services/booking_responder_spec.rb
@@ -152,29 +152,29 @@ RSpec.describe BookingResponder do
       end
 
       context 'when VO will be renewed' do
-        let(:vo_date) { Time.zone.today + 7 }
+        let(:allowance_date) { Time.zone.today + 7 }
 
         before do
-          booking_response.vo_will_be_renewed = true
-          booking_response.vo_renewed_on = vo_date
+          booking_response.allowance_will_renew = true
+          booking_response.allowance_renews_on = allowance_date
         end
 
         it 'sets the rejection VO renewal date' do
-          expect(visit_after_responding.rejection.vo_renewed_on).
-            to eq(vo_date)
+          expect(visit_after_responding.rejection.allowance_renews_on).
+            to eq(allowance_date)
         end
 
         context 'and PVO is possible' do
-          let(:pvo_date) { Time.zone.today + 7 }
+          let(:privileged_allowance_date) { Time.zone.today + 7 }
 
           before do
-            booking_response.pvo_possible = true
-            booking_response.pvo_expires_on = pvo_date
+            booking_response.privileged_allowance_available = true
+            booking_response.privileged_allowance_expires_on = privileged_allowance_date
           end
 
           it 'sets the rejection PVO expiry date' do
-            expect(visit_after_responding.rejection.pvo_expires_on).
-              to eq(pvo_date)
+            expect(visit_after_responding.rejection.privileged_allowance_expires_on).
+              to eq(privileged_allowance_date)
           end
         end
       end

--- a/spec/services/booking_responder_spec.rb
+++ b/spec/services/booking_responder_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe BookingResponder do
     allow(VisitorMailer).to receive(:booked).and_return(mailing)
     allow(PrisonMailer).to receive(:booked).and_return(mailing)
     allow(VisitorMailer).to receive(:rejected).and_return(mailing)
+    allow(PrisonMailer).to receive(:rejected).and_return(mailing)
   end
 
   context 'accepting a request' do
@@ -101,6 +102,13 @@ RSpec.describe BookingResponder do
 
     it 'emails the visitor' do
       expect(VisitorMailer).to receive(:rejected).with(visit).
+        and_return(mailing)
+      expect(mailing).to receive(:deliver_later)
+      subject.respond!
+    end
+
+    it 'emails the prison' do
+      expect(PrisonMailer).to receive(:rejected).with(visit).
         and_return(mailing)
       expect(mailing).to receive(:deliver_later)
       subject.respond!

--- a/spec/services/booking_responder_spec.rb
+++ b/spec/services/booking_responder_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe BookingResponder do
   before do
     allow(VisitorMailer).to receive(:booked).and_return(mailing)
     allow(PrisonMailer).to receive(:booked).and_return(mailing)
+    allow(VisitorMailer).to receive(:rejected).and_return(mailing)
   end
 
   context 'accepting a request' do
@@ -94,6 +95,17 @@ RSpec.describe BookingResponder do
   end
 
   context 'rejecting a request' do
+    before do
+      booking_response.selection = 'slot_unavailable'
+    end
+
+    it 'emails the visitor' do
+      expect(VisitorMailer).to receive(:rejected).with(visit).
+        and_return(mailing)
+      expect(mailing).to receive(:deliver_later)
+      subject.respond!
+    end
+
     context 'because no slot is available' do
       before do
         booking_response.selection = 'slot_unavailable'

--- a/spec/services/booking_responder_spec.rb
+++ b/spec/services/booking_responder_spec.rb
@@ -27,46 +27,46 @@ RSpec.describe BookingResponder do
       booking_response.reference_no = '1337807'
     end
 
+    it 'changes the status of the visit to booked' do
+      expect(visit_after_responding).to be_booked
+    end
+
+    it 'sets the reference number of the visit' do
+      expect(visit_after_responding.reference_no).to eq('1337807')
+    end
+
+    it 'marks the visit as closed' do
+      booking_response.closed_visit = true
+      expect(visit_after_responding).to be_closed
+    end
+
+    it 'marks the visit as not closed' do
+      booking_response.closed_visit = false
+      expect(visit_after_responding).not_to be_closed
+    end
+
+    it 'emails the visitor' do
+      expect(VisitorMailer).to receive(:booked).with(visit).
+        and_return(mailing)
+      expect(mailing).to receive(:deliver_later)
+      subject.respond!
+    end
+
+    it 'emails the prison' do
+      expect(PrisonMailer).to receive(:booked).with(visit).
+        and_return(mailing)
+      expect(mailing).to receive(:deliver_later)
+      subject.respond!
+    end
+
     context 'with the first slot' do
       before do
         booking_response.selection = 'slot_0'
       end
 
-      it 'changes the status of the visit.reload to booked' do
-        expect(visit_after_responding).to be_booked
-      end
-
-      it 'sets the reference number of the visit' do
-        expect(visit_after_responding.reference_no).to eq('1337807')
-      end
-
       it 'assigns the selected slot' do
         expect(visit_after_responding.slot_granted).
           to eq(visit_after_responding.slots[0])
-      end
-
-      it 'marks the visit as closed' do
-        booking_response.closed_visit = true
-        expect(visit_after_responding).to be_closed
-      end
-
-      it 'marks the visit as not closed' do
-        booking_response.closed_visit = false
-        expect(visit_after_responding).not_to be_closed
-      end
-
-      it 'emails the visitor' do
-        expect(VisitorMailer).to receive(:booked).with(visit).
-          and_return(mailing)
-        expect(mailing).to receive(:deliver_later)
-        subject.respond!
-      end
-
-      it 'emails the prison' do
-        expect(PrisonMailer).to receive(:booked).with(visit).
-          and_return(mailing)
-        expect(mailing).to receive(:deliver_later)
-        subject.respond!
       end
     end
 


### PR DESCRIPTION
This sends an email to a prospective visitor when their booking is rejected, and copies it to the prison for their records.