### PR TITLE
Let visitors override spam/bounced email rejection

### DIFF
--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -10,7 +10,7 @@ class Visit < ActiveRecord::Base
     :processing_state,
     presence: true
 
-  validates :spam_or_bounce,
+  validates :delivery_error_type,
     inclusion: { in: %w[ bounced spam_reported ] },
     allow_nil: true, allow_blank: true
 

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -10,9 +10,9 @@ class Visit < ActiveRecord::Base
     :processing_state,
     presence: true
 
-  validates :email_override,
+  validates :spam_or_bounce,
     inclusion: { in: %w[ bounced spam_reported ] },
-    allow_nil: true
+    allow_nil: true, allow_blank: true
 
   delegate :email_address, :phone_no, :name, to: :prison, prefix: true
   alias_attribute :recipient, :visitor_email_address

--- a/app/models/visitors_step.rb
+++ b/app/models/visitors_step.rb
@@ -3,8 +3,24 @@ class VisitorsStep
   include Person
 
   attribute :email_address, String
+  attribute :override_spam_or_bounce, Boolean
+  attribute :spam_or_bounce, String
+  attribute :spam_or_bounce_has_occurred, Boolean
   attribute :phone_no, String
 
   validates :email_address, presence: true
   validates :phone_no, presence: true, length: { minimum: 9 }
+
+  validate :validate_email
+
+private
+
+  def validate_email
+    checker = EmailChecker.new(email_address, override_spam_or_bounce)
+    unless checker.valid?
+      errors.add :email_address, checker.message
+      @spam_or_bounce_has_occurred = checker.spam_or_bounce_occurred?
+      @spam_or_bounce = checker.error
+    end
+  end
 end

--- a/app/models/visitors_step.rb
+++ b/app/models/visitors_step.rb
@@ -3,9 +3,9 @@ class VisitorsStep
   include Person
 
   attribute :email_address, String
-  attribute :override_spam_or_bounce, Boolean
-  attribute :spam_or_bounce, String
-  attribute :spam_or_bounce_has_occurred, Boolean
+  attribute :override_delivery_error, Boolean
+  attribute :delivery_error_type, String
+  attribute :delivery_error_occurred, Boolean
   attribute :phone_no, String
 
   validates :email_address, presence: true
@@ -16,11 +16,11 @@ class VisitorsStep
 private
 
   def validate_email
-    checker = EmailChecker.new(email_address, override_spam_or_bounce)
+    checker = EmailChecker.new(email_address, override_delivery_error)
     unless checker.valid?
       errors.add :email_address, checker.message
-      @spam_or_bounce_has_occurred = checker.spam_or_bounce_occurred?
-      @spam_or_bounce = checker.error
+      @delivery_error_occurred = checker.delivery_error_occurred?
+      @delivery_error_type = checker.error.to_sym
     end
   end
 end

--- a/app/services/booking_request_creator.rb
+++ b/app/services/booking_request_creator.rb
@@ -38,7 +38,9 @@ private
       visitor_last_name: step.last_name,
       visitor_date_of_birth: step.date_of_birth,
       visitor_email_address: step.email_address,
-      visitor_phone_no: step.phone_no
+      visitor_phone_no: step.phone_no,
+      override_spam_or_bounce: step.override_spam_or_bounce,
+      spam_or_bounce: step.spam_or_bounce
     }
   end
 

--- a/app/services/booking_request_creator.rb
+++ b/app/services/booking_request_creator.rb
@@ -39,8 +39,8 @@ private
       visitor_date_of_birth: step.date_of_birth,
       visitor_email_address: step.email_address,
       visitor_phone_no: step.phone_no,
-      override_spam_or_bounce: step.override_spam_or_bounce,
-      spam_or_bounce: step.spam_or_bounce
+      override_delivery_error: step.override_delivery_error,
+      delivery_error_type: step.delivery_error_type
     }
   end
 

--- a/app/services/email_checker.rb
+++ b/app/services/email_checker.rb
@@ -1,0 +1,89 @@
+class EmailChecker
+  extend Forwardable
+  def_delegators :SendgridApi, :bounced?, :spam_reported?
+
+  def initialize(original_address, override_sendgrid = false)
+    @original_address = original_address
+    @parsed = parse_address(original_address)
+    @override_sendgrid = override_sendgrid
+  end
+
+  def error
+    unless @error_checked
+      @error = compute_error
+      @error_checked = true
+    end
+    @error
+  end
+
+  def message
+    I18n.t(error, scope: 'email_checker.errors')
+  end
+
+  def valid?
+    error.nil?
+  end
+
+  def spam_or_bounce_occurred?
+    [:spam_reported, :bounced].include?(error)
+  end
+
+  def reset_bounce?
+    return false unless parsed
+    override_sendgrid? && bounced?(parsed.address)
+  end
+
+  def reset_spam_report?
+    return false unless parsed
+    override_sendgrid? && spam_reported?(parsed.address)
+  end
+
+private
+
+  attr_reader :original_address, :parsed
+
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
+  def compute_error
+    return :unparseable unless parsed
+    return :domain_dot if domain_dot_error?
+    return :malformed unless well_formed_address?
+    return :no_mx_record unless mx_records?
+    unless override_sendgrid?
+      return :spam_reported if spam_reported?(parsed.address)
+      return :bounced if bounced?(parsed.address)
+    end
+    nil
+  end
+
+  def override_sendgrid?
+    @override_sendgrid
+  end
+
+  def domain
+    parsed.domain
+  end
+
+  def parse_address(addr)
+    Mail::Address.new(addr)
+  rescue Mail::Field::ParseError
+    nil
+  end
+
+  def domain_dot_error?
+    domain && domain.start_with?('.')
+  end
+
+  def well_formed_address?
+    parsed.local && parsed.domain &&
+      parsed.address == original_address && parsed.local != original_address
+  end
+
+  def mx_records?
+    Resolv::DNS.new.getresource(domain, Resolv::DNS::Resource::IN::MX)
+  rescue Resolv::ResolvError
+    false
+  rescue Resolv::ResolvTimeout
+    true
+  end
+end

--- a/app/services/spam_and_bounce_resets.rb
+++ b/app/services/spam_and_bounce_resets.rb
@@ -3,13 +3,13 @@ class SpamAndBounceResets
     @visit = visit
   end
 
-  delegate :visitor_email_address, :override_email_checks?, :email_override,
+  delegate :visitor_email_address, :override_spam_or_bounce?, :spam_or_bounce,
     to: :@visit
 
   delegate :remove_from_bounce_list, :remove_from_spam_list, to: :SendgridApi
 
   def perform_resets
-    return unless override_email_checks?
+    return unless override_spam_or_bounce?
     remove_from_bounce_list(visitor_email_address) if reset.bounced?
     remove_from_spam_list(visitor_email_address) if reset.spam_reported?
   end
@@ -17,6 +17,6 @@ class SpamAndBounceResets
 private
 
   def reset
-    email_override.to_s.inquiry
+    spam_or_bounce.to_s.inquiry
   end
 end

--- a/app/services/spam_and_bounce_resets.rb
+++ b/app/services/spam_and_bounce_resets.rb
@@ -3,20 +3,21 @@ class SpamAndBounceResets
     @visit = visit
   end
 
-  delegate :visitor_email_address, :override_spam_or_bounce?, :spam_or_bounce,
-    to: :@visit
+  delegate :visitor_email_address, :override_delivery_error?,
+    :delivery_error_type, to: :@visit
 
   delegate :remove_from_bounce_list, :remove_from_spam_list, to: :SendgridApi
 
   def perform_resets
-    return unless override_spam_or_bounce?
-    remove_from_bounce_list(visitor_email_address) if reset.bounced?
-    remove_from_spam_list(visitor_email_address) if reset.spam_reported?
+    return unless override_delivery_error?
+    remove_from_bounce_list(visitor_email_address) if delivery_error.bounced?
+    remove_from_spam_list(visitor_email_address) if
+      delivery_error.spam_reported?
   end
 
 private
 
-  def reset
-    spam_or_bounce.to_s.inquiry
+  def delivery_error
+    delivery_error_type.to_s.inquiry
   end
 end

--- a/app/views/steps/_hidden_visitors_step.html.erb
+++ b/app/views/steps/_hidden_visitors_step.html.erb
@@ -8,7 +8,7 @@
                      @steps.fetch(:visitors_step).email_address) %>
 <%= hidden_field_tag('visitors_step[phone_no]',
                      @steps.fetch(:visitors_step).phone_no) %>
-<%= hidden_field_tag('visitors_step[override_spam_or_bounce]',
-                     @steps.fetch(:visitors_step).override_spam_or_bounce) %>
-<%= hidden_field_tag('visitors_step[spam_or_bounce]',
-                     @steps.fetch(:visitors_step).spam_or_bounce) %>
+<%= hidden_field_tag('visitors_step[override_delivery_error]',
+                     @steps.fetch(:visitors_step).override_delivery_error) %>
+<%= hidden_field_tag('visitors_step[delivery_error_type]',
+                     @steps.fetch(:visitors_step).delivery_error_type) %>

--- a/app/views/steps/_hidden_visitors_step.html.erb
+++ b/app/views/steps/_hidden_visitors_step.html.erb
@@ -8,3 +8,7 @@
                      @steps.fetch(:visitors_step).email_address) %>
 <%= hidden_field_tag('visitors_step[phone_no]',
                      @steps.fetch(:visitors_step).phone_no) %>
+<%= hidden_field_tag('visitors_step[override_spam_or_bounce]',
+                     @steps.fetch(:visitors_step).override_spam_or_bounce) %>
+<%= hidden_field_tag('visitors_step[spam_or_bounce]',
+                     @steps.fetch(:visitors_step).spam_or_bounce) %>

--- a/app/views/steps/visitors_step.html.erb
+++ b/app/views/steps/visitors_step.html.erb
@@ -26,10 +26,10 @@
         <% end %>
 
         <%= single_field(f, :email_address, :text_field) %>
-        <% if f.object.spam_or_bounce_has_occurred? %>
+        <% if f.object.delivery_error_occurred? %>
           <label class="validation-message">
-            <%= single_field(f, :override_spam_or_bounce, :check_box) %>
-            <%= single_field(f, :spam_or_bounce, :hidden_field) %>
+            <%= single_field(f, :override_delivery_error, :check_box) %>
+            <%= single_field(f, :delivery_error_type, :hidden_field) %>
           </label>
         <% end %>
 

--- a/app/views/steps/visitors_step.html.erb
+++ b/app/views/steps/visitors_step.html.erb
@@ -26,6 +26,12 @@
         <% end %>
 
         <%= single_field(f, :email_address, :text_field) %>
+        <% if f.object.spam_or_bounce_has_occurred? %>
+          <label class="validation-message">
+            <%= single_field(f, :override_spam_or_bounce, :check_box) %>
+            <%= single_field(f, :spam_or_bounce, :hidden_field) %>
+          </label>
+        <% end %>
 
         <%= single_field(f, :phone_no, :text_field) %>
 

--- a/config/locales/en/email_checker.yml
+++ b/config/locales/en/email_checker.yml
@@ -1,0 +1,12 @@
+en:
+  email_checker:
+    errors:
+      unparseable: "is not a valid address"
+      domain_dot: "is not a valid address because it ends with a dot or starts with a dot"
+      malformed: "is not a valid address"
+      no_mx_record: "does not appear to be valid"
+      spam_reported: >
+        needs to be checked as past messages were marked as spam.
+        Check your spam folder too
+      bounced: >
+        needs to be checked as messages have been returned in the past

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -1,0 +1,5 @@
+en:
+  steps:
+    visitors_step:
+      override_spam_or_bounce: >
+        Tick this box to confirm you’d like us to try sending messages to you again.

--- a/config/locales/en/steps.yml
+++ b/config/locales/en/steps.yml
@@ -1,5 +1,5 @@
 en:
   steps:
     visitors_step:
-      override_spam_or_bounce: >
+      override_delivery_error: >
         Tick this box to confirm you’d like us to try sending messages to you again.

--- a/db/migrate/20151125122313_rename_override_email_checks_and_email_override.rb
+++ b/db/migrate/20151125122313_rename_override_email_checks_and_email_override.rb
@@ -1,0 +1,6 @@
+class RenameOverrideEmailChecksAndEmailOverride < ActiveRecord::Migration
+  def change
+    rename_column :visits, :override_email_checks, :override_spam_or_bounce
+    rename_column :visits, :email_override, :spam_or_bounce
+  end
+end

--- a/db/migrate/20151125144622_rename_override_spam_or_bounce_and_spam_or_bounce.rb
+++ b/db/migrate/20151125144622_rename_override_spam_or_bounce_and_spam_or_bounce.rb
@@ -1,0 +1,6 @@
+class RenameOverrideSpamOrBounceAndSpamOrBounce < ActiveRecord::Migration
+  def change
+    rename_column :visits, :override_spam_or_bounce, :override_delivery_error
+    rename_column :visits, :spam_or_bounce, :delivery_error_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151125122313) do
+ActiveRecord::Schema.define(version: 20151125144622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,8 +71,8 @@ ActiveRecord::Schema.define(version: 20151125122313) do
     t.string   "processing_state",        default: "requested", null: false
     t.datetime "created_at",                                    null: false
     t.datetime "updated_at",                                    null: false
-    t.boolean  "override_spam_or_bounce", default: false
-    t.string   "spam_or_bounce"
+    t.boolean  "override_delivery_error", default: false
+    t.string   "delivery_error_type"
     t.string   "reference_no"
     t.boolean  "closed"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151124154246) do
+ActiveRecord::Schema.define(version: 20151125122313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,25 +54,25 @@ ActiveRecord::Schema.define(version: 20151124154246) do
   add_index "rejections", ["visit_id"], name: "index_rejections_on_visit_id", unique: true, using: :btree
 
   create_table "visits", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
-    t.uuid     "prison_id",                                    null: false
-    t.string   "prisoner_first_name",                          null: false
-    t.string   "prisoner_last_name",                           null: false
-    t.date     "prisoner_date_of_birth",                       null: false
-    t.string   "prisoner_number",                              null: false
-    t.string   "visitor_first_name",                           null: false
-    t.string   "visitor_last_name",                            null: false
-    t.date     "visitor_date_of_birth",                        null: false
-    t.string   "visitor_email_address",                        null: false
-    t.string   "visitor_phone_no",                             null: false
-    t.string   "slot_option_0",                                null: false
+    t.uuid     "prison_id",                                     null: false
+    t.string   "prisoner_first_name",                           null: false
+    t.string   "prisoner_last_name",                            null: false
+    t.date     "prisoner_date_of_birth",                        null: false
+    t.string   "prisoner_number",                               null: false
+    t.string   "visitor_first_name",                            null: false
+    t.string   "visitor_last_name",                             null: false
+    t.date     "visitor_date_of_birth",                         null: false
+    t.string   "visitor_email_address",                         null: false
+    t.string   "visitor_phone_no",                              null: false
+    t.string   "slot_option_0",                                 null: false
     t.string   "slot_option_1"
     t.string   "slot_option_2"
     t.string   "slot_granted"
-    t.string   "processing_state",       default: "requested", null: false
-    t.datetime "created_at",                                   null: false
-    t.datetime "updated_at",                                   null: false
-    t.boolean  "override_email_checks",  default: false
-    t.string   "email_override"
+    t.string   "processing_state",        default: "requested", null: false
+    t.datetime "created_at",                                    null: false
+    t.datetime "updated_at",                                    null: false
+    t.boolean  "override_spam_or_bounce", default: false
+    t.string   "spam_or_bounce"
     t.string   "reference_no"
     t.boolean  "closed"
   end

--- a/spec/controllers/steps_controller_spec.rb
+++ b/spec/controllers/steps_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
+require 'shared_sendgrid_context'
 
 RSpec.describe StepsController do
+  include_context 'disable resolv for domain', 'test.example.com'
   let(:prisoner_details) {
     {
       first_name: 'Oscar',

--- a/spec/features/override_sendgrid_spec.rb
+++ b/spec/features/override_sendgrid_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+require 'shared_sendgrid_context'
+
+RSpec.feature "overriding Sendgrid", js: true do
+  include ActiveJobHelper
+  include FeaturesHelper
+  include_context 'disable resolv for domain', 'maildrop.dsd.io'
+
+  let(:expected_email_address) { 'test@maildrop.dsd.io' }
+  let(:irrelevant_response) { { 'message' => 'success' } }
+  let!(:prison) { create(:prison, name: 'Reading Gaol') }
+
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  context 'spam' do
+    include_context 'sendgrid reports spam'
+
+    scenario 'overriding spam report' do
+      visit steps_path
+      enter_prisoner_information
+      click_button 'Continue'
+      enter_visitor_information(expected_email_address)
+      click_button 'Continue'
+
+      expect(page).to have_text('marked as spam')
+      check 'Tick this box to confirm you’d like us to try sending messages to you again'
+      click_button 'Continue'
+
+      expect(page).to have_content('When do you want to visit?')
+      select_a_slot
+      click_button 'Continue'
+
+      expect(page).to have_content('Check your request')
+
+      expect(SendgridApi).to receive(:remove_from_spam_list).
+        with(expected_email_address).
+        and_return(irrelevant_response)
+
+      expect(SendgridApi).to_not receive(:remove_from_bounce_list)
+
+      click_button 'Send request'
+
+      expect(page).to have_content('Your request is being processed')
+    end
+  end
+
+  context 'bounced' do
+    include_context 'sendgrid reports a bounce'
+
+    scenario 'overriding bounce' do
+      visit steps_path
+      enter_prisoner_information
+      click_button 'Continue'
+      enter_visitor_information(expected_email_address)
+      click_button 'Continue'
+
+      expect(page).to have_text('returned in the past')
+      check 'Tick this box to confirm you’d like us to try sending messages to you again'
+      click_button 'Continue'
+
+      expect(page).to have_content('When do you want to visit?')
+      select_a_slot
+      click_button 'Continue'
+
+      expect(page).to have_content('Check your request')
+
+      expect(SendgridApi).to receive(:remove_from_bounce_list).
+        with(expected_email_address).
+        and_return(irrelevant_response)
+
+      expect(SendgridApi).to_not receive(:remove_from_spam_list)
+
+      click_button 'Send request'
+
+      expect(page).to have_content('Your request is being processed')
+    end
+  end
+
+  scenario 'when no overrides are present' do
+    visit steps_path
+    enter_prisoner_information
+    click_button 'Continue'
+    enter_visitor_information(expected_email_address)
+    click_button 'Continue'
+
+    expect(page).to have_content('When do you want to visit?')
+    select_a_slot
+    click_button 'Continue'
+
+    expect(page).to have_content('Check your request')
+
+    expect(SendgridApi).to_not receive(:remove_from_bounce_list)
+    expect(SendgridApi).to_not receive(:remove_from_spam_list)
+
+    click_button 'Send request'
+
+    expect(page).to have_content('Your request is being processed')
+  end
+end

--- a/spec/features/request_a_visit_spec.rb
+++ b/spec/features/request_a_visit_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
+require 'shared_sendgrid_context'
 
 RSpec.feature 'Booking a visit', js: true do
+  include_context 'disable resolv for domain', 'test.example.com'
   include ActiveJobHelper
 
   let!(:prison) { create(:prison, name: 'Reading Gaol') }

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -3,14 +3,15 @@ require 'rails_helper'
 RSpec.describe Visit, type: :model do
   subject { build(:visit) }
 
-  describe '.email_override' do
+  describe '.spam_or_bounce' do
     specify do
       is_expected.
-        to validate_inclusion_of(:email_override).
+        to validate_inclusion_of(:spam_or_bounce).
         in_array(%w[ bounced spam_reported ])
     end
 
-    it { is_expected.to allow_value(nil).for(:email_override) }
+    it { is_expected.to allow_value(nil).for(:spam_or_bounce) }
+    it { is_expected.to allow_value('').for(:spam_or_bounce) }
   end
 
   describe 'states' do

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -3,15 +3,15 @@ require 'rails_helper'
 RSpec.describe Visit, type: :model do
   subject { build(:visit) }
 
-  describe '.spam_or_bounce' do
+  describe '.delivery_error_type' do
     specify do
       is_expected.
-        to validate_inclusion_of(:spam_or_bounce).
+        to validate_inclusion_of(:delivery_error_type).
         in_array(%w[ bounced spam_reported ])
     end
 
-    it { is_expected.to allow_value(nil).for(:spam_or_bounce) }
-    it { is_expected.to allow_value('').for(:spam_or_bounce) }
+    it { is_expected.to allow_value(nil).for(:delivery_error_type) }
+    it { is_expected.to allow_value('').for(:delivery_error_type) }
   end
 
   describe 'states' do

--- a/spec/poltergeist_helper.rb
+++ b/spec/poltergeist_helper.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+require 'capybara/rspec'
+require 'capybara/poltergeist'
+
+Capybara.default_driver = :poltergeist
+Capybara.javascript_driver = :poltergeist
+Capybara.default_max_wait_time = 3
+Capybara.asset_host = "http://localhost:3000"

--- a/spec/services/booking_request_creator_spec.rb
+++ b/spec/services/booking_request_creator_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe BookingRequestCreator do
         visitor_date_of_birth: Date.new(1970, 11, 30),
         visitor_email_address: 'ada@test.example.com',
         visitor_phone_no: '01154960222',
-        override_spam_or_bounce: nil,
-        spam_or_bounce: nil,
+        override_delivery_error: nil,
+        delivery_error_type: nil,
         slot_option_0: '2015-01-02T09:00/10:00',
         slot_option_1: '2015-01-03T09:00/10:00',
         slot_option_2: '2015-01-04T09:00/10:00'

--- a/spec/services/booking_request_creator_spec.rb
+++ b/spec/services/booking_request_creator_spec.rb
@@ -52,6 +52,8 @@ RSpec.describe BookingRequestCreator do
         visitor_date_of_birth: Date.new(1970, 11, 30),
         visitor_email_address: 'ada@test.example.com',
         visitor_phone_no: '01154960222',
+        override_spam_or_bounce: nil,
+        spam_or_bounce: nil,
         slot_option_0: '2015-01-02T09:00/10:00',
         slot_option_1: '2015-01-03T09:00/10:00',
         slot_option_2: '2015-01-04T09:00/10:00'

--- a/spec/services/email_checker_spec.rb
+++ b/spec/services/email_checker_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+require 'shared_sendgrid_context'
+
+RSpec.describe EmailChecker do
+  include_context 'disable resolv'
+  subject { described_class.new(address, override) }
+  let(:override) { false }
+
+  shared_examples 'a valid address' do
+    it { is_expected.to be_valid }
+
+    it 'has no error' do
+      expect(subject.error).to be_nil
+    end
+  end
+
+  shared_examples 'an invalid address' do |sym|
+    it { is_expected.not_to be_valid }
+
+    it "has the #{sym} error" do
+      expect(subject.error).to eq(sym)
+    end
+  end
+
+  context 'with invalid address' do
+    context 'with empty string' do
+      let(:address) { '' }
+      it_behaves_like 'an invalid address', :malformed
+      it { is_expected.not_to be_spam_or_bounce_occurred }
+      it { is_expected.not_to be_reset_spam_report }
+      it { is_expected.not_to be_reset_bounce }
+    end
+
+    context 'with domain only' do
+      let(:address) { '@test.example.com' }
+      it_behaves_like 'an invalid address', :unparseable
+      it { is_expected.not_to be_spam_or_bounce_occurred }
+    end
+
+    context 'with local part only' do
+      let(:address) { 'jimmy.harris' }
+      it_behaves_like 'an invalid address', :malformed
+      it { is_expected.not_to be_spam_or_bounce_occurred }
+    end
+
+    context 'with dot at start of domain' do
+      let(:address) { 'user@.test.example.com' }
+      it_behaves_like 'an invalid address', :domain_dot
+      it { is_expected.not_to be_spam_or_bounce_occurred }
+    end
+
+    context 'with dot at end of domain' do
+      let(:address) { 'user@test.example.com.' }
+      it_behaves_like 'an invalid address', :unparseable
+      it { is_expected.not_to be_spam_or_bounce_occurred }
+    end
+  end
+
+  context 'with valid address' do
+    let(:address) { 'user@test.example.com' }
+
+    it_behaves_like 'a valid address'
+
+    it 'checks MX record only once' do
+      expect_any_instance_of(Resolv::DNS).
+        to receive(:getresource).once.and_return(true)
+
+      2.times do
+        subject.valid?
+      end
+    end
+
+    it 'checks Sendgrid only once' do
+      expect(SendgridApi).to receive(:spam_reported?).once.and_return(false)
+      expect(SendgridApi).to receive(:bounced?).once.and_return(false)
+
+      2.times do
+        subject.valid?
+      end
+    end
+
+    context 'with no MX record' do
+      include_context 'resolv raises an error'
+
+      it_behaves_like 'an invalid address', :no_mx_record
+      it { is_expected.not_to be_spam_or_bounce_occurred }
+    end
+
+    context 'when MX lookup times out' do
+      include_context 'resolv times out'
+
+      it_behaves_like 'a valid address'
+    end
+
+    context 'when spam is reported' do
+      include_context 'sendgrid reports spam'
+
+      it { is_expected.to be_spam_or_bounce_occurred }
+
+      context 'and override is not set' do
+        it_behaves_like 'an invalid address', :spam_reported
+        it { is_expected.not_to be_reset_spam_report }
+      end
+
+      context 'but override is set' do
+        let(:override) { true }
+        it_behaves_like 'a valid address'
+        it { is_expected.to be_reset_spam_report }
+      end
+    end
+
+    context 'when bounce is reported' do
+      include_context 'sendgrid reports a bounce'
+
+      it { is_expected.to be_spam_or_bounce_occurred }
+
+      context 'and override is not set' do
+        it_behaves_like 'an invalid address', :bounced
+        it { is_expected.not_to be_reset_bounce }
+      end
+
+      context 'but override is set' do
+        let(:override) { true }
+        it_behaves_like 'a valid address'
+        it { is_expected.to be_reset_bounce }
+      end
+    end
+  end
+end

--- a/spec/services/email_checker_spec.rb
+++ b/spec/services/email_checker_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe EmailChecker do
     it { is_expected.to be_valid }
 
     it 'has no error' do
-      expect(subject.error).to be_nil
+      expect(subject.error).to be_valid
     end
   end
 
@@ -25,34 +25,34 @@ RSpec.describe EmailChecker do
   context 'with invalid address' do
     context 'with empty string' do
       let(:address) { '' }
-      it_behaves_like 'an invalid address', :malformed
-      it { is_expected.not_to be_spam_or_bounce_occurred }
+      it_behaves_like 'an invalid address', 'malformed'
+      it { is_expected.not_to be_delivery_error_occurred }
       it { is_expected.not_to be_reset_spam_report }
       it { is_expected.not_to be_reset_bounce }
     end
 
     context 'with domain only' do
       let(:address) { '@test.example.com' }
-      it_behaves_like 'an invalid address', :unparseable
-      it { is_expected.not_to be_spam_or_bounce_occurred }
+      it_behaves_like 'an invalid address', 'unparseable'
+      it { is_expected.not_to be_delivery_error_occurred }
     end
 
     context 'with local part only' do
       let(:address) { 'jimmy.harris' }
-      it_behaves_like 'an invalid address', :malformed
-      it { is_expected.not_to be_spam_or_bounce_occurred }
+      it_behaves_like 'an invalid address', 'malformed'
+      it { is_expected.not_to be_delivery_error_occurred }
     end
 
     context 'with dot at start of domain' do
       let(:address) { 'user@.test.example.com' }
-      it_behaves_like 'an invalid address', :domain_dot
-      it { is_expected.not_to be_spam_or_bounce_occurred }
+      it_behaves_like 'an invalid address', 'domain_dot'
+      it { is_expected.not_to be_delivery_error_occurred }
     end
 
     context 'with dot at end of domain' do
       let(:address) { 'user@test.example.com.' }
-      it_behaves_like 'an invalid address', :unparseable
-      it { is_expected.not_to be_spam_or_bounce_occurred }
+      it_behaves_like 'an invalid address', 'unparseable'
+      it { is_expected.not_to be_delivery_error_occurred }
     end
   end
 
@@ -82,8 +82,8 @@ RSpec.describe EmailChecker do
     context 'with no MX record' do
       include_context 'resolv raises an error'
 
-      it_behaves_like 'an invalid address', :no_mx_record
-      it { is_expected.not_to be_spam_or_bounce_occurred }
+      it_behaves_like 'an invalid address', 'no_mx_record'
+      it { is_expected.not_to be_delivery_error_occurred }
     end
 
     context 'when MX lookup times out' do
@@ -95,10 +95,10 @@ RSpec.describe EmailChecker do
     context 'when spam is reported' do
       include_context 'sendgrid reports spam'
 
-      it { is_expected.to be_spam_or_bounce_occurred }
+      it { is_expected.to be_delivery_error_occurred }
 
       context 'and override is not set' do
-        it_behaves_like 'an invalid address', :spam_reported
+        it_behaves_like 'an invalid address', 'spam_reported'
         it { is_expected.not_to be_reset_spam_report }
       end
 
@@ -112,10 +112,10 @@ RSpec.describe EmailChecker do
     context 'when bounce is reported' do
       include_context 'sendgrid reports a bounce'
 
-      it { is_expected.to be_spam_or_bounce_occurred }
+      it { is_expected.to be_delivery_error_occurred }
 
       context 'and override is not set' do
-        it_behaves_like 'an invalid address', :bounced
+        it_behaves_like 'an invalid address', 'bounced'
         it { is_expected.not_to be_reset_bounce }
       end
 

--- a/spec/services/spam_and_bounce_resets_spec.rb
+++ b/spec/services/spam_and_bounce_resets_spec.rb
@@ -5,14 +5,14 @@ RSpec.describe SpamAndBounceResets do
   subject { described_class.new(visit) }
 
   describe '.perform_resets' do
-    context 'when override_email_check is true' do
+    context 'when override_delivery_error is true' do
       before do
-        visit.override_spam_or_bounce = true
+        visit.override_delivery_error = true
       end
 
       context 'when reset.bounced? is true' do
         before do
-          visit.spam_or_bounce = 'bounced'
+          visit.delivery_error_type = 'bounced'
         end
 
         it 'calls SendgridApi#remove_from_bounce_list' do
@@ -23,7 +23,7 @@ RSpec.describe SpamAndBounceResets do
 
       context 'when reset.bounced? is false' do
         before do
-          visit.spam_or_bounce = nil
+          visit.delivery_error_type = nil
         end
 
         it 'does not call SendgridApi#remove_from_bounce_list' do
@@ -34,7 +34,7 @@ RSpec.describe SpamAndBounceResets do
 
       context 'when reset.spam_reported? is true' do
         before do
-          visit.spam_or_bounce = 'spam_reported'
+          visit.delivery_error_type = 'spam_reported'
         end
 
         it 'calls SendgriApi#remove_from_spam_list' do
@@ -45,7 +45,7 @@ RSpec.describe SpamAndBounceResets do
 
       context 'when reset.spam_reported? is false' do
         before do
-          visit.spam_or_bounce = nil
+          visit.delivery_error_type = nil
         end
 
         it 'does not call SendgriApi#remove_from_spam_list' do
@@ -55,14 +55,14 @@ RSpec.describe SpamAndBounceResets do
       end
     end
 
-    context 'when override_email_check is false' do
+    context 'when override_delivery_error is false' do
       before do
-        visit.override_spam_or_bounce = false
+        visit.override_delivery_error = false
       end
 
       context 'when reset.bounced? is true' do
         before do
-          visit.spam_or_bounce = 'bounced'
+          visit.delivery_error_type = 'bounced'
         end
 
         it 'does not call SendgriApi#remove_from_bounce_list' do
@@ -73,7 +73,7 @@ RSpec.describe SpamAndBounceResets do
 
       context 'when reset.bounced? is false' do
         before do
-          visit.spam_or_bounce = nil
+          visit.delivery_error_type = nil
         end
 
         it 'does not call SendgriApi#remove_from_bounce_list' do

--- a/spec/services/spam_and_bounce_resets_spec.rb
+++ b/spec/services/spam_and_bounce_resets_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe SpamAndBounceResets do
   describe '.perform_resets' do
     context 'when override_email_check is true' do
       before do
-        visit.override_email_checks = true
+        visit.override_spam_or_bounce = true
       end
 
       context 'when reset.bounced? is true' do
         before do
-          visit.email_override = 'bounced'
+          visit.spam_or_bounce = 'bounced'
         end
 
         it 'calls SendgridApi#remove_from_bounce_list' do
@@ -23,7 +23,7 @@ RSpec.describe SpamAndBounceResets do
 
       context 'when reset.bounced? is false' do
         before do
-          visit.email_override = nil
+          visit.spam_or_bounce = nil
         end
 
         it 'does not call SendgridApi#remove_from_bounce_list' do
@@ -34,7 +34,7 @@ RSpec.describe SpamAndBounceResets do
 
       context 'when reset.spam_reported? is true' do
         before do
-          visit.email_override = 'spam_reported'
+          visit.spam_or_bounce = 'spam_reported'
         end
 
         it 'calls SendgriApi#remove_from_spam_list' do
@@ -45,7 +45,7 @@ RSpec.describe SpamAndBounceResets do
 
       context 'when reset.spam_reported? is false' do
         before do
-          visit.email_override = nil
+          visit.spam_or_bounce = nil
         end
 
         it 'does not call SendgriApi#remove_from_spam_list' do
@@ -57,12 +57,12 @@ RSpec.describe SpamAndBounceResets do
 
     context 'when override_email_check is false' do
       before do
-        visit.override_email_checks = false
+        visit.override_spam_or_bounce = false
       end
 
       context 'when reset.bounced? is true' do
         before do
-          visit.email_override = 'bounced'
+          visit.spam_or_bounce = 'bounced'
         end
 
         it 'does not call SendgriApi#remove_from_bounce_list' do
@@ -73,7 +73,7 @@ RSpec.describe SpamAndBounceResets do
 
       context 'when reset.bounced? is false' do
         before do
-          visit.email_override = nil
+          visit.spam_or_bounce = nil
         end
 
         it 'does not call SendgriApi#remove_from_bounce_list' do

--- a/spec/shared_sendgrid_context.rb
+++ b/spec/shared_sendgrid_context.rb
@@ -1,0 +1,40 @@
+RSpec.shared_context 'disable resolv for domain' do |domain|
+  let(:resolv_response) { double('Resolv::DNS') }
+
+  before do
+    allow(resolv_response).to receive(:getresource).with(domain, anything).and_return(true)
+    allow(Resolv::DNS).to receive(:new).and_return(resolv_response)
+  end
+end
+
+RSpec.shared_context 'disable resolv' do
+  before do
+    allow_any_instance_of(Resolv::DNS).to receive(:getresource).and_return(true)
+  end
+end
+
+RSpec.shared_context 'sendgrid reports a bounce' do
+  before do
+    allow(SendgridApi).to receive(:bounced?).at_least(:once).and_return(true)
+  end
+end
+
+RSpec.shared_context 'sendgrid reports spam' do
+  before do
+    allow(SendgridApi).to receive(:spam_reported?).at_least(:once).and_return(true)
+  end
+end
+
+RSpec.shared_context 'resolv times out' do
+  before do
+    allow_any_instance_of(Resolv::DNS).
+      to receive(:getresource).and_raise(Resolv::ResolvTimeout)
+  end
+end
+
+RSpec.shared_context 'resolv raises an error' do
+  before do
+    allow_any_instance_of(Resolv::DNS).
+      to receive(:getresource).and_raise(Resolv::ResolvError)
+  end
+end

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -1,0 +1,28 @@
+module FeaturesHelper
+  def enter_prisoner_information
+    fill_in 'Prisoner first name', with: 'Oscar'
+    fill_in 'Prisoner last name', with: 'Wilde'
+    fill_in 'Day', with: '31'
+    fill_in 'Month', with: '12'
+    fill_in 'Year', with: '1980'
+    fill_in 'Prisoner number', with: 'a1234bc'
+    select 'Reading Gaol', from: 'Name of the prison'
+  end
+
+  def enter_visitor_information(expected_email_address)
+    fill_in 'Your first name', with: 'Ada'
+    fill_in 'Your last name', with: 'Lovelace'
+    fill_in 'Day', with: '30'
+    fill_in 'Month', with: '11'
+    fill_in 'Year', with: '1970'
+    fill_in 'Email address', with: expected_email_address
+    fill_in 'Phone number', with: '01154960222'
+  end
+
+  def select_a_slot
+    available_slots = all('#slots_step_option_0 option').map(&:text)
+    select available_slots[1], from: 'Option 1'
+    select available_slots[2], from: 'Option 1'
+    select available_slots[3], from: 'Option 1'
+  end
+end


### PR DESCRIPTION
This improves the reporting of email errors when an address has been reported
by Sendgrid as having bounced or been marked as spam.

It adds a checkbox to the visitor form to allow the visitor to force acceptance
of an email address that failed the Sendgrid checks. The checkbox is only
displayed if validation fails for one of these two reasons. If selected, we
permit the email address, and tell Sendgrid to remove the spam or bounced
categorisation before sending the email.  # Please enter the commit message for
your changes.