### PR TITLE
Stop rake db:drop db:create db:migrate breaking

### DIFF
--- a/db/migrate/20151127095415_rename_contact_details.rb
+++ b/db/migrate/20151127095415_rename_contact_details.rb
@@ -1,6 +1,11 @@
 class RenameContactDetails < ActiveRecord::Migration
   def change
-    rename_column :visits, :visitor_email_address, :contact_email_address
-    rename_column :visits, :visitor_phone_no, :contact_phone_no
+    if column_exists?(:visits, :visitor_email_address)
+      rename_column :visits, :visitor_email_address, :contact_email_address
+    end
+
+    if column_exists?(:visits, :visitor_phone_no)
+      rename_column :visits, :visitor_phone_no, :contact_phone_no
+    end
   end
 end


### PR DESCRIPTION
The columns get remaned in `8ac98e0`, which causes this to break if
drop, recreate and migrate.