### PR TITLE
Enable datepicker

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,6 +2,7 @@
 //= require handlebars
 //= require lodash
 //= require jquery-ui-autocomplete
+//= require vendor/modernizr.custom.85598
 //= require dist/javascripts/moj.slot-picker
 //= require dist/javascripts/moj.date-slider
 //= require dest/respond.min

--- a/app/helpers/calendar_helper.rb
+++ b/app/helpers/calendar_helper.rb
@@ -27,4 +27,20 @@ module CalendarHelper
     end_on = prison.last_bookable_date.end_of_month.end_of_week
     (begin_on..end_on).group_by(&:beginning_of_week).values
   end
+
+  def calendar_day(date, bookable)
+    day = content_tag(:span, date.strftime('%-e'), class: 'BookingCalendar-day')
+    return day if bookable == false
+    content_tag(
+      :a,
+      day,
+      class: 'BookingCalendar-dateLink',
+      'data-date': date.iso8601,
+      href: "#date-#{date.iso8601}"
+    )
+  end
+
+  def bookable(prison, day)
+    prison.bookable_date?(day) ? 'bookable' : 'unavailable'
+  end
 end

--- a/app/models/concrete_slot.rb
+++ b/app/models/concrete_slot.rb
@@ -25,7 +25,7 @@ ConcreteSlot = Struct.new(
   end
 
   def on?(date)
-    self.to_date == date
+    to_date == date
   end
 
   # We are explicitly parsing these as UTC, but this Rubocop cop isn't clever

--- a/app/models/concrete_slot.rb
+++ b/app/models/concrete_slot.rb
@@ -20,6 +20,15 @@ ConcreteSlot = Struct.new(
 
   alias_method :to_s, :iso8601
 
+  def to_date
+    Date.new(year, month, day)
+  end
+
+  def on?(date)
+    self.to_date == date
+  end
+
+  # We are explicitly parsing these as UTC, but this Rubocop cop isn't clever
   # We use UTC because we don't actually care about time zone offsets: booking
   # times are always given in terms of wall time, and we only use Time to give
   # us a convenient way to perform maths and to format dates and times for

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -36,7 +36,7 @@ class Prison < ActiveRecord::Base
   end
 
   def bookable_date?(requested_date = Time.zone.today)
-    available_slots.any? { |slot| slot.on? requested_date }
+    available_slots.any? { |slot| slot.on?(requested_date) }
   end
 
   def confirm_by(today = Time.zone.today)

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -35,6 +35,10 @@ class Prison < ActiveRecord::Base
     today + booking_window
   end
 
+  def bookable_date?(requested_date = Time.zone.today)
+    available_slots.any? { |slot| slot.on? requested_date }
+  end
+
   def confirm_by(today = Time.zone.today)
     ((today + 1)..last_bookable_date(today)).
       select { |d| processing_day?(d) }.

--- a/app/views/booking_requests/_booking_calendar.html.erb
+++ b/app/views/booking_requests/_booking_calendar.html.erb
@@ -1,0 +1,38 @@
+<div class="BookingCalendar hidden--mobile">
+  <div class="BookingCalendar-header">
+    <a class="BookingCalendar-nav BookingCalendar-nav--prev" href="#"></a>
+    <strong class="BookingCalendar-currentMonth"></strong>
+    <a class="BookingCalendar-nav BookingCalendar-nav--next" href="#"></a>
+  </div>
+  <table class="BookingCalendar-dates">
+    <thead>
+      <tr>
+        <% each_day_of_week do |day| %>
+          <th><%= day.strftime('%a') %></th>
+        <% end %>
+      </tr>
+    </thead>
+  </table>
+
+  <div class="BookingCalendar-mask">
+    <table class="BookingCalendar-dates">
+      <tbody class=BookingCalendar-datesBody">
+        <% weeks(prison).each do |days| %>
+          <tr>
+            <% days.each do |day| %>
+              <td class="BookingCalendar-date--<%= bookable(prison, day) %>">
+                <div class="BookingCalendar-content <%= (tagged?(day)) ? 'has-tag' : '' %>">
+                  <%= calendar_day(day, prison.bookable_date?(day)) %>
+                  <% if today?(day) %>
+                    <span class="BookingCalendar-tag BookingCalendar-tag--today"
+                      ><%= t('.today') %></span>
+                  <% end %>
+                </div>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+</div>

--- a/app/views/booking_requests/_booking_calendar_legend.html.erb
+++ b/app/views/booking_requests/_booking_calendar_legend.html.erb
@@ -1,0 +1,11 @@
+<ul class="BookingCalendar-legend">
+  <li>
+  <div class="BookingCalendar-legendBox BookingCalendar-legendBox--available"></div>
+  <p class="BookingCalendar-legendDesc"><%= t('.visit_days') %></p>
+  </li>
+  <li>
+  <div class="BookingCalendar-legendBox BookingCalendar-legendBox--unavailable"></div>
+  <p class="BookingCalendar-legendDesc"><%= t('.non_visit_days') %></p>
+  </li>
+</ul>
+

--- a/app/views/booking_requests/_date_slider.html.erb
+++ b/app/views/booking_requests/_date_slider.html.erb
@@ -1,0 +1,18 @@
+<div class="DateSlider visible--mobile" data-selectonload="true">
+  <div class="DateSlider-month"></div>
+  <div class="DateSlider-sliders">
+    <a class="DateSlider-button DateSlider-buttonLeft" href="#">❮</a>
+    <a class="DateSlider-button DateSlider-buttonRight" href="#">❯</a>
+    <div class="DateSlider-smallDates scroll">
+      <ol class="DateSlider-days"></ol>
+    </div>
+    <div class="DateSlider-touch scroll">
+      <ol class="DateSlider-days"></ol>
+    </div>
+    <div class="DateSlider-portalFrame"></div>
+    <div class="DateSlider-largeDates scroll">
+      <ol class="DateSlider-days"></ol>
+    </div>
+  </div>
+</div>
+

--- a/app/views/booking_requests/_hidden_inputs_for_calendars.html.erb
+++ b/app/views/booking_requests/_hidden_inputs_for_calendars.html.erb
@@ -1,0 +1,15 @@
+<div class="hidden--js-enabled">
+  <% 3.times do |i| %>
+    <div class="group">
+      <label for="slot_step_option_<%= i %>"><%= t('.option', n: i) %></label>
+      <select class="SlotPicker-input" name='slots_step[option_<%= i %>]' id="slots_step_<%= i %>">
+        <option value=''><%= t('.none') %></option>
+        <% f.object.available_slots.each do |slot| %>
+          <option value="<%= slot.iso8601 %>">
+            <%= format_slot_begin_time_for_public(slot) %>
+          </option>
+         <% end %>
+      </select>
+    </div>
+  <% end %>
+</div>

--- a/app/views/booking_requests/_slot_picker.html.erb
+++ b/app/views/booking_requests/_slot_picker.html.erb
@@ -1,0 +1,3 @@
+<div class="SlotPicker-choices visible--js-enabled">
+  <p class="SlotPicker-promoteHelp"><%= t('.slot_picker_help') %></p>
+</div>

--- a/app/views/booking_requests/_slot_picker_time_slots.html.erb
+++ b/app/views/booking_requests/_slot_picker_time_slots.html.erb
@@ -1,0 +1,20 @@
+<div class="SlotPicker-timeSlots">
+  <ul class="SlotPicker-days">
+    <li class="SlotPicker-day SlotPicker-day--past">
+    <h2 class="SlotPicker-dayTitle"></h2>
+    <p><%= t('.visit_in_the_past') %></p>
+    </li>
+    <li class="SlotPicker-day SlotPicker-day--unavailable">
+    <h2 class="SlotPicker-dayTitle"></h2>
+    <p><%= t('.visit_today') %></p>
+    </li>
+    <li class="SlotPicker-day SlotPicker-day--beyond">
+    <h2 class="SlotPicker-dayTitle"></h2>
+    <p><%= t('.bookability_window', days: '{{ daysInRange }}') %></p>
+    </li>
+    <li class="SlotPicker-day SlotPicker-day--leadtime">
+    <h2 class="SlotPicker-dayTitle"></h2>
+    <p><%= t('.required_notice') %></p>
+    </li>
+  </ul>
+</div>

--- a/app/views/booking_requests/slots_step.html.erb
+++ b/app/views/booking_requests/slots_step.html.erb
@@ -1,33 +1,33 @@
 <% content_for :header, t('.title') %>
+<%= render('shared/slotpicker_templates') %>
 
-<div class="Grid">
-  <div class="Grid-2-3">
     <%= form_for(@steps.fetch(:slots_step), url: booking_requests_path) do |f| %>
       <%= render(partial: 'hidden_prisoner_step') %>
       <%= render(partial: 'hidden_visitors_step') %>
 
-      <fieldset>
-        <% 3.times do |i| %>
-          <%=
-            single_field(
-              f, :"option_#{i}", :select,
-              f.object.available_slots.map { |s|
-                [format_slot_begin_time_for_public(s), s.iso8601]
-              },
-              include_blank: true
-            )
-          %>
-        <% end %>
+  <div class="SlotPicker" data-today="<%= Time.zone.today %>">
+    <div class="Grid visible--js-enabled">
+      <div class="Grid-1-2">
+        <fieldset>
+          <%= render('booking_calendar', prison: f.object.prison) %>
+          <%= render('date_slider') %>
+          <%= render('booking_calendar_legend') %>
+          <%= render('slot_picker_time_slots') %>
 
-        <div class="actions">
-          <div class="primary-actions">
-            <%= f.submit(t('.next_step'), class: 'button button-primary') %>
+          <div class="actions">
+            <div class="primary-actions">
+              <%= f.submit(t('.next_step'), class: 'button button-primary') %>
+            </div>
+            <%= render(partial: 'cancel') %>
           </div>
-          <%= render(partial: 'cancel') %>
-        </div>
-      </fieldset>
-    <% end %>
+        </fieldset>
+      </div>
 
-    <%= render(partial: 'contact_prison') %>
+      <div class="Grid-1-2">
+        <%= render(partial: 'slot_picker') %>
+      </div>
+      <%= render('hidden_inputs_for_calendars', f: f) %>
+    </div>
   </div>
-</div>
+<% end %>
+<%= render(partial: 'contact_prison') %>

--- a/app/views/shared/_slotpicker_templates.html.erb
+++ b/app/views/shared/_slotpicker_templates.html.erb
@@ -1,0 +1,76 @@
+<script type="text/html" id="SlotPicker-tmplDay">
+  <li class="SlotPicker-day" id="date-{{ slot }}" tabindex="-1">
+    <h2 class="SlotPicker-dayTitle">{{ date }}</h2>
+    {{#if oneSlot}}
+    <p class="SlotPicker-dayOneSlot"><%= t('.one_slot_available') %></p>
+    {{/if}}
+    {{{ slots }}}
+  </li>
+</script>
+
+<script type="text/html" id="SlotPicker-tmplTimeSlot">
+  <label class="SlotPicker-label" for="slot-{{ slot }}">
+    <input class="SlotPicker-slot" type="checkbox" value="{{ slot }}" id="slot-{{ slot }}">
+    <strong class="SlotPicker-time">{{ time }}</strong>
+    <span class="SlotPicker-duration">{{ duration }}</span>
+  </label>
+</script>
+
+<script type="text/html" id="BookingCalendar-tmplRow">
+  <tr>
+    {{{ cells }}}
+  </tr>
+</script>
+
+<script type="text/html" id="BookingCalendar-tmplDate">
+  <td class="{{ klass }}">
+    <div class="BookingCalendar-content">
+      <a class="BookingCalendar-dateLink" data-date="{{ date }}" href="#date-{{ date }}">
+        <span class="BookingCalendar-day">{{ day }}</span>
+        {{#if today}}
+          <span class="BookingCalendar-tag BookingCalendar-tag--today">t('.today')</span>
+        {{/if}}
+        {{#if newMonth}}
+          <span class="BookingCalendar-tag" id="month-{{ monthIso }}">{{ monthShort }}</span>
+        {{/if}}
+      </a>
+    </div>
+  </td>
+</script>
+
+<script type="text/html" id="BookingCalendar-tmplNav">
+  {{ monthAbr }}<span class="BookingCalendar-navFull">{{ monthRemaining }}</span>
+</script>
+
+<script type="text/html" id="SlotPicker-tmplChoice">
+  <div class="SlotPicker-choice">
+    <div class="SlotPicker-choiceInner">
+      <div class="SlotPicker-position"><span>{{ num }}</span></div>
+      <div class="SlotPicker-choiceContent">
+        <p class="SlotPicker-date"></p>
+        <p class="SlotPicker-time"></p>
+      </div>
+      <p class="SlotPicker-prompt"><%= t('.choose_date_and_time') %></p>
+      {{#unless first}}
+      <a class="SlotPicker-icon SlotPicker-icon--promote" href="#"><%= t('.promote') %></a>
+      {{/unless}}
+      <a class="SlotPicker-icon SlotPicker-icon--remove" href="#"><%= t('.remove') %></a>
+    </div>
+  </div>
+  {{#if first}}
+    <p><%= t('.choose_two_alternatives') %></p>
+  {{/if}}
+</script>
+
+<script type="text/html" id="DateSlider-tmplDay">
+  <li data-date="{{ isoDate }}" class="{{ klass }}">
+    {{#if dayLabel}}
+      <small>{{ weekDay }}</small>
+    {{/if}}
+    {{ day }}
+  </li>
+</script>
+
+<script type="text/html" id="DateSlider-tmplMonth">
+  <span data-date="{{ yearMonth }}">{{ month }}</span>
+</script>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,15 +1,10 @@
-# Be sure to restart your server when you modify this file.
-
-# Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = '1.0'
 
-# Add additional assets to the asset load path
-# Rails.application.config.assets.paths << Emoji.images_path
-
-# Precompile additional assets.
-# application.js, application.css, and all non-JS/CSS in app/assets folder are
-# already added.
 Rails.application.config.assets.precompile += %w[
   email.css
   back-office.css
+  *.png
 ]
+
+Rails.application.config.assets.paths <<
+  "#{Rails.root}/vendor/assets/moj.slot-picker/dist/stylesheets"

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -4,6 +4,20 @@ en:
       intro: GOV.UK uses cookies to make the site simpler.
       find_out_more: Find out more about cookies.
   booking_requests:
+    hidden_inputs_for_calendars:
+      option: Option %{n}
+      none: None
+    booking_calendar:
+      today: Today
+    booking_calendar_legend:
+      visit_days: Visit Days
+      non_visit_days: Non-visit Days
+    slot_picker_time_slots:
+      visit_in_the_past: It is not possible to book a visit in the past.
+      visit_today: It is not possible to book a visit on this day.
+      bookability_window: >-
+        You can only book a visit in the next %{days} days.
+      required_notice: You can only book a visit 3 working days in advance.
     prisoner_step:
       title: Who are you visiting?
       information_html: |
@@ -90,7 +104,7 @@ en:
       title: Your request is being processed
     cancel:
       link_text: Cancel and delete all details
-      confirmation: |
+      confirmation: >-
         Are you sure you wish to cancel this visit request?
         This will delete all the information you have entered
     contact_prison:
@@ -98,6 +112,9 @@ en:
         <a href="http://www.justice.gov.uk/contacts/prison-finder"
         rel="external">Contact the prison</a> if you can’t request a visit
         using this service.
+    slot_picker:
+      slot_picker_help: >-
+        Use the arrows to put your visit choices in the order that suits you best.
   prison:
     visits:
       calendar:
@@ -240,6 +257,15 @@ en:
           </p>
         visitor_banned_label: "%{name} (%{date}) is banned"
   shared:
+    slotpicker_templates:
+      one_slot_available: >-
+        Only one time is available on this day, select it to continue
+      choose_date_and_time: Choose a date and time from the calendar
+      promote: Promote
+      remove: Remove
+      today: Today
+      choose_two_alternatives: >-
+        Choose two alternative dates in case your first choice isn‘t available.
     validation:
       heading: You need to fix the errors on this page before continuing.
       see_below: See highlighted errors below.

--- a/spec/helpers/calendar_helper_spec.rb
+++ b/spec/helpers/calendar_helper_spec.rb
@@ -24,4 +24,35 @@ RSpec.describe CalendarHelper do
       end
     end
   end
+
+  describe 'calendar_day' do
+    let(:day) { Date.new(2015, 01, 01) }
+    let(:bookable_day) {
+      '<a class="BookingCalendar-dateLink" data-date="2015-01-01" ' \
+        'href="#date-2015-01-01"><span class="BookingCalendar-day">1</span></a>'
+    }
+
+    let(:non_bookable_day) { '<span class="BookingCalendar-day">1</span>' }
+
+    it 'builds the html for a bookable day' do
+      expect(calendar_day(day, true)).to eq(bookable_day)
+    end
+
+    it 'builds the html for a non-bookable day' do
+      expect(calendar_day(day, false)).to eq(non_bookable_day)
+    end
+  end
+
+  describe 'bookable' do
+    let(:prison) { double('prison', bookable_date?: [true, false]) }
+    let(:day) { double('day').as_null_object }
+
+    it 'returns "bookable" if a prison is bookable for a date' do
+      expect(bookable(prison, day)).to eq('bookable')
+    end
+
+    it 'returns "unavailable" if a prison is not bookable for a date' do
+      expect(bookable(prison, day)).to eq('bookable')
+    end
+  end
 end

--- a/spec/models/concrete_slot_spec.rb
+++ b/spec/models/concrete_slot_spec.rb
@@ -21,6 +21,22 @@ RSpec.describe ConcreteSlot do
     end
   end
 
+  describe 'to_date' do
+    it 'generates a date object' do
+      expect(subject.to_date).to eq(Date.new(2015, 10, 23))
+    end
+  end
+
+  describe 'on?' do
+    it 'returns true if slots can be booked on requested date' do
+      expect(subject.on?(Date.new(2015, 10, 23))).to be_truthy
+    end
+
+    it 'returns false if slots cannot be booked on requested date' do
+      expect(subject.on?(Date.new(2015, 10, 24))).to be_falsey
+    end
+  end
+
   describe 'begin_at' do
     subject {
       super().begin_at

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -30,15 +30,14 @@ RSpec.describe Prison, type: :model do
     end
   end
 
-  describe 'available_slots' do
-    it 'enumerates available slots within booking window starting after lead time' do
+  context 'available slots and bookability' do
+    before do
       #
       #    Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo
       #     1  2  3  4  5  6  7  8  9 10 11 12
       #     T  1  .  .  2  3  *  *  *  .  .  *
       #     |              |  |<--------->|
       #   Today       Confirm    Bookable
-
       subject.slot_details = {
         'recurring' => {
           'mon' => ['1001-1100'],
@@ -51,16 +50,43 @@ RSpec.describe Prison, type: :model do
         }
       }
       subject.booking_window = 10
-      today = Date.new(2015, 10, 1) # Thursday
-      expect(subject.available_slots(today).to_a).to eq(
-        [
-          ConcreteSlot.new(2015, 10,  7, 10, 3, 11, 0),
-          ConcreteSlot.new(2015, 10,  8, 10, 4, 11, 0),
-          ConcreteSlot.new(2015, 10,  9, 10, 5, 11, 0),
-          ConcreteSlot.new(2015, 10, 10, 10, 6, 11, 0),
-          ConcreteSlot.new(2015, 10, 11, 10, 7, 11, 0)
-        ]
-      )
+    end
+
+    let(:today) { Date.new(2015, 10, 1) } # Thursday
+
+    describe 'available_slots' do
+      it 'enumerates available slots within booking window starting after lead time' do
+        expect(subject.available_slots(today).to_a).to eq(
+          [
+            ConcreteSlot.new(2015, 10,  7, 10, 3, 11, 0),
+            ConcreteSlot.new(2015, 10,  8, 10, 4, 11, 0),
+            ConcreteSlot.new(2015, 10,  9, 10, 5, 11, 0),
+            ConcreteSlot.new(2015, 10, 10, 10, 6, 11, 0),
+            ConcreteSlot.new(2015, 10, 11, 10, 7, 11, 0)
+          ]
+        )
+      end
+    end
+
+    describe 'bookable_date?' do
+      around do |example|
+        travel_to today do
+          example.run
+        end
+      end
+
+      it 'returns true if a slot is within the available range' do
+        requested_date = Date.new(2015, 10, 10)
+        expect(subject.bookable_date?(requested_date)).to be_truthy
+      end
+
+      it 'returns false if a slot is not within the available range' do
+        first_date = Date.new(2015, 10, 12)
+        second_date = Date.new(2015, 10, 6)
+
+        expect(subject.bookable_date?(first_date)).to be_falsey
+        expect(subject.bookable_date?(second_date)).to be_falsey
+      end
     end
   end
 

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -48,9 +48,10 @@ module FeaturesHelper
   end
 
   def select_slots(how_many = 3)
-    available_slots = all('#slots_step_option_0 option').map(&:text)
-    (1..how_many).each do |n|
-      select available_slots[n], from: "Option #{n}"
+    how_many.times do |n|
+      all(".BookingCalendar-date--bookable .BookingCalendar-dateLink")[n].
+        trigger('click')
+      first('.SlotPicker-slot').trigger('click')
     end
   end
 

--- a/vendor/assets/moj.slot-picker/dist/javascripts/moj.slot-picker.js
+++ b/vendor/assets/moj.slot-picker/dist/javascripts/moj.slot-picker.js
@@ -24,7 +24,7 @@
   };
 
   SlotPicker.prototype = {
-    
+
     defaults: {
       optionLimit: 3,
       singleUnavailableMsg: true,
@@ -42,7 +42,7 @@
 
     cacheEls: function($el) {
       this.$_el = $el;
-      
+
       this.$slotInputs = $('.SlotPicker-input', $el);
       this.$promoteHelp = $('.SlotPicker-promoteHelp', $el);
       this.$timeSlots = $('.SlotPicker-timeSlots', $el);
@@ -117,7 +117,7 @@
           demoted = $('.SlotPicker-choice:eq(' + (index - 1) + ')'),
           h = promoted.find('.SlotPicker-choiceInner').height() + parseInt(promoted.find('.SlotPicker-choiceInner').css('padding-top')),
           self = this;
-      
+
       var promote = function() {
         self.shiftSlot(index);
         self.processSlots();
@@ -126,7 +126,7 @@
       var transition = function() {
         return Modernizr.csstransitions ? 300 : 0;
       };
-      
+
       promoted.find('.SlotPicker-choiceContent').css('top', -h + 'px');
       demoted.find('.SlotPicker-choiceContent').css('top', h + 'px');
 
@@ -150,7 +150,7 @@
 
     getMonthPositions: function(dates) {
       var months = [], lastMonth, day, month;
-      
+
       for (day in dates) {
         month = moj.Helpers.dateFromIso(day).getMonth();
         if (month !== lastMonth) {
@@ -223,7 +223,7 @@
       this.settings.bookableDates = $.map(slots, function(s) {
         return s.substr(0, 10);
       });
-      
+
       for (i = 0; i < slots.length; i++) {
         day = this.splitDateAndSlot(slots[i])[0];
 
@@ -240,7 +240,7 @@
 
         previous = day;
       }
-      
+
       this.settings.bookableTimes = days;
     },
 
@@ -257,7 +257,7 @@
 
     chosenDaySelector: function(dateStr) {
       var bookingFrom, bookingTo, date;
-      
+
       if (moj.Helpers.dateBookable(dateStr, this.settings.bookableDates)) {
         return '#date-' + dateStr;
       }
@@ -265,7 +265,7 @@
       date = moj.Helpers.dateFromIso(dateStr);
       bookingFrom = moj.Helpers.dateFromIso(this.settings.bookableDates[0]);
       bookingTo = moj.Helpers.dateFromIso(this.settings.bookableDates[this.settings.bookableDates.length-1]);
-      
+
       if (date < this.settings.today) {
         return '.SlotPicker-day--past';
       } else {
@@ -324,7 +324,7 @@
           time = label.find('.SlotPicker-time').text(),
           duration = label.find('.SlotPicker-duration').text(),
           $slot = this.$choice.eq(index);
-      
+
       $slot.addClass('is-chosen');
       $slot.find('.SlotPicker-date').text(day);
       $slot.find('.SlotPicker-time').text(time + ', ' + duration);
@@ -335,13 +335,13 @@
     populateSlotInputs: function(index, chosen) {
       $('.SlotPicker-input', this.$_el).eq(index).val(chosen);
     },
-    
+
     processSlots: function() {
       var slots = this.settings.currentSlots,
           i, $slotEl;
 
       for (i = 0; i < slots.length; i++) {
-        $slotEl = $('.SlotPicker-slot[value=' + slots[i] + ']', this.$_el);
+        $slotEl = $('.SlotPicker-slot[value="' + slots[i] + '"]', this.$_el);
 
         this.highlightSlot($slotEl.closest('label'));
         this.populateSlotInputs(i, $slotEl.val());
@@ -363,10 +363,8 @@
     },
 
     splitDateAndSlot: function(str) {
-      var bits = str.split('-'),
-          time = bits.splice(-2, 2).join('-');
-      
-      return [bits.join('-'), time];
+
+      return str.split('T');
     },
 
     activateNextOption: function() {
@@ -390,7 +388,7 @@
 
     removeSlot: function(slot) {
       var pos = moj.Helpers.indexOf(this.settings.currentSlots, slot);
-      
+
       this.settings.currentSlots.splice(pos, 1);
       this.markDate(slot);
     },
@@ -401,7 +399,7 @@
 
     markDate: function(slot) {
       var day = this.splitDateAndSlot(slot)[0];
-      
+
       $('[data-date=' + day + ']', this.$_el)[~this.settings.currentSlots.join('-').indexOf(day) ? 'addClass' : 'removeClass']('is-chosen');
     },
 
@@ -422,9 +420,9 @@
 
       for (i = 0; i < slots.length; i++) {
         out+= template({
-          time: this.displayTime(slots[i].split('-')[0]),
-          duration: this.duration( this.timeFromSlot(slots[i].split('-')[0]), this.timeFromSlot(slots[i].split('-')[1]) ),
-          slot: [date,slots[i]].join('-')
+          time: this.displayTime(slots[i].split('/')[0]),
+          duration: this.duration( this.timeFromSlot(slots[i].split('/')[0]), this.timeFromSlot(slots[i].split('/')[1]) ),
+          slot: [date,slots[i]].join('T')
         });
       }
 
@@ -471,7 +469,7 @@
           todayIso = moj.Helpers.formatIso(this.settings.today),
           end = moj.Helpers.dateFromIso(to),
           count = 1;
-      
+
       curDate = this.firstDayOfWeek(moj.Helpers.dateFromIso(from));
       end = this.lastDayOfWeek(this.lastDayOfMonth(end));
 
@@ -503,13 +501,13 @@
         curDate.setDate(curDate.getDate() + 1);
         count++;
       }
-      
+
       return out;
     },
 
     displayTime: function(time) {
-      var hrs = parseInt(time.substr(0, 2), 10),
-          mins = time.substr(2),
+      var hrs = time.split(':')[0],
+          mins = time.split(':')[1],
           out = hrs;
 
       if (hrs > 12) {
@@ -531,14 +529,14 @@
       var out = '',
           diff = end.getTime() - start.getTime(),
           duration = new Date(diff);
-      
+
       if (duration.getUTCHours()) {
         out+= duration.getUTCHours() + ' hr';
         if (duration.getUTCHours() > 1) {
           out+= 's';
         }
       }
-      
+
       if (duration.getMinutes()) {
         out+= ' ' + duration.getMinutes() + ' min';
         if (duration.getMinutes() > 1) {
@@ -552,8 +550,8 @@
     timeFromSlot: function(slot) {
       var time = new Date();
 
-      time.setHours(slot.substr(0, 2));
-      time.setMinutes(slot.substr(2));
+      time.setHours(slot.split(':')[0]);
+      time.setMinutes(slot.split(':')[1]);
 
       return time;
     },


### PR DESCRIPTION
The smoke tests depend on the MoJ JS datepicker.  This is a port/adaption/simplification based on what is in the old app and what @threedaymonk has already done for the prison staff. 

I was doing it in the `smoke-tests` branch, but it is of sufficiently high complexity that it seemed sensible to break it out into its own branch. 