### PR TITLE
Destroy dependent visitors and rejection objects

### DIFF
--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -7,7 +7,7 @@ class Prison < ActiveRecord::Base
   MAX_ADULTS = 3
   MIN_ADULTS = 1
 
-  has_many :visits
+  has_many :visits, dependent: :destroy
 
   validates :estate, :name, :nomis_id, :slot_details, presence: true
   validates :enabled, inclusion: { in: [true, false] }

--- a/app/models/prisoner.rb
+++ b/app/models/prisoner.rb
@@ -1,6 +1,6 @@
 class Prisoner < ActiveRecord::Base
   include Person
 
-  has_many :visits
+  has_many :visits, dependent: :destroy
   validates :number, presence: true
 end

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -1,8 +1,8 @@
 class Visit < ActiveRecord::Base
   belongs_to :prison
   belongs_to :prisoner
-  has_many :visitors
-  has_one :rejection
+  has_many :visitors, dependent: :destroy
+  has_one :rejection, dependent: :destroy
 
   validates :prison, :prisoner,
     :contact_email_address, :contact_phone_no, :slot_option_0,


### PR DESCRIPTION
The foreign key constraint prevents deletion of a Visit object in the console without
first deleting all its associated Visitors and the Rejection.