### PR TITLE
Send tickets to Zendesk from in-app feedback form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'state_machines-activerecord'
 gem 'string_scrubber'
 gem 'uglifier', '>= 1.3.0'
 gem 'virtus'
+gem 'zendesk_api'
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,8 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
     ffaker (2.1.0)
     fuubar (2.0.0)
@@ -100,6 +102,7 @@ GEM
     haml (4.0.7)
       tilt
     hashdiff (0.2.3)
+    hashie (3.4.3)
     high_voltage (2.4.0)
     highline (1.7.8)
     htmlentities (4.3.4)
@@ -108,6 +111,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
     ice_nine (0.11.1)
+    inflection (1.0.0)
     json (1.8.3)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -129,6 +133,7 @@ GEM
       rails (>= 3.1)
     multi_json (1.11.2)
     multi_xml (0.5.5)
+    multipart-post (2.0.0)
     nokogiri (1.6.7)
       mini_portile2 (~> 2.0.0.rc2)
     parser (2.2.3.0)
@@ -230,6 +235,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    scrub_rb (1.0.1)
     sendgrid_toolkit (1.4.0)
       httparty (>= 0.7.6)
     sexp_processor (4.6.0)
@@ -288,6 +294,13 @@ GEM
     websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    zendesk_api (1.13.1)
+      faraday (~> 0.9)
+      hashie (>= 1.2, < 4.0, != 3.3.0)
+      inflection
+      mime-types
+      multipart-post (~> 2.0)
+      scrub_rb (~> 1.0.1)
 
 PLATFORMS
   ruby
@@ -326,6 +339,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   virtus
   webmock
+  zendesk_api
 
 BUNDLED WITH
    1.10.6

--- a/README.md
+++ b/README.md
@@ -198,3 +198,8 @@ build information to be returned by `/ping.json`. e.g.:
   "commit_id": "a444e4b05276ae7dc2b1d4224e551dfcbf768795"
 }
 ```
+### `ZENDESK_USERNAME`, `ZENDESK_TOKEN`, `ZENDESK_URL`
+
+These are required in order to submit user feedback to Zendesk.
+
+`ZENDESK_URL` defaults to `https://ministryofjustice.zendesk.com/api/v2`.

--- a/README.md
+++ b/README.md
@@ -183,7 +183,9 @@ environment to `https://www.prisonvisits.service.gov.uk/`.
 
 ### `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_HOSTNAME`, `SMTP_PORT`, `SMTP_DOMAIN`
 
-These configure email delivery in the production environment.
+These configure email delivery in the production environment. `SMTP_DOMAIN` is
+also used when generating the `no-reply@` address and the `feedback@` stand-in
+address used when submitting feedback without an email address to Zendesk.
 
 ## Files to be created on deployment
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,14 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+private
+
+  def http_referrer
+    request.headers['REFERER']
+  end
+
+  def http_user_agent
+    request.headers['HTTP_USER_AGENT']
+  end
 end

--- a/app/controllers/feedback_submissions_controller.rb
+++ b/app/controllers/feedback_submissions_controller.rb
@@ -1,0 +1,24 @@
+class FeedbackSubmissionsController < ApplicationController
+  def new
+    @feedback = FeedbackSubmission.new(referrer: http_referrer)
+  end
+
+  def create
+    @feedback = FeedbackSubmission.new(feedback_params)
+
+    if @feedback.save
+      ZendeskTicketsJob.perform_later(@feedback)
+    else
+      render 'new'
+    end
+  end
+
+private
+
+  def feedback_params
+    params.
+      require(:feedback_submission).
+      permit(:referrer, :body, :email_address).
+      merge(user_agent: http_user_agent)
+  end
+end

--- a/app/jobs/zendesk_tickets_job.rb
+++ b/app/jobs/zendesk_tickets_job.rb
@@ -1,0 +1,28 @@
+class ZendeskTicketsJob < ActiveJob::Base
+  queue_as :zendesk
+
+  # Custom ticket fields configured in the MOJ Digital Zendesk account
+  URL_FIELD = '23730083'
+  SERVICE_FIELD = '23757677'
+  BROWSER_FIELD = '23791776'
+
+  def perform(feedback)
+    ZendeskAPI::Ticket.create!(
+      Rails.configuration.zendesk_client,
+      description: feedback.body,
+      requester: {
+        email: feedback.email_address,
+        name: 'Unknown'
+      },
+      custom_fields: custom_fields(feedback)
+    )
+  end
+
+  def custom_fields(feedback)
+    [
+      { id: URL_FIELD, value: feedback.referrer },
+      { id: SERVICE_FIELD, value: 'prison_visits' },
+      { id: BROWSER_FIELD, value: feedback.user_agent }
+    ]
+  end
+end

--- a/app/models/feedback_submission.rb
+++ b/app/models/feedback_submission.rb
@@ -3,7 +3,7 @@ class FeedbackSubmission < ActiveRecord::Base
   validate :validate_email
 
   def email_address
-    super.present? ? super : 'feedback@email.prisonvisits.service.gov.uk'
+    super.present? ? super : Rails.configuration.address_book.feedback
   end
 
 private

--- a/app/models/feedback_submission.rb
+++ b/app/models/feedback_submission.rb
@@ -1,0 +1,16 @@
+class FeedbackSubmission < ActiveRecord::Base
+  validates :body, presence: true
+  validate :validate_email
+
+  def email_address
+    super.present? ? super : 'feedback@email.prisonvisits.service.gov.uk'
+  end
+
+private
+
+  def validate_email
+    return unless email_address.present?
+    email_checker = EmailChecker.new(email_address)
+    errors.add :email_address, email_checker.message unless email_checker.valid?
+  end
+end

--- a/app/services/address_book.rb
+++ b/app/services/address_book.rb
@@ -1,0 +1,13 @@
+class AddressBook
+  def initialize(domain)
+    @domain = domain
+  end
+
+  def feedback
+    "feedback@#{@domain}"
+  end
+
+  def no_reply
+    "no-reply@#{@domain}"
+  end
+end

--- a/app/views/feedback_submissions/create.html.erb
+++ b/app/views/feedback_submissions/create.html.erb
@@ -1,0 +1,3 @@
+<% content_for :header do %>
+  <%= t('.title') %>
+<% end %>

--- a/app/views/feedback_submissions/new.html.erb
+++ b/app/views/feedback_submissions/new.html.erb
@@ -1,0 +1,61 @@
+<% content_for :header do %>
+  <%= t('.title') %>
+<% end %>
+
+<p>
+  <%= t('.intro_html') %>
+</p>
+
+<ul>
+  <li>
+    <%= t('.whether_booked') %>
+  </li>
+  <li>
+    <%= t('.cancelling_changing') %>
+  </li>
+  <li>
+    <%= t('.what_can_bring') %>
+  </li>
+  <li>
+    <%= t('.contact_lists') %>
+  </li>
+</ul>
+
+<p>
+  <%= t('.not_able_to_help') %>
+</p>
+
+<%= form_for(@feedback,
+             url: feedback_submissions_path,
+             html: { novalidate: 'novalidate', class: 'js-SubmitOnce' }) do |f| %>
+
+  <%= render(partial: 'shared/validation', object: f.object) %>
+
+  <%= f.hidden_field :referrer %>
+
+  <p><strong><%= t('.no_sensitive_info') %></strong></p>
+
+  <fieldset>
+    <legend class="visuallyhidden">
+      <%= t('.feedback_form') %>
+    </legend>
+
+    <%= single_field(f, :body, :text_area, cols: 50, rows: 5) %>
+  </fieldset>
+
+  <fieldset>
+    <legend>
+      <%= t('.want_reply_title') %>
+    </legend>
+
+    <p>
+      <%= t('.want_reply_text') %>
+    </p>
+
+    <%= single_field(f, :email_address, :email_field) %>
+
+    <div class="actions">
+      <%= f.submit(t('.send'), class: 'button button-primary') %>
+    </div>
+  </fieldset>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,8 +21,8 @@
 <% end %>
 
 <% content_for :cookie_message do %>
-  <%= t('layout.cookies.intro') %>
-  <%= link_to(t('layout.cookies.find_out_more'), '/') %>
+  <%= t('.cookies_intro') %>
+  <%= link_to(t('.cookies_find_out_more'), '/TODO-cookies') %>
 <% end %>
 
 <% content_for :content_override do %>
@@ -48,6 +48,15 @@
 <% end %>
 
 <% content_for :footer_support_links do %>
+  <li>
+    <%= link_to(t('.cookies'), '/TODO-cookies') %>
+  </li>
+  <li>
+    <%= link_to(t('.ts_and_cs'), '/TODO-terms-and-conditions') %>
+  </li>
+  <li>
+    <%= link_to(t('.contact_us'), new_feedback_submission_path) %>
+  </li>
 <% end %>
 
 <%= render(template: 'layouts/moj_template') %>

--- a/app/views/pages/unsubscribe.html.erb
+++ b/app/views/pages/unsubscribe.html.erb
@@ -1,7 +1,7 @@
 <% content_for :header, "Why did I receive this email?" %>
 <p>
 <%= t('.you_received_an_email',
-      email: 'no-reply@email.prisonvisits.service.gov.uk') %>
+      email: Rails.configuration.address_book.no_reply) %>
 </p>
 <p>
   <%= t('.why') %>

--- a/app/views/visitor_mailer/booked.html.erb
+++ b/app/views/visitor_mailer/booked.html.erb
@@ -60,9 +60,9 @@
   </li>
 </ul>
 
-<h1><%= t(".add_to_address_book_title") %></h1>
+<h1><%= t(".avoid_spam_filtering_title") %></h1>
 
-<p><%= t(".add_to_address_book_body",
+<p><%= t(".avoid_spam_filtering_body",
          email: Rails.configuration.address_book.no_reply) %>
 
 <h1><%= t(".what_to_bring") %></h1>

--- a/app/views/visitor_mailer/booked.html.erb
+++ b/app/views/visitor_mailer/booked.html.erb
@@ -62,7 +62,8 @@
 
 <h1><%= t(".add_to_address_book_title") %></h1>
 
-<p><%= t(".add_to_address_book_body") %></p>
+<p><%= t(".add_to_address_book_body",
+         email: Rails.configuration.address_book.no_reply) %>
 
 <h1><%= t(".what_to_bring") %></h1>
 

--- a/app/views/visitor_mailer/request_acknowledged.html.erb
+++ b/app/views/visitor_mailer/request_acknowledged.html.erb
@@ -18,7 +18,7 @@
   <%= t('.add_to_address_book') %>
 </h1>
 <p>
-  <%= t('.add_address', email: 'no-reply@email.prisonvisits.service.gov.uk') %>
+  <%= t('.add_address', email: Rails.configuration.address_book.no_reply) %>
 </p>
 <h1>
   <%= t('.details') %>

--- a/app/views/visitor_mailer/request_acknowledged.html.erb
+++ b/app/views/visitor_mailer/request_acknowledged.html.erb
@@ -15,7 +15,7 @@
   <%= t('.when_to_check_spam', when: 'TODO') %>
 </p>
 <h1>
-  <%= t('.add_to_address_book') %>
+  <%= t('.avoid_spam_filtering') %>
 </h1>
 <p>
   <%= t('.add_address', email: Rails.configuration.address_book.no_reply) %>

--- a/app/views/visits/_booked.html.erb
+++ b/app/views/visits/_booked.html.erb
@@ -4,7 +4,8 @@
 
 <p><%= t('.not_received') %></p>
 
-<p><%= t('visits.shared.add_to_address_book_html') %></p>
+<p><%= t('visits.shared.add_to_address_book_html',
+         email: Rails.configuration.address_book.no_reply) %></p>
 
 <h2><%= t('.cancel_title') %></h2>
 

--- a/app/views/visits/_booked.html.erb
+++ b/app/views/visits/_booked.html.erb
@@ -4,7 +4,7 @@
 
 <p><%= t('.not_received') %></p>
 
-<p><%= t('visits.shared.add_to_address_book_html',
+<p><%= t('visits.shared.avoid_spam_filtering_html',
          email: Rails.configuration.address_book.no_reply) %></p>
 
 <h2><%= t('.cancel_title') %></h2>

--- a/app/views/visits/_rejected.html.erb
+++ b/app/views/visits/_rejected.html.erb
@@ -4,7 +4,7 @@
 
 <p><%= t('.not_received') %></p>
 
-<p><%= t('visits.shared.add_to_address_book_html',
+<p><%= t('visits.shared.avoid_spam_filtering_html',
          email: Rails.configuration.address_book.no_reply) %></p>
 
 <p><%= t('visits.shared.request_new_visit_html',

--- a/app/views/visits/_rejected.html.erb
+++ b/app/views/visits/_rejected.html.erb
@@ -4,7 +4,8 @@
 
 <p><%= t('.not_received') %></p>
 
-<p><%= t('visits.shared.add_to_address_book_html') %></p>
+<p><%= t('visits.shared.add_to_address_book_html',
+         email: Rails.configuration.address_book.no_reply) %></p>
 
 <p><%= t('visits.shared.request_new_visit_html',
          url: booking_requests_path) %></p>

--- a/app/views/visits/_requested.html.erb
+++ b/app/views/visits/_requested.html.erb
@@ -4,7 +4,8 @@
 
 <p><%= t('.not_received') %></p>
 
-<p><%= t('visits.shared.add_to_address_book_html') %></p>
+<p><%= t('visits.shared.add_to_address_book_html',
+         email: Rails.configuration.address_book.no_reply) %></p>
 
 <h2><%= t('.cancel_title') %></h2>
 

--- a/app/views/visits/_requested.html.erb
+++ b/app/views/visits/_requested.html.erb
@@ -4,7 +4,7 @@
 
 <p><%= t('.not_received') %></p>
 
-<p><%= t('visits.shared.add_to_address_book_html',
+<p><%= t('visits.shared.avoid_spam_filtering_html',
          email: Rails.configuration.address_book.no_reply) %></p>
 
 <h2><%= t('.cancel_title') %></h2>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default_url_options =
-    { host: 'localhost', protocol: 'https', port: '3000' }
+    { host: 'localhost', protocol: 'http', port: '3000' }
   config.action_mailer.smtp_settings =
     { address: 'localhost', port: 1025, domain: 'localhost' }
   config.active_support.deprecation = :log

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,5 @@
 Rails.application.configure do
-  config.action_mailer.smtp_settings = {}
+  config.action_mailer.smtp_settings = { domain: 'email.test.host' }
   config.cache_classes = true
   config.eager_load = false
   config.serve_static_files   = true

--- a/config/initializers/address_book.rb
+++ b/config/initializers/address_book.rb
@@ -1,0 +1,3 @@
+Rails.configuration.address_book = AddressBook.new(
+  Rails.configuration.action_mailer.smtp_settings.fetch(:domain)
+)

--- a/config/initializers/zendesk.rb
+++ b/config/initializers/zendesk.rb
@@ -1,0 +1,7 @@
+Rails.configuration.zendesk_client = ZendeskAPI::Client.new do |config|
+  config.url =
+    ENV.fetch('ZENDESK_URL', 'https://ministryofjustice.zendesk.com/api/v2')
+  config.username = ENV['ZENDESK_USERNAME']
+  config.token = ENV['ZENDESK_TOKEN']
+  config.retry = true
+end

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -58,8 +58,7 @@ en:
       add_to_address_book_title: Add this email to your address book
       add_to_address_book_body: >-
         To stop visit confirmation emails going to your spam or junk folder
-        please add no-reply@email.prisonvisits.service.gov.uk to your address
-        book or safe senders list.
+        please add %{email} to your address book or safe senders list.
       what_to_bring: What to bring when you visit
       id_requirements_html: |
         <p>

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -55,8 +55,8 @@ en:
         your visit. Instead you must contact us directly.
       phone_no: "Phone:"
       email_address: "Email:"
-      add_to_address_book_title: Add this email to your address book
-      add_to_address_book_body: >-
+      avoid_spam_filtering_title: Add this email to your address book
+      avoid_spam_filtering_body: >-
         To stop visit confirmation emails going to your spam or junk folder
         please add %{email} to your address book or safe senders list.
       what_to_bring: What to bring when you visit
@@ -210,7 +210,7 @@ en:
       add_address: >-
         To stop visit confirmation emails going to your spam or junk folder
         please add %{email} to your address book or safe senders list.
-      add_to_address_book: "Add this email to your address book"
+      avoid_spam_filtering: "Add this email to your address book"
       cancel_title: Cancel this visit request
       cancel_html: >-
         If you no longer want to visit on this date,

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -308,7 +308,7 @@ en:
     show:
       title: Visit status
     shared:
-      add_to_address_book_html: >-
+      avoid_spam_filtering_html: >-
         To stop visit confirmation emails going to your spam or junk folder
         please add <span class="no-wrap">%{email}</span> to your address book
         or safe senders list.

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -1,8 +1,11 @@
 en:
-  layout:
-    cookies:
-      intro: GOV.UK uses cookies to make the site simpler.
-      find_out_more: Find out more about cookies.
+  layouts:
+    application:
+      cookies_intro: GOV.UK uses cookies to make the site simpler.
+      cookies_find_out_more: Find out more about cookies.
+      cookies: Cookies
+      ts_and_cs: Terms and conditions
+      contact_us: Contact us
   booking_requests:
     hidden_inputs_for_calendars:
       option: Option %{n}
@@ -115,6 +118,38 @@ en:
     slot_picker:
       slot_picker_help: >-
         Use the arrows to put your visit choices in the order that suits you best.
+  feedback_submissions:
+    new:
+      title: Contact us
+      intro_html: >-
+        You can use this form to tell us about a problem you’re having with the
+        website. You must
+        <a href="http://www.justice.gov.uk/contacts/prison-finder">contact the
+        prison</a> if your question is about:
+      whether_booked: >-
+        whether your visit has been booked
+      cancelling_changing: >-
+        cancelling or changing visit details eg names of visitors, dates or
+        times
+      what_can_bring: >-
+        what you can bring when you visit, eg clothes or money
+      contact_lists: >-
+        prisoner’s contact lists or visiting allowance
+      not_able_to_help: >-
+        We’re not able to help with questions about the above.
+      no_sensitive_info: >-
+        Please don’t include any sensitive personal information (eg. prisoner
+        numbers).
+      feedback_form: Feedback form
+      body: Your question
+      want_reply_title: Do you want a reply?
+      want_reply_text: >-
+        If you’d like us to get back to you, please leave your details below.
+      email_address: Your email address
+      email_address_hint: We’ll only use this to reply to your message.
+      send: Send
+    create:
+      title: Thank you for your feedback
   prison:
     visits:
       calendar:

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -310,9 +310,8 @@ en:
     shared:
       add_to_address_book_html: >-
         To stop visit confirmation emails going to your spam or junk folder
-        please add
-        <span class="no-wrap">no-reply@email.prisonvisits.service.gov.uk</span>
-        to your address book or safe senders list.
+        please add <span class="no-wrap">%{email}</span> to your address book
+        or safe senders list.
       request_new_visit_html: >-
         Request a <a href="%{url}">new visit</a>
       yes_cancel: Yes, I want to cancel this visit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :booking_requests, path: 'request', only: %i[ index create ]
   resources :visits, only: %i[ show ]
   resources :cancellations, path: 'cancel', only: %i[ create ]
+  resources :feedback_submissions, path: 'feedback', only: %i[ new create ]
 
   namespace :prison do
     resources :visits, only: %i[ edit update ]

--- a/db/migrate/20151211145100_create_feedback_submissions.rb
+++ b/db/migrate/20151211145100_create_feedback_submissions.rb
@@ -1,0 +1,10 @@
+class CreateFeedbackSubmissions < ActiveRecord::Migration
+  def change
+    create_table :feedback_submissions, id: :uuid do |t|
+      t.text :body, null: false
+      t.string :email_address
+      t.string :referrer
+      t.string :user_agent
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,11 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151204142443) do
+ActiveRecord::Schema.define(version: 20151211145100) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
+
+  create_table "feedback_submissions", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
+    t.text   "body",          null: false
+    t.string "email_address"
+    t.string "referrer"
+    t.string "user_agent"
+  end
 
   create_table "prisoners", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.string "first_name",    null: false

--- a/spec/controllers/feedback_submissions_controller_spec.rb
+++ b/spec/controllers/feedback_submissions_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe FeedbackSubmissionsController, type: :controller do
+  include ActiveJobHelper
+
+  before do
+    allow(ZendeskTicketsJob).to receive(:perform_later)
+  end
+
+  context 'new' do
+    it 'responds with success' do
+      get :new
+      expect(response).to be_success
+    end
+
+    it 'renders the new template' do
+      get :new
+      expect(response).to render_template('new')
+    end
+  end
+
+  context 'create' do
+    context 'with a successful feedback submission' do
+      let(:feedback_params) {
+        { email_address: 'test@maildrop.dsd.io', body: 'feedback', referrer: 'ref' }
+      }
+
+      it 'renders the create template' do
+        post :create, feedback_submission: feedback_params
+        expect(response).to render_template('create')
+      end
+
+      it 'sends to ZenDesk' do
+        expect(ZendeskTicketsJob).to receive(:perform_later).once do |feedback|
+          expect(feedback.email_address).to eq('test@maildrop.dsd.io')
+          expect(feedback.body).to eq('feedback')
+        end
+        post :create, feedback_submission: feedback_params
+      end
+    end
+
+    context 'with no body entered' do
+      let(:feedback_params) {
+        { email_address: 'test@maildrop.dsd.io', body: '', referrer: 'ref' }
+      }
+
+      it 'responds with success' do
+        post :create, feedback_submission: feedback_params
+        expect(response).to be_success
+      end
+
+      it 'does not send to ZenDesk' do
+        expect(ZendeskTicketsJob).to receive(:perform_later).never
+        post :create, feedback_submission: feedback_params
+      end
+
+      it 're-renders the new template' do
+        post :create, feedback_submission: feedback_params
+        expect(response).to render_template('new')
+      end
+    end
+  end
+end

--- a/spec/features/submit_feedback_spec.rb
+++ b/spec/features/submit_feedback_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.feature 'Submit feedback', js: true do
+  include ActiveJobHelper
+  include FeaturesHelper
+
+  scenario 'submitting feedback' do
+    text = 'How many times did the Batmobile catch a flat?'
+    email_address = 'user@test.example.com'
+
+    visit booking_requests_path
+    click_link 'Contact us'
+
+    fill_in 'Your question', with: text
+    fill_in 'Your email address', with: email_address
+
+    expect(ZendeskTicketsJob).to receive(:perform_later) do |fb|
+      expect(fb.body).to eq(text)
+      expect(fb.email_address).to eq(email_address)
+      expect(fb.user_agent).to match('Mozilla')
+      expect(fb.referrer).to match(booking_requests_path)
+    end
+
+    click_button 'Send'
+
+    expect(page).to have_text('Thank you for your feedback')
+  end
+end

--- a/spec/jobs/zendesk_tickets_job_spec.rb
+++ b/spec/jobs/zendesk_tickets_job_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe ZendeskTicketsJob, type: :job do
+  subject { described_class }
+
+  let(:feedback) {
+    FeedbackSubmission.new(
+      body: 'text',
+      email_address: 'email@example.com',
+      referrer: 'ref',
+      user_agent: 'Mozilla'
+    )
+  }
+  let(:client) { Rails.configuration.zendesk_client }
+  let(:ticket) { double(ZendeskAPI::Ticket, save!: nil) }
+
+  it 'creates a ticket with feedback and custom fields' do
+    expect(ZendeskAPI::Ticket).
+      to receive(:new).
+      with(
+        client,
+        description: 'text',
+        requester: { email: 'email@example.com', name: 'Unknown' },
+        custom_fields: [
+          { id: '23730083', value: 'ref' },
+          { id: '23757677', value: 'prison_visits' },
+          { id: '23791776', value: 'Mozilla' }
+        ]
+      ).and_return(ticket)
+    subject.perform_now(feedback)
+  end
+
+  it 'calls save! to send the feedback' do
+    allow(ZendeskAPI::Ticket).
+      to receive(:new).
+      and_return(ticket)
+    expect(ticket).to receive(:save!).once
+    subject.perform_now(feedback)
+  end
+end

--- a/spec/models/feedback_submission_spec.rb
+++ b/spec/models/feedback_submission_spec.rb
@@ -25,14 +25,12 @@ RSpec.describe FeedbackSubmission do
 
   describe 'email_address' do
     it 'returns default when not set' do
-      expect(subject.email_address).
-        to eq('feedback@email.prisonvisits.service.gov.uk')
+      expect(subject.email_address).to eq('feedback@email.test.host')
     end
 
     it 'returns default when blank' do
       subject.email_address = ''
-      expect(subject.email_address).
-        to eq('feedback@email.prisonvisits.service.gov.uk')
+      expect(subject.email_address).to eq('feedback@email.test.host')
     end
 
     it 'returns explicitly assigned value' do

--- a/spec/models/feedback_submission_spec.rb
+++ b/spec/models/feedback_submission_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe FeedbackSubmission do
+  context 'validations' do
+    context 'email_address' do
+      it 'is valid when absent' do
+        subject.email_address = ''
+        subject.validate
+        expect(subject.errors).not_to have_key(:email_address)
+      end
+
+      it 'is valid when reasonable' do
+        subject.email_address = 'user@test.example.com'
+        subject.validate
+        expect(subject.errors).not_to have_key(:email_address)
+      end
+
+      it 'is invalid when not an email address' do
+        subject.email_address = 'BOGUS!'
+        subject.validate
+        expect(subject.errors).to have_key(:email_address)
+      end
+    end
+  end
+
+  describe 'email_address' do
+    it 'returns default when not set' do
+      expect(subject.email_address).
+        to eq('feedback@email.prisonvisits.service.gov.uk')
+    end
+
+    it 'returns default when blank' do
+      subject.email_address = ''
+      expect(subject.email_address).
+        to eq('feedback@email.prisonvisits.service.gov.uk')
+    end
+
+    it 'returns explicitly assigned value' do
+      subject.email_address = 'user@test.example.com'
+      expect(subject.email_address).
+        to eq('user@test.example.com')
+    end
+  end
+end


### PR DESCRIPTION
Unlike the old app, we no longer bother with the duplication of the email and Zendesk routes. (It would send all feedback via email, but only feedback with a supplied email address went to Zendesk.) Instead, we now send all feedback to Zendesk, using a placeholder address (currently `feedback@` etc.) when someone has chosen not to supply one.