### PR TITLE
Rationalise I18n YAML

### DIFF
--- a/config/locales/en/email_checker.yml
+++ b/config/locales/en/email_checker.yml
@@ -5,8 +5,8 @@ en:
       domain_dot: "is not a valid address because it ends with a dot or starts with a dot"
       malformed: "is not a valid address"
       no_mx_record: "does not appear to be valid"
-      spam_reported: >
+      spam_reported:
         needs to be checked as past messages were marked as spam.
         Check your spam folder too
-      bounced: >
+      bounced:
         needs to be checked as messages have been returned in the past

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -13,23 +13,23 @@ en:
       email_address: "Email:"
       phone_no: "Phone:"
       process_booking: "Process the booking"
-      copy_paste_explanation: >
+      copy_paste_explanation:
         If you cannot click on the link above, copy the entire link and paste
         it into the address bar of your browser.
       visit_id: "Visit ID:"
     booked:
-      subject: >
+      subject:
         COPY of booking confirmation for %{prisoner}
-      copy_of_booking: >
+      copy_of_booking:
         This is a copy of the booking confirmation email sent to the visitor
     rejected:
-      subject: >
+      subject:
         COPY of booking rejection for %{prisoner}
-      copy_of_rejection: >
+      copy_of_rejection:
         This is a copy of the booking rejection email sent to the visitor
   visitor_mailer:
     booked:
-      subject: >
+      subject:
         Visit confirmed: your visit for %{date} has been confirmed
       salutation: Dear %{name},
       visit_confirmed: Your visit to %{prison} is now successfully confirmed.
@@ -38,26 +38,26 @@ en:
       number: "Number:"
       visitor: "Visitor %{n}:"
       reference_no: "Your reference number is:"
-      this_is_a_closed_visit_html: >
+      this_is_a_closed_visit_html:
         <strong>This is a closed visit:</strong>
         the prisoner will be behind a glass screen in a separate area rather
         than in the visiting hall.
-      want_to_change: >
+      want_to_change:
         If you want to change anything about your visit, like dates or visitors
         coming, contact the prison.
       questions_about_your_visit: Questions about your visit
-      dont_reply: >
+      dont_reply:
         Please don’t reply to this email if you have any other questions about
         your visit. Instead you must contact us directly.
       phone_no: "Phone:"
       email_address: "Email:"
       add_to_address_book_title: Add this email to your address book
-      add_to_address_book_body: >
+      add_to_address_book_body:
         To stop visit confirmation emails going to your spam or junk folder
         please add no-reply@email.prisonvisits.service.gov.uk to your address
         book or safe senders list.
       what_to_bring: What to bring when you visit
-      id_requirements_html: >
+      id_requirements_html: |
         <p>
           Please make sure you bring ID with you. This can be ONE of
           the following:
@@ -116,25 +116,25 @@ en:
             foreign identity or residents’ card
           </li>
         </ul>
-      any_questions: >
+      any_questions:
         If you have any questions about ID requirements, please contact the
         prison.
       bringing_child_title: If you’re bringing someone else’s child
-      bringing_child_body: >
+      bringing_child_body:
         You’ll need a letter from that child’s parents giving you permission to
         accompany their child.
       what_to_expect_title: What to expect when visiting prison
-      what_to_expect_body: >
+      what_to_expect_body:
         You will be searched before entering the prison visiting room. Prison
         staff may check  your pockets, pat you down and ask you to go through a
         metal detector. Dogs may also be used to detect illegal substances.
       what_not_to_bring_title: What not to bring
-      what_not_to_bring_body_html: >
+      what_not_to_bring_body_html:
         Please don’t bring anything restricted or illegal to the prison. The
         <a href="%{url}">%{prison} prison page</a> has more information about
         what you can bring.
       your_data_title: Your data
-      your_data_body: >
+      your_data_body:
         The Ministry of Justice (HM Prison Service) uses and retains the
         personal data of visitors for the purposes of the safe and secure
         provision of Prison Services, including those related to the management
@@ -149,36 +149,36 @@ en:
         and management of offenders; prevention of terrorism; National
         Security; or required to do by law.
       need_help_title: Need help or have a question?
-      need_help_body_html: >
+      need_help_body_html:
         If you have a question or need any help with the online visits service,
         please <a href="%{url}">contact us</a>.
       visit_id: "Visit ID:"
     rejected:
-      subject: >
+      subject:
         Visit cannot take place: your visit for %{date} could not be booked
       salutation: Dear %{name}
-      slot_unavailable_html: >
+      slot_unavailable_html:
         We’re sorry but none of the dates and times you chose to visit
         <strong>%{prisoner}</strong> at <strong>%{prison}</strong>
         were available.
-      alternatives_html: >
+      alternatives_html:
         Please visit
         <a href="https://www.gov.uk/prison-visits">www.gov.uk/prison-visits</a>
         to choose some alternative dates.
-      no_allowance: >
+      no_allowance:
         We’re sorry, but the prisoner you want to visit has not got any
         visiting allowance left for the dates you’ve chosen.
-      privileged_allowance_available: >
+      privileged_allowance_available:
         However, you can book a weekday visit with visiting allowance valid
         until %{date}. The visit must be taken before the allowance expires.
-      allowance_will_renew: >
+      allowance_will_renew:
         %{prisoner} will have their full visiting allowance (VO) renewed on
         %{date}.
-      prisoner_details_incorrect: >
+      prisoner_details_incorrect:
         Your visit cannot take place as you haven’t given correct information
         for the prisoner. Eg, the prisoner’s name, number or date of birth is
         incorrect. Contact the prisoner to get up-to-date information.
-      prisoner_moved_html: >
+      prisoner_moved_html:
         Your visit cannot take place as the prisoner you want to visit has
         moved prison. They should contact you about where they are now. You can
         also use the
@@ -204,7 +204,7 @@ en:
       visit_id: "Visit ID:"
     request_acknowledged:
       subject: "Not booked yet: we’ve received your visit request for %{receipt_date}"
-      add_address: >
+      add_address:
         To stop visit confirmation emails going to your spam or junk folder
         please add %{email} to your address book or safe senders list.
       add_to_address_book: "Add this email to your address book"
@@ -212,7 +212,7 @@ en:
       cancellation_title: "Cancel this visit request"
       choice: "Choice %{n}"
       details: "Visit request details"
-      feedback_html: >
+      feedback_html:
         Need help or want to make a complaint? If you have a question or need
         any help with the online visits service, please
         <a href="%{url}">contact us</a>.
@@ -225,14 +225,14 @@ en:
       status: "Your visit is not booked yet"
       phone_no: "Phone:"
       email_address: "Email:"
-      when_to_check_spam: >
+      when_to_check_spam:
         If you don’t receive a confirmation email by %{when}, please check
         your spam or junk folder for it. You need to do this on a computer or
         tablet (rather than a smart phone).
-      when_to_expect_response: >
+      when_to_expect_response:
         We’ll email you by %{when} to confirm the date and time of your visit.
         Please don’t contact us any sooner than that, as we won’t be able to
         comment on booking requests that are being processed.
-      where_to_check_status_html: >
+      where_to_check_status_html:
        You can check whether your visit has been booked on the
        <a href="%{url}">visit status page</a>.

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -3,7 +3,7 @@ en:
     unsubscribe:
       you_received_an_email: You’ve received an email from %{email}
       why: This is probably because you requested a prison visit.
-      confirmation: >
+      confirmation:
         We’ll confirm your visit by email, so make sure you add this email
         address to your address book or safe senders list.
 

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -30,7 +30,7 @@ en:
       prison_id_hint: eg Cardiff
       prison_id_prompt: select a prison
       note_header: Please note
-      note: >
+      note:
         If you don’t enter any information for more than 20 minutes, then your
         session will time out and you’ll need to start again.
       next_step: Continue
@@ -38,7 +38,7 @@ en:
       title: Visitor 1
       your_details: Your details
       other_visitors: Other visitors
-      seating_arrangements: >
+      seating_arrangements:
         Seating arrangements at this prison allow 3 visitors over the age of 18
         plus 3 children under that age. Children may have to sit on your lap.
       additional_visitor_count: How many other visitors?
@@ -51,7 +51,7 @@ en:
       email_address: Email address
       email_address_hint: You’ll receive confirmation by email
       phone_no: Phone number
-      override_delivery_error: >
+      override_delivery_error:
         Tick this box to confirm you’d like us to try sending messages to you again.
     additional_visitors:
       visitor: 'Visitor %{n}'
@@ -60,7 +60,7 @@ en:
       date_of_birth: Date of birth
     slots_step:
       title: When do you want to visit?
-      choose_alternatives: >
+      choose_alternatives:
         Choose two alternative dates in case your first choice isn’t available.
       option_0: Option 1
       option_1: Option 2
@@ -78,7 +78,7 @@ en:
       visitor_n: "Visitor %{n}:"
       change_visitor_details: Change visitor details
       your_visit: Your visit
-      options_available: >
+      options_available:
         You can choose up to 2 alternative dates if your first choice isn’t
         available.
       first_choice: "First choice:"
@@ -94,7 +94,7 @@ en:
         Are you sure you wish to cancel this visit request?
         This will delete all the information you have entered
     contact_prison:
-      help_html: >
+      help_html:
         <a href="http://www.justice.gov.uk/contacts/prison-finder"
         rel="external">Contact the prison</a> if you can’t request a visit
         using this service.
@@ -104,7 +104,7 @@ en:
         today: Today
       edit:
         title: Process a visit request
-        introduction_html: >
+        introduction_html: |
           <ul>
             <li>
               book the visit in NOMIS first
@@ -135,14 +135,14 @@ en:
         reference_no: Reference number
         reference_no_hint: eg Last 8 digits of VO number or “none” for remand
         closed_visit: This is a closed visit
-        closed_visit_wording_html: >
+        closed_visit_wording_html: |
           <p>
             <strong>This is a closed visit:</strong> the prisoner will be
             behind a glass screen in a separate area rather than in the
             visiting hall.
           </p>
         none_available: None of the chosen times are available
-        none_available_explanation_html: >
+        none_available_explanation_html: |
           <p>
             Choose this option if:
           </p>
@@ -159,7 +159,7 @@ en:
               visit at the same time and they are incompatible
             </li>
           </ul>
-        none_available_wording_html: >
+        none_available_wording_html: |
           <p>
             We’re sorry but none of the dates and times you chose to visit
             %{prisoner} at %{prison} were available. Please visit
@@ -168,25 +168,25 @@ en:
       visiting_allowance_section:
         title: Visiting allowance
         no_allowance: The prisoner does not have any visiting allowance (VO)
-        no_allowance_wording_html: >
+        no_allowance_wording_html: |
           <p>
             We’re sorry, but the prisoner you want to visit has not got any
             visiting allowance left for the dates you’ve chosen.
           </p>
-        no_allowance_tell_more: >
+        no_allowance_tell_more:
           You can also tell the visitor more about the VO and PVO status:
-        allowance_will_renew: >
+        allowance_will_renew:
           Visiting allowance (weekends and weekday visits) (VO) will
           be renewed:
-        allowance_will_renew_wording_html: >
+        allowance_will_renew_wording_html: |
           <p>
             %{prisoner} will have their full visiting allowance (VO) renewed on
             <span class="date">[DATE NOT CHOSEN]</span>.
           </p>
-        privileged_allowance_available: >
+        privileged_allowance_available:
           If weekday visit (PVO) is possible instead, choose the date
           PVO expires:
-        privileged_allowance_available_wording_html: >
+        privileged_allowance_available_wording_html: |
           <p>
             However, you can book a weekday visit with visiting allowance valid
             until <span class="date">[DATE NOT CHOSEN]</date>.
@@ -195,7 +195,7 @@ en:
       issue_with_prisoner_section:
         title: Issue with the prisoner
         prisoner_details_incorrect: Prisoner details are incorrect
-        prisoner_details_incorrect_wording_html: >
+        prisoner_details_incorrect_wording_html: |
           <p>
             Your visit cannot take place as you haven’t given correct
             information for the prisoner. Eg, the prisoner’s name, number or
@@ -203,7 +203,7 @@ en:
             information.
           </p>
         prisoner_moved: Prisoner no longer at the prison
-        prisoner_moved_wording_html: >
+        prisoner_moved_wording_html: |
           <p>
             Your visit cannot take place as the prisoner you want to visit has
             moved prison. They should contact you about where they are now. You
@@ -213,7 +213,7 @@ en:
       issue_with_visitors_section:
         title: Issue with visitors
         visitor_not_on_list: Visitor isn’t on the contact list
-        visitor_not_on_list_wording_html: >
+        visitor_not_on_list_wording_html: |
           <p>
             Your visit cannot take place as details for
             <span class="CheckboxSummary-summary">[VISITOR NAME]</span> don’t
@@ -230,7 +230,7 @@ en:
           </p>
         visitor_not_on_list_label: "%{name} (%{date}) is not on the list"
         visitor_banned: Visitor is banned
-        visitor_banned_wording_html: >
+        visitor_banned_wording_html: |
           <p>
             Your visit cannot take place.
             <span class="CheckboxSummary-summary">[VISITOR NAME]</span> should


### PR DESCRIPTION
The difference between `key:`, `key: >`, and `key: |` can be illustrated thus:

```yaml
a:
  one
  two
    three
b: >
  one
  two
    three
c: |
  one
  two
    three
```

results in

```ruby
a = "one two three"
b = "one two\n  three\n"
c = "one\ntwo\n  three\n"
```

In other words, we never want to use `key: >` over plain `key:`, and we want to use `key: |` whenever it's useful to preserve the layout of complex HTML in a localisation string.

This updates the files in `config/locales` to make it so.