### PR TITLE
Never attempt an MX check in test/dev

### DIFF
--- a/app/services/email_checker.rb
+++ b/app/services/email_checker.rb
@@ -73,10 +73,6 @@ private
   end
 
   def mx_records?
-    Resolv::DNS.new.getresource(domain, Resolv::DNS::Resource::IN::MX)
-  rescue Resolv::ResolvError
-    false
-  rescue Resolv::ResolvTimeout
-    true
+    Rails.configuration.mx_checker.records?(domain)
   end
 end

--- a/app/services/mx_checker.rb
+++ b/app/services/mx_checker.rb
@@ -1,0 +1,19 @@
+class MxChecker
+  def initialize(resolver = ::Resolv::DNS.new)
+    @resolver = resolver
+  end
+
+  def records?(domain)
+    @resolver.getresource(domain, ::Resolv::DNS::Resource::IN::MX)
+  rescue ::Resolv::ResolvError
+    false
+  rescue ::Resolv::ResolvTimeout
+    true
+  end
+
+  class Dummy
+    def records?(_)
+      true
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,4 +13,6 @@ Rails.application.configure do
   config.assets.debug = true
   config.assets.digest = true
   config.assets.raise_runtime_errors = true
+
+  config.mx_checker = MxChecker::Dummy.new
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,4 +29,6 @@ Rails.application.configure do
   config.logstasher.source = 'logstasher'
   config.logstasher.backtrace = true
   config.logstasher.logger_path = "#{Rails.root}/log/logstash_#{Rails.env}.json"
+
+  config.mx_checker = MxChecker.new
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,4 +14,6 @@ Rails.application.configure do
     { host: 'localhost', protocol: 'https', port: '3000' }
   config.active_support.test_order = :random
   config.active_support.deprecation = :stderr
+
+  config.mx_checker = MxChecker::Dummy.new
 end

--- a/spec/controllers/steps_controller_spec.rb
+++ b/spec/controllers/steps_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
-require 'shared_sendgrid_context'
 
 RSpec.describe StepsController do
-  include_context 'disable resolv for domain', 'test.example.com'
   let(:prisoner_details) {
     {
       first_name: 'Oscar',

--- a/spec/features/override_sendgrid_spec.rb
+++ b/spec/features/override_sendgrid_spec.rb
@@ -4,7 +4,6 @@ require 'shared_sendgrid_context'
 RSpec.feature "overriding Sendgrid", js: true do
   include ActiveJobHelper
   include FeaturesHelper
-  include_context 'disable resolv for domain', 'maildrop.dsd.io'
 
   let(:expected_email_address) { 'test@maildrop.dsd.io' }
   let(:irrelevant_response) { { 'message' => 'success' } }

--- a/spec/features/request_a_visit_spec.rb
+++ b/spec/features/request_a_visit_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
-require 'shared_sendgrid_context'
 
 RSpec.feature 'Booking a visit', js: true do
-  include_context 'disable resolv for domain', 'test.example.com'
   include ActiveJobHelper
   include FeaturesHelper
 

--- a/spec/services/mx_checker_spec.rb
+++ b/spec/services/mx_checker_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe MxChecker do
+  subject { described_class.new(resolver) }
+  let(:resolver) { double('Resolv::DNS') }
+  let(:domain) { 'test.example.com' }
+
+  before do
+    allow(Resolv::DNS).to receive(:new).and_return(resolver)
+  end
+
+  describe 'records?' do
+    context 'when MX records are found' do
+      before do
+        allow(resolver).
+          to receive(:getresource).with(domain, anything).
+          and_return(true)
+      end
+
+      it 'is true' do
+        expect(subject.records?(domain)).to be_truthy
+      end
+    end
+
+    context 'when the MX query times out' do
+      before do
+        allow(resolver).
+          to receive(:getresource).
+          and_raise(Resolv::ResolvTimeout)
+      end
+
+      it 'is true' do
+        expect(subject.records?(domain)).to be_truthy
+      end
+    end
+
+    context 'when the MX query fails' do
+      before do
+        allow(resolver).
+          to receive(:getresource).
+          and_raise(Resolv::ResolvError)
+      end
+
+      it 'is false' do
+        expect(subject.records?(domain)).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/shared_sendgrid_context.rb
+++ b/spec/shared_sendgrid_context.rb
@@ -1,18 +1,3 @@
-RSpec.shared_context 'disable resolv for domain' do |domain|
-  let(:resolv_response) { double('Resolv::DNS') }
-
-  before do
-    allow(resolv_response).to receive(:getresource).with(domain, anything).and_return(true)
-    allow(Resolv::DNS).to receive(:new).and_return(resolv_response)
-  end
-end
-
-RSpec.shared_context 'disable resolv' do
-  before do
-    allow_any_instance_of(Resolv::DNS).to receive(:getresource).and_return(true)
-  end
-end
-
 RSpec.shared_context 'sendgrid reports a bounce' do
   before do
     allow(SendgridApi).to receive(:bounced?).at_least(:once).and_return(true)
@@ -22,19 +7,5 @@ end
 RSpec.shared_context 'sendgrid reports spam' do
   before do
     allow(SendgridApi).to receive(:spam_reported?).at_least(:once).and_return(true)
-  end
-end
-
-RSpec.shared_context 'resolv times out' do
-  before do
-    allow_any_instance_of(Resolv::DNS).
-      to receive(:getresource).and_raise(Resolv::ResolvTimeout)
-  end
-end
-
-RSpec.shared_context 'resolv raises an error' do
-  before do
-    allow_any_instance_of(Resolv::DNS).
-      to receive(:getresource).and_raise(Resolv::ResolvError)
   end
 end


### PR DESCRIPTION
Checking DNS in tests is slow and failure-prone, and in development it's just plain annoying.