### PR TITLE
Add specs for emails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,10 @@ Style/FormatString:
 Style/GuardClause:
   Enabled: false
 
+Style/SymbolProc:
+  Exclude:
+    - 'spec/factories/**/*'
+
 Metrics/LineLength:
   Max: 80
   Exclude:

--- a/spec/factories/rejections.rb
+++ b/spec/factories/rejections.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :rejection do
-    visit
+    association :visit, processing_state: 'rejected'
     reason 'no_allowance'
   end
 end

--- a/spec/factories/visits.rb
+++ b/spec/factories/visits.rb
@@ -1,6 +1,7 @@
 FactoryGirl.define do
   factory :visit do
     prison
+
     prisoner_first_name do
       FFaker::Name.first_name
     end
@@ -44,6 +45,18 @@ FactoryGirl.define do
       slot_option_2 do |v|
         v.prison.available_slots.to_a[2]
       end
+    end
+
+    factory :booked_visit do
+      slot_granted do |v|
+        v.slot_option_0
+      end
+
+      sequence :reference_no do |n|
+        '%08d' % n
+      end
+
+      processing_state 'booked'
     end
   end
 end

--- a/spec/factories/visits.rb
+++ b/spec/factories/visits.rb
@@ -58,5 +58,9 @@ FactoryGirl.define do
 
       processing_state 'booked'
     end
+
+    factory :rejected_visit do
+      processing_state 'rejected'
+    end
   end
 end

--- a/spec/mailers/prison_mailer/booked_spec.rb
+++ b/spec/mailers/prison_mailer/booked_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+require 'mailers/shared_mailer_examples'
+
+RSpec.describe PrisonMailer, '.booked' do
+  let(:visit) {
+    create(
+      :booked_visit,
+      prisoner_first_name: 'Arthur',
+      prisoner_last_name: 'Raffles'
+    )
+  }
+  let(:mail) { described_class.booked(visit) }
+
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  include_examples 'template checks'
+
+  it 'sends an email confirming the booking' do
+    expect(mail.subject).
+      to match(/COPY of booking confirmation for Arthur Raffles/)
+  end
+end

--- a/spec/mailers/prison_mailer/rejected_spec.rb
+++ b/spec/mailers/prison_mailer/rejected_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+require 'mailers/shared_mailer_examples'
+
+RSpec.describe PrisonMailer, '.rejected' do
+  let(:rejection) {
+    create(
+      :rejection,
+      visit: create(
+        :rejected_visit,
+        prisoner_first_name: 'Arthur',
+        prisoner_last_name: 'Raffles'
+      )
+    )
+  }
+  let(:mail) { described_class.rejected(rejection.visit) }
+  let(:body) { mail.html_part.body }
+
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  include_examples 'template checks'
+
+  it 'sends an email reporting the rejection' do
+    expect(mail.subject).
+      to match(/COPY of booking rejection for Arthur Raffles/)
+  end
+end

--- a/spec/mailers/prison_mailer/request_received_spec.rb
+++ b/spec/mailers/prison_mailer/request_received_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+require 'mailers/shared_mailer_examples'
+
+RSpec.describe PrisonMailer, '.request_received' do
+  let(:visit) {
+    create(
+      :visit,
+      prisoner_first_name: 'Arthur',
+      prisoner_last_name: 'Raffles'
+    )
+  }
+  let(:mail) { described_class.request_received(visit) }
+
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  around do |example|
+    Timecop.travel(Date.new(2015, 10, 1)) do
+      example.call
+    end
+  end
+
+  include_examples 'template checks'
+
+  it 'reports the request' do
+    expect(mail.subject).
+      to match(/Visit request for Arthur Raffles on Monday 12 October/)
+  end
+end

--- a/spec/mailers/shared_mailer_examples.rb
+++ b/spec/mailers/shared_mailer_examples.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples 'template checks' do
   it 'has no missing translations' do
-    html = subject.html_part.body
+    html = mail.html_part.body
     expect(html).not_to match(/translation missing/)
   end
 end

--- a/spec/mailers/shared_mailer_examples.rb
+++ b/spec/mailers/shared_mailer_examples.rb
@@ -1,0 +1,6 @@
+RSpec.shared_examples 'template checks' do
+  it 'has no missing translations' do
+    html = subject.html_part.body
+    expect(html).not_to match(/translation missing/)
+  end
+end

--- a/spec/mailers/visitor_mailer/booked_spec.rb
+++ b/spec/mailers/visitor_mailer/booked_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+require 'mailers/shared_mailer_examples'
+
+RSpec.describe VisitorMailer, '.booked' do
+  let(:visit) { create(:booked_visit) }
+  let(:mail) { described_class.booked(visit) }
+
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  around do |example|
+    Timecop.travel(Date.new(2015, 10, 1)) do
+      example.call
+    end
+  end
+
+  include_examples 'template checks'
+
+  it 'sends an email confirming the booking' do
+    expect(mail.subject).
+      to match(/your visit for Monday 12 October has been confirmed/)
+  end
+end

--- a/spec/mailers/visitor_mailer/rejected_spec.rb
+++ b/spec/mailers/visitor_mailer/rejected_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+require 'mailers/shared_mailer_examples'
+
+RSpec.describe VisitorMailer, '.rejected' do
+  let(:rejection) { create(:rejection, reason: reason) }
+  let(:reason) { 'slot_unavailable' }
+  let(:mail) { described_class.rejected(rejection.visit) }
+  let(:body) { mail.html_part.body }
+
+  around do |example|
+    Timecop.travel(Date.new(2015, 10, 1)) do
+      example.call
+    end
+  end
+
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  context 'always' do
+    it 'sends an email reporting the rejection' do
+      expect(mail.subject).
+        to match(/your visit for Monday 12 October could not be booked/)
+    end
+  end
+
+  context 'slot_unavailable' do
+    let(:reason) { 'slot_unavailable' }
+
+    include_examples 'template checks'
+  end
+
+  context 'no_allowance' do
+    let(:rejection) {
+      create(
+        :rejection,
+        reason: 'no_allowance',
+        allowance_renews_on: Date.new(2015, 10, 1),
+        privileged_allowance_expires_on: Date.new(2015, 10, 2)
+      )
+    }
+
+    include_examples 'template checks'
+
+    it 'explains the error' do
+      expect(body).to match(/has not got any visiting allowance left/)
+    end
+
+    it 'explains privileged allowance expiry' do
+      expect(body).to match(/valid until Friday 2 October/)
+    end
+
+    it 'explains allowance renewal' do
+      expect(body).to match(/renewed on Thursday 1 October/)
+    end
+  end
+
+  context 'prisoner_details_incorrect' do
+    let(:reason) { 'prisoner_details_incorrect' }
+
+    include_examples 'template checks'
+
+    it 'explains the error' do
+      expect(body).to match(/haven’t given correct information for the prisoner/)
+    end
+  end
+
+  context 'prisoner_moved' do
+    let(:reason) { 'prisoner_moved' }
+
+    include_examples 'template checks'
+
+    it 'explains the error' do
+      expect(body).to match(/the prisoner you want to visit has moved prison/)
+    end
+  end
+
+  context 'visitor_banned' do
+    let(:reason) { 'visitor_banned' }
+
+    include_examples 'template checks'
+
+    it 'explains the error' do
+      expect(body).to match(/banned from visiting the prison/)
+    end
+  end
+
+  context 'visitor_not_on_list' do
+    let(:reason) { 'visitor_not_on_list' }
+
+    include_examples 'template checks'
+
+    it 'explains the error' do
+      expect(body).to match(/ask them to update their contact list/)
+    end
+  end
+end

--- a/spec/mailers/visitor_mailer/request_acknowledged_spec.rb
+++ b/spec/mailers/visitor_mailer/request_acknowledged_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'mailers/shared_mailer_examples'
 
 RSpec.describe VisitorMailer, '.request_acknowledged' do
   let(:visit) { create(:visit) }
@@ -7,6 +8,8 @@ RSpec.describe VisitorMailer, '.request_acknowledged' do
   before do
     ActionMailer::Base.deliveries.clear
   end
+
+  include_examples 'template checks'
 
   it 'sends an email acknowleging the request' do
     expect(subject.subject).

--- a/spec/mailers/visitor_mailer/request_acknowledged_spec.rb
+++ b/spec/mailers/visitor_mailer/request_acknowledged_spec.rb
@@ -3,17 +3,23 @@ require 'mailers/shared_mailer_examples'
 
 RSpec.describe VisitorMailer, '.request_acknowledged' do
   let(:visit) { create(:visit) }
-  subject { described_class.request_acknowledged(visit) }
+  let(:mail) { described_class.request_acknowledged(visit) }
 
   before do
     ActionMailer::Base.deliveries.clear
   end
 
+  around do |example|
+    Timecop.travel(Date.new(2015, 10, 1)) do
+      example.call
+    end
+  end
+
   include_examples 'template checks'
 
-  it 'sends an email acknowleging the request' do
-    expect(subject.subject).
-      to match(/received your visit request for \w+ \d+ \w+\z/)
+  it 'acknowledges the request' do
+    expect(mail.subject).
+      to match(/received your visit request for Monday 12 October/)
   end
 
   context 'spam and bounce handling' do
@@ -25,7 +31,7 @@ RSpec.describe VisitorMailer, '.request_acknowledged' do
 
     it 'resets sendgrid spam and bounce settings before sending' do
       expect(SpamAndBounceResets).to receive(:new).and_return(reset_call)
-      subject.deliver_now
+      mail.deliver_now
     end
   end
 end


### PR DESCRIPTION
This ensures that we have no missing localisation strings or interpolated values, and checks expected parts of the email body. It's much easier to find and fix errors here than in the feature specs, where
the error is hidden by the delayed mailer.

The dates in some of the specs are coupled to the default slots in the factory, which isn't great, but I think it's probably no worse than laboriously building up a graph in the spec itself.