### PR TITLE
Add smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,14 +259,30 @@ same effect as running it once.
 
 The files can be edited by anyone with access to this repository. The
 [YAML](http://en.wikipedia.org/wiki/YAML) specification is complex and fraught
+`SMOKE_TEST_EMAIL_LOCAL_PART`@`SMOKE_TEST_EMAIL_DOMAIN`, it will not
+send that email to the prison, but will direct all mail the
 with edge cases, so be careful.
 
 #### Prison visibility
+To start the smoke tests, set the environment variables and run
+`ruby ./smoke_test/smoke_test.rb`.
 
 All known prisons should exist in the data files. If a prison is not in scope
 of the service, it should be disabled.
 
+##### Smoke Test Steps:
+  1. Starts the form
+  2. Fills in prisoner details page
+  3. Fills in visitor details page for one visitor
+  4. Selects three available days on the slot page
+  5. Submits the booking on the check your request page
+  6. Checks that the user received a booking receipt email
+  7. Checks that the prison received a booking request email
+  8. Visits the process booking page and confirms the booking
 To disable visit requests to a prison, set `enabled` to `false`.
+  10. Checks that the visitor received a confirmation email
+  11. Checks the status of the visit and cancels it
+  12. Checks that the prison receives a booking cancellation email
 
 ```yaml
   nomis_id: SFI
@@ -275,7 +291,7 @@ To disable visit requests to a prison, set `enabled` to `false`.
   ...
 
 ```
-
+SMOKE_TEST_EMAIL_LOCAL_PART
 #### Weekly visiting slots
 
 Slots are defined per prison via a weekly schedule. Only days listed here with
@@ -290,12 +306,12 @@ slots:
   - 1350-1450 # creates a 1 hour slot every Wednesday from 1:50pm
   sat:
   - 0900-1100 # creates a 2 hour slot every Saturday from 9am
-  - 1330-1530 # creates a 2 hour slot every Saturday from 1:30pm
+SMOKE_TEST_EMAIL_DOMAIN
 ```
 
 #### Slot anomalies
 
-Use this to make exceptions to the weekly schedule.
+##### Required environment variables for the smoke test:
 
 When a day is found in `slot_anomalies` the whole day is replaced with this
 data. Therefore if the weekday usually contains multiple slots and only a
@@ -306,10 +322,10 @@ slot_anomalies:
   2015-01-10:
   - 0930-1130 # replaces Saturday 10 January 2015 with only one slot at 9:30am
 ```
-
-#### Non-bookable days
-
-Use this to remove specified dates, such as staff training days or Christmas
+SMOKE_TEST_EMAIL_LOCAL_PART
+SMOKE_TEST_EMAIL_DOMAIN
+SMOKE_TEST_EMAIL_PASSWORD
+SMOKE_TEST_APP_HOST
 Day from the schedule. Public holidays are already excluded by default:
 visiting can be enabled by adding them as anomalies, above.
 
@@ -317,19 +333,21 @@ This overrides `slots`.
 
 ```yaml
 unbookable:
-- 2015-12-25 # removes any slots from 25 December 2015
+SMOKE_TEST_EMAIL_HOST
 ```
+### `SMOKE_TEST_EMAIL_LOCAL_PART`, `SMOKE_TEST_EMAIL_DOMAIN`
 
-**Note** If an enabled prison does not have any unbookable dates, please
-make sure you represent this in the yaml as:
+These determine the email address that will trigger the smoke tests on
+the application. See note above.
 
 ```yaml
 unbookable: []
-```
+### `SMOKE_TEST_EMAIL_HOST`, `SMOKE_TEST_EMAIL_PASSWORD`
 
-If you do not, the specs will fail.
+These are the details for the IMAP host that allows the smoke test to
+check that the emails have been delivered.
 
-#### Response times
+### `SMOKE_TEST_APP_HOST`
 
 Set the amount of full working days which booking staff have to respond to each
 request. The default is 3 days.
@@ -355,7 +373,7 @@ works_weekends: true
 
 When the service links to [Prison
 Finder](https://www.justice.gov.uk/contacts/prison-finder), it turns the prison
-name into part of the URL. For example, 'Drake Hall' becomes
+This is the url of the particular version of the application that the
 [drake-hall](https://www.justice.gov.uk/contacts/prison-finder/drake-hall).
 
 When the Prison Finder link does not simply match the prison name in lower
@@ -397,4 +415,4 @@ change the UUID.
 #### Deleting a prison
 
 You can't. This is because historical bookings still refer to that prison.
-Disable it instead (see above).
+smoke test will run against.

--- a/app/mailers/mail_utilities/smoke_test_email_check.rb
+++ b/app/mailers/mail_utilities/smoke_test_email_check.rb
@@ -1,0 +1,31 @@
+class SmokeTestEmailCheck
+  attr_accessor :email_address
+
+  def initialize(email_address)
+    @email_address = email_address
+  end
+
+  def matches?
+    smoke_test_email_regex.match(email_address)
+  end
+
+private
+
+  def smoke_test_email_regex
+    %r{
+      \A             # match from the start of the string
+      #{local_part}
+      \+             # google address alias see: https://support.google.com/mail/answer/12096
+      [0-9a-z\-]{36} # RFC 4122 uuid extension
+      @              # it's an email!
+      #{domain}
+      \z             # match until the end of the string
+    }x
+  end
+
+  def smoke_test
+    Rails.configuration.smoke_test
+  end
+
+  delegate :local_part, :domain, to: :smoke_test
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,17 @@ module PrisonVisits
       'StateMachines::InvalidTransition' => :unprocessable_entity
     )
     config.prison_ip_ranges = ENV.fetch('PRISON_ESTATE_IPS', '127.0.0.1,::1')
+
+    config.smoke_test =
+      OpenStruct.new(
+        local_part:
+          Regexp.escape(
+            ENV.fetch('SMOKE_TEST_EMAIL_LOCAL_PART', 'prison-visits-smoke-test')
+          ),
+        domain:
+          Regexp.escape(
+            ENV.fetch('SMOKE_TEST_EMAIL_DOMAIN', 'digital.justice.gov.uk')
+          )
+      )
   end
 end

--- a/smoke_test/helpers/imap_processor.rb
+++ b/smoke_test/helpers/imap_processor.rb
@@ -1,4 +1,16 @@
-module WithRetries
+module ImapProcessor
+module_function
+
+  def email
+    @email ||= with_retries {
+      SmokeTest::MailBox.find_email(
+        state.unique_email_address,
+        expected_email_subject)
+    }
+  end
+
+  private_class_method :email
+
 protected
 
   def with_retries(attempts: 10, initial_delay: 2, max_delay: 120)

--- a/smoke_test/helpers/with_retries.rb
+++ b/smoke_test/helpers/with_retries.rb
@@ -1,0 +1,16 @@
+module WithRetries
+protected
+
+  def with_retries(attempts: 10, initial_delay: 2, max_delay: 120)
+    delay = initial_delay
+    result = nil
+    attempts.times do
+      result = yield
+      break if result
+      puts "waiting #{delay}s .."
+      sleep delay
+      delay = [max_delay, delay * 2].min
+    end
+    result
+  end
+end

--- a/smoke_test/mail_box.rb
+++ b/smoke_test/mail_box.rb
@@ -1,0 +1,32 @@
+require 'mail'
+require 'net/imap'
+
+module SmokeTest
+  module MailBox
+  module_function
+
+    def find_email(unique_address, subject)
+      client = Net::IMAP.new(SMOKE_TEST_EMAIL_HOST, port: 993, ssl: true)
+      client.login imap_username, SMOKE_TEST_EMAIL_PASSWORD
+      client.examine 'INBOX'
+      mail_id_list = client.search(['TO', unique_address, 'SUBJECT', subject])
+
+      return if mail_id_list.empty? # empty lists appear to break imap->fetch
+
+      client.fetch(mail_id_list, 'RFC822').map(&method(:parse_email)).first
+    ensure
+      client.logout
+      client.disconnect
+    end
+
+    def parse_email(msg)
+      Mail.read_from_string(msg.attr['RFC822'])
+    end
+
+    def imap_username
+      "#{SMOKE_TEST_EMAIL_LOCAL_PART}@#{SMOKE_TEST_EMAIL_DOMAIN}"
+    end
+
+    private_class_method :parse_email, :imap_username
+  end
+end

--- a/smoke_test/smoke_test.rb
+++ b/smoke_test/smoke_test.rb
@@ -58,19 +58,26 @@ module SmokeTest
       puts 'Beginning Smoke Test..'
       Capybara.reset_sessions!
       visit '/request'
-      STEPS.map(&method(:complete))
+      STEPS.map do |step|
+        puts "Step: #{step_name(step)}"
+        complete(step)
+      end
       puts 'Smoke Test Completed'
     end
 
   private
 
+    def step_name(step)
+      step.name.split('::').last.gsub(/(?=[A-Z])/, ' ').strip
+    end
+
     def complete(step)
-      current_step = step.new state
+      current_step = step.new
       current_step.validate!
       current_step.complete_step
     end
 
-    def state
+    def self.state
       @state ||= State.new
     end
   end

--- a/smoke_test/smoke_test.rb
+++ b/smoke_test/smoke_test.rb
@@ -3,7 +3,7 @@ require 'capybara/dsl'
 require 'phantomjs/poltergeist'
 require 'capybara/poltergeist'
 
-require_relative 'helpers/with_retries'
+require_relative 'helpers/imap_processor'
 require_relative 'state'
 require_relative 'mail_box'
 require_relative 'steps/base_step'

--- a/smoke_test/smoke_test.rb
+++ b/smoke_test/smoke_test.rb
@@ -3,6 +3,7 @@ require 'capybara/dsl'
 require 'phantomjs/poltergeist'
 require 'capybara/poltergeist'
 
+require_relative 'helpers/with_retries'
 require_relative 'state'
 require_relative 'mail_box'
 require_relative 'steps/base_step'

--- a/smoke_test/smoke_test.rb
+++ b/smoke_test/smoke_test.rb
@@ -1,0 +1,78 @@
+require 'capybara'
+require 'capybara/dsl'
+require 'phantomjs/poltergeist'
+require 'capybara/poltergeist'
+
+require_relative 'state'
+require_relative 'mail_box'
+require_relative 'steps/base_step'
+require_relative 'steps/prisoner_page'
+require_relative 'steps/visitors_page'
+require_relative 'steps/slots_page'
+require_relative 'steps/check_your_request_page'
+require_relative 'steps/visitor_booking_receipt'
+require_relative 'steps/prison_booking_request'
+require_relative 'steps/process_visit_request_page'
+require_relative 'steps/visitor_booking_confirmation'
+require_relative 'steps/prison_booking_confirmation_copy'
+require_relative 'steps/cancel_booking_page'
+require_relative 'steps/prison_booking_cancelled'
+
+module SuppressJsConsoleLogging; end
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new \
+    app, phantomjs_logger: SuppressJsConsoleLogging
+end
+
+Capybara.run_server = false
+Capybara.current_driver = :poltergeist
+Capybara.app_host = ENV.fetch('SMOKE_TEST_APP_HOST', 'http://localhost:3000')
+
+module SmokeTest
+  SMOKE_TEST_EMAIL_LOCAL_PART = ENV.fetch(
+    'SMOKE_TEST_EMAIL_LOCAL_PART',
+    'smoke-test')
+  SMOKE_TEST_EMAIL_DOMAIN = ENV.fetch('SMOKE_TEST_EMAIL_DOMAIN', 'example.com')
+  SMOKE_TEST_EMAIL_PASSWORD = ENV.fetch('SMOKE_TEST_EMAIL_PASSWORD', nil)
+  SMOKE_TEST_EMAIL_HOST = ENV.fetch('SMOKE_TEST_EMAIL_HOST', nil)
+
+  STEPS = [
+    Steps::PrisonerPage,
+    Steps::VisitorsPage,
+    Steps::SlotsPage,
+    Steps::CheckYourRequestPage,
+    Steps::VisitorBookingReceipt,
+    Steps::PrisonBookingRequest,
+    Steps::ProcessVisitRequestPage,
+    Steps::PrisonBookingConfirmationCopy,
+    Steps::VisitorBookingConfirmation,
+    Steps::CancelBookingPage,
+    Steps::PrisonBookingCancelled
+  ]
+
+  class Runner
+    include Capybara::DSL
+
+    def run
+      puts 'Beginning Smoke Test..'
+      Capybara.reset_sessions!
+      visit '/request'
+      STEPS.map(&method(:complete))
+      puts 'Smoke Test Completed'
+    end
+
+  private
+
+    def complete(step)
+      current_step = step.new state
+      current_step.validate!
+      current_step.complete_step
+    end
+
+    def state
+      @state ||= State.new
+    end
+  end
+end
+
+SmokeTest::Runner.new.run

--- a/smoke_test/state.rb
+++ b/smoke_test/state.rb
@@ -1,0 +1,70 @@
+require 'ostruct'
+require 'yaml'
+require 'erb'
+
+module SmokeTest
+  class State
+    attr_accessor :slot_data
+
+    TEST_DATA = YAML.load(
+      ERB.new(
+        File.read(File.expand_path('../test_data.yml', __FILE__))
+      ).result)
+
+    def prisoner
+      @prisoner ||= Prisoner.new
+    end
+
+    def visitor
+      @visitor ||= Visitor.new
+    end
+
+    def process_data
+      @process_data ||= OpenStruct.new(TEST_DATA.fetch 'process_data')
+    end
+
+    def unique_email_address
+      visitor.email_address
+    end
+
+    def first_slot_date
+      slot_data.first[:date]
+    end
+
+    alias_method :first_slot_date_prison_format, :first_slot_date
+
+    def first_slot_date_visitor_format
+      Date.parse(first_slot_date).strftime('%A %-d %B')
+    end
+
+    class Prisoner < SimpleDelegator
+      def initialize
+        super(OpenStruct.new State::TEST_DATA.fetch('prisoner_details'))
+      end
+
+      def full_name
+        "#{first_name} #{last_name}"
+      end
+    end
+
+    class Visitor < SimpleDelegator
+      def initialize
+        super(OpenStruct.new State::TEST_DATA.fetch('visitor_details'))
+      end
+
+      def email_address
+        @email_address ||= UniqueEmailAddress.new
+      end
+
+      class UniqueEmailAddress < String
+        def initialize(*)
+          uuid = SecureRandom.uuid
+          super \
+            "#{SMOKE_TEST_EMAIL_LOCAL_PART}+#{uuid}@#{SMOKE_TEST_EMAIL_DOMAIN}"
+
+          freeze
+        end
+      end
+    end
+  end
+end

--- a/smoke_test/steps/base_step.rb
+++ b/smoke_test/steps/base_step.rb
@@ -24,18 +24,6 @@ module SmokeTest
         self.class.name.split('::').last.gsub(/(?=[A-Z])/, ' ')
       end
 
-      def with_retries(attempts: 10, initial_delay: 2, max_delay: 120)
-        delay = initial_delay
-        result = nil
-        attempts.times do
-          result = yield
-          break if result
-          puts "waiting #{delay}s .."
-          sleep delay
-          delay = [max_delay, delay * 2].min
-        end
-        result
-      end
     end
   end
 end

--- a/smoke_test/steps/base_step.rb
+++ b/smoke_test/steps/base_step.rb
@@ -1,0 +1,41 @@
+module SmokeTest
+  module Steps
+    class BaseStep
+      include Capybara::DSL
+
+      attr_accessor :state
+
+      def initialize(state)
+        puts "Step:#{step_name}"
+        @state = state
+      end
+
+      def validate!
+        true
+      end
+
+      def complete_step
+        fail NotImplementedError
+      end
+
+    protected
+
+      def step_name
+        self.class.name.split('::').last.gsub(/(?=[A-Z])/, ' ')
+      end
+
+      def with_retries(attempts: 10, initial_delay: 2, max_delay: 120)
+        delay = initial_delay
+        result = nil
+        attempts.times do
+          result = yield
+          break if result
+          puts "waiting #{delay}s .."
+          sleep delay
+          delay = [max_delay, delay * 2].min
+        end
+        result
+      end
+    end
+  end
+end

--- a/smoke_test/steps/base_step.rb
+++ b/smoke_test/steps/base_step.rb
@@ -2,28 +2,13 @@ module SmokeTest
   module Steps
     class BaseStep
       include Capybara::DSL
-
-      attr_accessor :state
-
-      def initialize(state)
-        puts "Step:#{step_name}"
-        @state = state
-      end
-
-      def validate!
-        true
-      end
-
-      def complete_step
-        fail NotImplementedError
-      end
+      extend Forwardable
 
     protected
 
-      def step_name
-        self.class.name.split('::').last.gsub(/(?=[A-Z])/, ' ')
+      def state
+        SmokeTest::Runner.state
       end
-
     end
   end
 end

--- a/smoke_test/steps/cancel_booking_page.rb
+++ b/smoke_test/steps/cancel_booking_page.rb
@@ -1,0 +1,18 @@
+module SmokeTest
+  module Steps
+    class CancelBookingPage < BaseStep
+      PAGE_PATH = %r{\A/visits/([0-9a-f-]){36}}
+
+      def validate!
+        unless PAGE_PATH.match page.current_path
+          fail "expected #{PAGE_PATH}, got #{page.current_path}"
+        end
+      end
+
+      def complete_step
+        check 'Yes, I want to cancel this visit'
+        click_button 'Cancel visit'
+      end
+    end
+  end
+end

--- a/smoke_test/steps/check_your_request_page.rb
+++ b/smoke_test/steps/check_your_request_page.rb
@@ -1,0 +1,17 @@
+module SmokeTest
+  module Steps
+    class CheckYourRequestPage < BaseStep
+      PAGE_PATH = '/request'
+
+      def validate!
+        if page.current_path != PAGE_PATH
+          fail "expected #{PAGE_PATH}, got #{page.current_path}"
+        end
+      end
+
+      def complete_step
+        click_button 'Send request'
+      end
+    end
+  end
+end

--- a/smoke_test/steps/prison_booking_cancelled.rb
+++ b/smoke_test/steps/prison_booking_cancelled.rb
@@ -1,6 +1,8 @@
 module SmokeTest
   module Steps
     class PrisonBookingCancelled < BaseStep
+      include WithRetries
+
       def validate!
         fail 'Could not find prison booking cancelled email' unless email
       end

--- a/smoke_test/steps/prison_booking_cancelled.rb
+++ b/smoke_test/steps/prison_booking_cancelled.rb
@@ -1,23 +1,17 @@
 module SmokeTest
   module Steps
     class PrisonBookingCancelled < BaseStep
-      include WithRetries
+      include ImapProcessor
 
       def validate!
         fail 'Could not find prison booking cancelled email' unless email
       end
 
       def complete_step
-        # nothing for us to do with this page
+        # nothing for us to do with this email
       end
 
     private
-
-      def email
-        @email ||= with_retries {
-          MailBox.find_email state.unique_email_address, expected_email_subject
-        }
-      end
 
       def expected_email_subject
         'CANCELLED: %s on %s' % [

--- a/smoke_test/steps/prison_booking_cancelled.rb
+++ b/smoke_test/steps/prison_booking_cancelled.rb
@@ -1,0 +1,28 @@
+module SmokeTest
+  module Steps
+    class PrisonBookingCancelled < BaseStep
+      def validate!
+        fail 'Could not find prison booking cancelled email' unless email
+      end
+
+      def complete_step
+        # nothing for us to do with this page
+      end
+
+    private
+
+      def email
+        @email ||= with_retries {
+          MailBox.find_email state.unique_email_address, expected_email_subject
+        }
+      end
+
+      def expected_email_subject
+        'CANCELLED: %s on %s' % [
+          state.prisoner.full_name,
+          state.first_slot_date_prison_format
+        ]
+      end
+    end
+  end
+end

--- a/smoke_test/steps/prison_booking_confirmation_copy.rb
+++ b/smoke_test/steps/prison_booking_confirmation_copy.rb
@@ -1,0 +1,27 @@
+module SmokeTest
+  module Steps
+    class PrisonBookingConfirmationCopy < BaseStep
+      def validate!
+        unless email
+          fail 'Could not find prison booking confirmation copy email'
+        end
+      end
+
+      def complete_step
+        # nothing for us to do with this email
+      end
+
+    private
+
+      def email
+        @email ||= with_retries {
+          MailBox.find_email state.unique_email_address, expected_email_subject
+        }
+      end
+
+      def expected_email_subject
+        'COPY of booking confirmation for %s' % [state.prisoner.full_name]
+      end
+    end
+  end
+end

--- a/smoke_test/steps/prison_booking_confirmation_copy.rb
+++ b/smoke_test/steps/prison_booking_confirmation_copy.rb
@@ -1,7 +1,7 @@
 module SmokeTest
   module Steps
     class PrisonBookingConfirmationCopy < BaseStep
-      include WithRetries
+      include ImapProcessor
 
       def validate!
         unless email
@@ -14,12 +14,6 @@ module SmokeTest
       end
 
     private
-
-      def email
-        @email ||= with_retries {
-          MailBox.find_email state.unique_email_address, expected_email_subject
-        }
-      end
 
       def expected_email_subject
         'COPY of booking confirmation for %s' % [state.prisoner.full_name]

--- a/smoke_test/steps/prison_booking_confirmation_copy.rb
+++ b/smoke_test/steps/prison_booking_confirmation_copy.rb
@@ -1,6 +1,8 @@
 module SmokeTest
   module Steps
     class PrisonBookingConfirmationCopy < BaseStep
+      include WithRetries
+
       def validate!
         unless email
           fail 'Could not find prison booking confirmation copy email'

--- a/smoke_test/steps/prison_booking_request.rb
+++ b/smoke_test/steps/prison_booking_request.rb
@@ -1,7 +1,7 @@
 module SmokeTest
   module Steps
     class PrisonBookingRequest < BaseStep
-      include WithRetries
+      include ImapProcessor
 
       def validate!
         fail 'Could not find prison booking request email' unless email
@@ -12,12 +12,6 @@ module SmokeTest
       end
 
     private
-
-      def email
-        @email ||= with_retries {
-          MailBox.find_email state.unique_email_address, expected_email_subject
-        }
-      end
 
       def expected_email_subject
         'Visit request for %s on %s' % [

--- a/smoke_test/steps/prison_booking_request.rb
+++ b/smoke_test/steps/prison_booking_request.rb
@@ -1,0 +1,33 @@
+module SmokeTest
+  module Steps
+    class PrisonBookingRequest < BaseStep
+      def validate!
+        fail 'Could not find prison booking request email' unless email
+      end
+
+      def complete_step
+        visit booking_processing_url
+      end
+
+    private
+
+      def email
+        @email ||= with_retries {
+          MailBox.find_email state.unique_email_address, expected_email_subject
+        }
+      end
+
+      def expected_email_subject
+        'Visit request for %s on %s' % [
+          state.prisoner.full_name,
+          state.first_slot_date_prison_format
+        ]
+      end
+
+      def booking_processing_url
+        Nokogiri::HTML(email.html_part.body.decoded).
+          at('a:contains("Process the booking")')['href']
+      end
+    end
+  end
+end

--- a/smoke_test/steps/prison_booking_request.rb
+++ b/smoke_test/steps/prison_booking_request.rb
@@ -1,6 +1,8 @@
 module SmokeTest
   module Steps
     class PrisonBookingRequest < BaseStep
+      include WithRetries
+
       def validate!
         fail 'Could not find prison booking request email' unless email
       end

--- a/smoke_test/steps/prisoner_page.rb
+++ b/smoke_test/steps/prisoner_page.rb
@@ -30,9 +30,7 @@ module SmokeTest
           set(name)
       end
 
-      def prisoner
-        state.prisoner
-      end
+      def_delegator :state, :prisoner
     end
   end
 end

--- a/smoke_test/steps/prisoner_page.rb
+++ b/smoke_test/steps/prisoner_page.rb
@@ -1,0 +1,38 @@
+module SmokeTest
+  module Steps
+    class PrisonerPage < BaseStep
+      PAGE_PATH = '/request'
+
+      def validate!
+        if page.current_path != PAGE_PATH
+          fail "expected #{PAGE_PATH}, got #{page.current_path}"
+        end
+      end
+
+      # rubocop:disable Metrics/AbcSize
+      def complete_step
+        fill_in 'Prisoner first name', with: prisoner.first_name
+        fill_in 'Prisoner last name', with: prisoner.last_name
+        fill_in 'Day', with: prisoner.birth_day
+        fill_in 'Month', with: prisoner.birth_month
+        fill_in 'Year', with: prisoner.birth_year
+        fill_in 'Prisoner number', with: prisoner.prison_number
+        select_prison(prisoner.prison_name)
+        click_button 'Continue'
+      end
+
+    # rubocop:enable Metrics/AbcSize
+
+    private
+
+      def select_prison(name)
+        find('input[data-input-name="prisoner_step[prison_id]"]').
+          set(name)
+      end
+
+      def prisoner
+        state.prisoner
+      end
+    end
+  end
+end

--- a/smoke_test/steps/process_visit_request_page.rb
+++ b/smoke_test/steps/process_visit_request_page.rb
@@ -1,6 +1,7 @@
 module SmokeTest
   module Steps
     class ProcessVisitRequestPage < BaseStep
+
       PAGE_PATH = %r{/prison/visits/([0-9a-f-]){36}}
 
       def validate!

--- a/smoke_test/steps/process_visit_request_page.rb
+++ b/smoke_test/steps/process_visit_request_page.rb
@@ -1,0 +1,25 @@
+module SmokeTest
+  module Steps
+    class ProcessVisitRequestPage < BaseStep
+      PAGE_PATH = %r{/prison/visits/([0-9a-f-]){36}}
+
+      def validate!
+        unless page.current_path.match(PAGE_PATH)
+          fail "expected #{PAGE_PATH} to match #{page.current_path}"
+        end
+      end
+
+      def complete_step
+        choose 'Choice 1'
+        fill_in 'Reference number', with: process_data.vo_digits
+        click_button 'Send email'
+      end
+
+    private
+
+      def process_data
+        state.process_data
+      end
+    end
+  end
+end

--- a/smoke_test/steps/process_visit_request_page.rb
+++ b/smoke_test/steps/process_visit_request_page.rb
@@ -1,7 +1,6 @@
 module SmokeTest
   module Steps
     class ProcessVisitRequestPage < BaseStep
-
       PAGE_PATH = %r{/prison/visits/([0-9a-f-]){36}}
 
       def validate!
@@ -18,9 +17,7 @@ module SmokeTest
 
     private
 
-      def process_data
-        state.process_data
-      end
+      def_delegator :state, :process_data
     end
   end
 end

--- a/smoke_test/steps/slots_page.rb
+++ b/smoke_test/steps/slots_page.rb
@@ -1,0 +1,48 @@
+module SmokeTest
+  module Steps
+    class SlotsPage < BaseStep
+      PAGE_PATH = '/request'
+
+      def validate!
+        if page.current_path != PAGE_PATH
+          fail "expected #{PAGE_PATH}, got #{page.current_path}"
+        end
+      end
+
+      def complete_step
+        select_three_visiting_slots
+        state.slot_data = selected_dates_and_times
+        click_button 'Continue'
+      end
+
+    private
+
+      def select_three_visiting_slots
+        available_dates_on_calendar.
+          take(3).
+          each do |calendar_date|
+            calendar_date.click
+            click_first_available_time
+          end
+      end
+
+      def available_dates_on_calendar
+        all('.BookingCalendar-date--bookable')
+      end
+
+      def click_first_available_time
+        all('.SlotPicker-label').first.click
+      end
+
+      def selected_dates_and_times
+        page.all('.SlotPicker-choice').reduce([]) do |slots, el|
+          slot_data = {
+            date: el.find('.SlotPicker-date').text,
+            time: el.find('.SlotPicker-time').text
+          }
+          slots << slot_data
+        end
+      end
+    end
+  end
+end

--- a/smoke_test/steps/visitor_booking_confirmation.rb
+++ b/smoke_test/steps/visitor_booking_confirmation.rb
@@ -1,7 +1,7 @@
 module SmokeTest
   module Steps
     class VisitorBookingConfirmation < BaseStep
-      include WithRetries
+      include ImapProcessor
 
       def validate!
         fail 'Could not find visitor booking confirmation email' unless email
@@ -12,12 +12,6 @@ module SmokeTest
       end
 
     private
-
-      def email
-        @email ||= with_retries {
-          MailBox.find_email state.unique_email_address, expected_email_subject
-        }
-      end
 
       def expected_email_subject
         'Visit confirmed: your visit for %s has been confirmed' % [

--- a/smoke_test/steps/visitor_booking_confirmation.rb
+++ b/smoke_test/steps/visitor_booking_confirmation.rb
@@ -1,6 +1,8 @@
 module SmokeTest
   module Steps
     class VisitorBookingConfirmation < BaseStep
+      include WithRetries
+
       def validate!
         fail 'Could not find visitor booking confirmation email' unless email
       end

--- a/smoke_test/steps/visitor_booking_confirmation.rb
+++ b/smoke_test/steps/visitor_booking_confirmation.rb
@@ -1,0 +1,32 @@
+module SmokeTest
+  module Steps
+    class VisitorBookingConfirmation < BaseStep
+      def validate!
+        fail 'Could not find visitor booking confirmation email' unless email
+      end
+
+      def complete_step
+        visit cancel_booking_url
+      end
+
+    private
+
+      def email
+        @email ||= with_retries {
+          MailBox.find_email state.unique_email_address, expected_email_subject
+        }
+      end
+
+      def expected_email_subject
+        'Visit confirmed: your visit for %s has been confirmed' % [
+          state.first_slot_date_visitor_format
+        ]
+      end
+
+      def cancel_booking_url
+        Nokogiri::HTML(email.html_part.body.decoded).
+          at('a:contains("you can cancel this visit")')['href']
+      end
+    end
+  end
+end

--- a/smoke_test/steps/visitor_booking_receipt.rb
+++ b/smoke_test/steps/visitor_booking_receipt.rb
@@ -1,0 +1,27 @@
+module SmokeTest
+  module Steps
+    class VisitorBookingReceipt < BaseStep
+      def validate!
+        fail 'Could not find visitor booking receipt email' unless email
+      end
+
+      def complete_step
+        # nothing for us to do with this email
+      end
+
+    private
+
+      def email
+        @email ||= with_retries {
+          MailBox.find_email state.unique_email_address, expected_email_subject
+        }
+      end
+
+      def expected_email_subject
+        "Not booked yet: we've received your visit request for %s" % [
+          state.first_slot_date_visitor_format
+        ]
+      end
+    end
+  end
+end

--- a/smoke_test/steps/visitor_booking_receipt.rb
+++ b/smoke_test/steps/visitor_booking_receipt.rb
@@ -1,6 +1,8 @@
 module SmokeTest
   module Steps
     class VisitorBookingReceipt < BaseStep
+      include WithRetries
+
       def validate!
         fail 'Could not find visitor booking receipt email' unless email
       end

--- a/smoke_test/steps/visitor_booking_receipt.rb
+++ b/smoke_test/steps/visitor_booking_receipt.rb
@@ -1,7 +1,7 @@
 module SmokeTest
   module Steps
     class VisitorBookingReceipt < BaseStep
-      include WithRetries
+      include ImapProcessor
 
       def validate!
         fail 'Could not find visitor booking receipt email' unless email
@@ -12,12 +12,6 @@ module SmokeTest
       end
 
     private
-
-      def email
-        @email ||= with_retries {
-          MailBox.find_email state.unique_email_address, expected_email_subject
-        }
-      end
 
       def expected_email_subject
         "Not booked yet: we've received your visit request for %s" % [

--- a/smoke_test/steps/visitors_page.rb
+++ b/smoke_test/steps/visitors_page.rb
@@ -1,0 +1,33 @@
+module SmokeTest
+  module Steps
+    class VisitorsPage < BaseStep
+      PAGE_PATH = '/request'
+
+      def validate!
+        if page.current_path != PAGE_PATH
+          fail "expected #{PAGE_PATH}, got #{page.current_path}"
+        end
+      end
+
+      # rubocop:disable Metrics/AbcSize
+      def complete_step
+        fill_in 'Your first name', with: visitor.first_name
+        fill_in 'Your last name', with: visitor.last_name
+        fill_in 'Day', with: visitor.birth_day
+        fill_in 'Month', with: visitor.birth_month
+        fill_in 'Year', with: visitor.birth_year
+        fill_in 'Email address', with: visitor.email_address
+        fill_in 'Phone number', with: visitor.phone_number
+        click_button 'Continue'
+      end
+
+    # rubocop:enable Metrics/AbcSize
+
+    private
+
+      def visitor
+        state.visitor
+      end
+    end
+  end
+end

--- a/smoke_test/steps/visitors_page.rb
+++ b/smoke_test/steps/visitors_page.rb
@@ -25,9 +25,7 @@ module SmokeTest
 
     private
 
-      def visitor
-        state.visitor
-      end
+      def_delegator :state, :visitor
     end
   end
 end

--- a/smoke_test/test_data.yml
+++ b/smoke_test/test_data.yml
@@ -1,0 +1,19 @@
+prisoner_details:
+  first_name: Arnold
+  last_name: Prisoner
+  birth_day: 10
+  birth_month: 12
+  birth_year: 1987
+  prison_number: a1234bc
+  prison_name: Cardiff
+
+visitor_details:
+  first_name: Joe
+  last_name: Visitor
+  birth_day: 29
+  birth_month: 7
+  birth_year: 1982
+  phone_number: 12345678911
+
+process_data:
+  vo_digits: 12345678

--- a/spec/features/booking_shared_examples.rb
+++ b/spec/features/booking_shared_examples.rb
@@ -1,0 +1,21 @@
+RSpec.shared_examples 'make a booking' do
+  scenario do
+    find('#booking_response_selection_slot_0').click
+    fill_in 'Reference number', with: '12345678'
+
+    click_button 'Send email'
+
+    vst.reload
+    expect(vst).to be_booked
+    expect(vst.reference_no).to eq('12345678')
+
+    expect(visitor_email_address).
+      to receive_email.
+      with_subject(/Visit confirmed: your visit for \w+ \d+ \w+ has been confirmed/).
+      and_body(/Your visit to Reading Gaol is now successfully confirmed/)
+    expect(prison_email_address).
+      to receive_email.
+      with_subject(/COPY of booking confirmation for Oscar Wilde/).
+      and_body(/This is a copy of the booking confirmation email sent to the visitor/)
+  end
+end

--- a/spec/mailers/mail_utilities/smoke_test_email_check_spec.rb
+++ b/spec/mailers/mail_utilities/smoke_test_email_check_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe SmokeTestEmailCheck do
+  subject { described_class.new email_address }
+
+  describe '#matches?' do
+    context 'a smoke test email address with a uuid' do
+      let(:email_address) {
+        "prison-visits-smoke-test+#{SecureRandom.uuid}@digital.justice.gov.uk"
+      }
+
+      specify { expect(subject.matches?).to be_truthy }
+    end
+
+    context 'a regular email address' do
+      let(:email_address) { "some-email@gmail.com" }
+
+      specify { expect(subject.matches?).to be_falsey }
+    end
+  end
+end

--- a/spec/mailers/prison_mailer_spec.rb
+++ b/spec/mailers/prison_mailer_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+require 'mailers/shared_mailer_examples'
+
+RSpec.describe PrisonMailer do
+  context 'smoke test' do
+    let(:visit) {
+      create(
+        :booked_visit,
+        prisoner: create(
+          :prisoner,
+          first_name: 'Arthur',
+          last_name: 'Raffles'
+        )
+      )
+    }
+
+    let(:mail) { described_class.booked(visit) }
+    let(:smoke_test_email) {
+      "prison-visits-smoke-test+#{'a' * 36}@digital.justice.gov.uk"
+    }
+
+    before do
+      ActionMailer::Base.deliveries.clear
+      allow(visit).to receive(:contact_email_address).
+        and_return(smoke_test_email)
+    end
+
+    let(:smoke_test) { double('smoke_test_check', matches?: true) }
+
+    it 'changes the to address from the prison email to the smoke test email' do
+      mail.deliver_now
+      expect(mail.to).to eq([smoke_test_email])
+    end
+  end
+end


### PR DESCRIPTION
This is an adaption of the DanP's smoke tests from the original version
of the application.  The main things that have changed are the end points and the way cancellations are handled.  