### PR TITLE
Undo accidental renaming of columns in migrations

### DIFF
--- a/db/migrate/20151021110523_create_visits.rb
+++ b/db/migrate/20151021110523_create_visits.rb
@@ -9,8 +9,8 @@ class CreateVisits < ActiveRecord::Migration
       t.string :visitor_first_name, null: false
       t.string :visitor_last_name, null: false
       t.date :visitor_date_of_birth, null: false
-      t.string :contact_email_address, null: false
-      t.string :contact_phone_no, null: false
+      t.string :visitor_email_address, null: false
+      t.string :visitor_phone_no, null: false
       t.string :slot_option_1, null: false
       t.string :slot_option_2
       t.string :slot_option_3

--- a/db/migrate/20151112112158_replace_visits_with_table_that_uses_uuid_primary_key.rb
+++ b/db/migrate/20151112112158_replace_visits_with_table_that_uses_uuid_primary_key.rb
@@ -9,8 +9,8 @@ class ReplaceVisitsWithTableThatUsesUuidPrimaryKey < ActiveRecord::Migration
       t.string :visitor_first_name, null: false
       t.string :visitor_last_name, null: false
       t.date :visitor_date_of_birth, null: false
-      t.string :contact_email_address, null: false
-      t.string :contact_phone_no, null: false
+      t.string :visitor_email_address, null: false
+      t.string :visitor_phone_no, null: false
       t.string :slot_option_1, null: false
       t.string :slot_option_2
       t.string :slot_option_3


### PR DESCRIPTION
These were inadvertently changed in 8ac98e0, leading to an inconsistent stack of migrations.