### PR TITLE
Add /healthcheck.json endpoint

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,0 +1,7 @@
+class HealthcheckController < ApplicationController
+  def index
+    healthcheck = Healthcheck.new
+    status = healthcheck.ok? ? nil : :bad_gateway
+    render status: status, json: healthcheck.checks
+  end
+end

--- a/app/services/healthcheck.rb
+++ b/app/services/healthcheck.rb
@@ -5,7 +5,8 @@ class Healthcheck
     @components = {
       database: DatabaseCheck.new('Postgres database'),
       mailers: QueueCheck.new('Email queue', queue_name: 'mailers'),
-      zendesk: QueueCheck.new('Zendesk queue', queue_name: 'zendesk')
+      zendesk: QueueCheck.new('Zendesk queue', queue_name: 'zendesk'),
+      smtp: SmtpCheck.new('SMTP server', smtp_settings: smtp_settings)
     }
   end
 
@@ -17,5 +18,9 @@ class Healthcheck
     @components.inject(ok: ok?) { |hash, (key, checker)|
       hash.merge(key => checker.report)
     }
+  end
+
+  def smtp_settings
+    Rails.configuration.action_mailer.smtp_settings
   end
 end

--- a/app/services/healthcheck.rb
+++ b/app/services/healthcheck.rb
@@ -1,66 +1,21 @@
 require 'sidekiq/api'
 
 class Healthcheck
-  STALENESS_THRESHOLD = 10.minutes
-
   def initialize
-    @queues = {}
+    @components = {
+      database: DatabaseCheck.new('Postgres database'),
+      mailers: QueueCheck.new('Email queue', queue_name: 'mailers'),
+      zendesk: QueueCheck.new('Zendesk queue', queue_name: 'zendesk')
+    }
   end
 
   def ok?
-    checks.fetch(:ok)
+    @components.values.all?(&:ok?)
   end
 
   def checks
-    components = {
-      database: database,
-      mailers: mailers,
-      zendesk: zendesk
+    @components.inject(ok: ok?) { |hash, (key, checker)|
+      hash.merge(key => checker.report)
     }
-    components.merge(ok: components.values.map { |h| h.fetch(:ok) }.all?)
-  end
-
-private
-
-  def database
-    {
-      description: 'Postgres database',
-      ok: database_active?
-    }
-  end
-
-  def mailers
-    queue_info('mailers', 'Email queue')
-  end
-
-  def zendesk
-    queue_info('zendesk', 'Zendesk queue')
-  end
-
-  def queue_info(name, description)
-    q = Sidekiq::Queue.new(name)
-    {
-      description: description,
-      ok: fresh?(q),
-      oldest: oldest(q),
-      count: q.count
-    }
-  rescue StandardError
-    { description: description, ok: false, oldest: nil, count: 0 }
-  end
-
-  def fresh?(q)
-    return true unless q.any?
-    q.first.created_at > STALENESS_THRESHOLD.ago
-  end
-
-  def oldest(q)
-    q.any? ? q.first.created_at : nil
-  end
-
-  def database_active?
-    ActiveRecord::Base.connection.active?
-  rescue StandardError
-    false
   end
 end

--- a/app/services/healthcheck.rb
+++ b/app/services/healthcheck.rb
@@ -1,0 +1,66 @@
+require 'sidekiq/api'
+
+class Healthcheck
+  STALENESS_THRESHOLD = 10.minutes
+
+  def initialize
+    @queues = {}
+  end
+
+  def ok?
+    checks.fetch(:ok)
+  end
+
+  def checks
+    components = {
+      database: database,
+      mailers: mailers,
+      zendesk: zendesk
+    }
+    components.merge(ok: components.values.map { |h| h.fetch(:ok) }.all?)
+  end
+
+private
+
+  def database
+    {
+      description: 'Postgres database',
+      ok: database_active?
+    }
+  end
+
+  def mailers
+    queue_info('mailers', 'Email queue')
+  end
+
+  def zendesk
+    queue_info('zendesk', 'Zendesk queue')
+  end
+
+  def queue_info(name, description)
+    q = Sidekiq::Queue.new(name)
+    {
+      description: description,
+      ok: fresh?(q),
+      oldest: oldest(q),
+      count: q.count
+    }
+  rescue StandardError
+    { description: description, ok: false, oldest: nil, count: 0 }
+  end
+
+  def fresh?(q)
+    return true unless q.any?
+    q.first.created_at > STALENESS_THRESHOLD.ago
+  end
+
+  def oldest(q)
+    q.any? ? q.first.created_at : nil
+  end
+
+  def database_active?
+    ActiveRecord::Base.connection.active?
+  rescue StandardError
+    false
+  end
+end

--- a/app/services/healthcheck/check_component.rb
+++ b/app/services/healthcheck/check_component.rb
@@ -1,0 +1,20 @@
+class Healthcheck
+  module CheckComponent
+    attr_reader :report
+
+    def ok?
+      report.fetch(:ok)
+    end
+
+  private
+
+    def build_report(description)
+      @report =
+        begin
+          yield
+        rescue StandardError => err
+          { error: err.to_s, ok: false }
+        end.merge(description: description)
+    end
+  end
+end

--- a/app/services/healthcheck/database_check.rb
+++ b/app/services/healthcheck/database_check.rb
@@ -1,0 +1,11 @@
+class Healthcheck
+  class DatabaseCheck
+    include CheckComponent
+
+    def initialize(description)
+      build_report description do
+        { ok: ActiveRecord::Base.connection.active? }
+      end
+    end
+  end
+end

--- a/app/services/healthcheck/queue_check.rb
+++ b/app/services/healthcheck/queue_check.rb
@@ -1,0 +1,29 @@
+class Healthcheck
+  class QueueCheck
+    include CheckComponent
+
+    STALENESS_THRESHOLD = 10.minutes
+
+    def initialize(description, queue_name:)
+      build_report description do
+        queue = Sidekiq::Queue.new(queue_name)
+        {
+          ok: fresh?(queue),
+          oldest: oldest(queue),
+          count: queue.count
+        }
+      end
+    end
+
+  private
+
+    def fresh?(queue)
+      return true unless queue.any?
+      queue.first.created_at > STALENESS_THRESHOLD.ago
+    end
+
+    def oldest(queue)
+      queue.any? ? queue.first.created_at : nil
+    end
+  end
+end

--- a/app/services/healthcheck/smtp_check.rb
+++ b/app/services/healthcheck/smtp_check.rb
@@ -1,0 +1,25 @@
+require 'net/smtp'
+
+class Healthcheck
+  class SmtpCheck
+    include CheckComponent
+
+    def initialize(description, smtp_settings:)
+      host = smtp_settings.fetch(:address)
+      port = smtp_settings.fetch(:port)
+
+      build_report description do
+        { ok: alive?(host, port) }
+      end
+    end
+
+    def alive?(host, port)
+      Net::SMTP.start(host, port) do |smtp|
+        smtp.enable_starttls_auto
+        smtp.ehlo(Socket.gethostname)
+        smtp.finish
+      end
+      true
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,9 @@ Rails.application.routes.draw do
   end
 
   get 'unsubscribe' => 'high_voltage/pages#show', id: 'unsubscribe'
-  get 'ping' => 'ping#index'
+
+  constraints format: 'json' do
+    get 'ping', to: 'ping#index'
+    get 'healthcheck', to: 'healthcheck#index'
+  end
 end

--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -1,0 +1,118 @@
+require 'rails_helper'
+
+RSpec.describe HealthcheckController, type: :controller do
+  let(:parsed_body) {
+    JSON.parse(response.body)
+  }
+
+  let(:healthcheck) {
+    double(
+      Healthcheck,
+      ok?: true,
+      checks: {
+        database: {
+          description: "Postgres database", ok: true
+        },
+        mailers: {
+          description: "Email queue", ok: true,
+          oldest: nil, count: 0
+        },
+        zendesk: {
+          description: "Zendesk queue", ok: true,
+          oldest: nil, count: 0
+        },
+        ok: true
+      }
+    )
+  }
+
+  before do
+    allow(Healthcheck).to receive(:new).and_return(healthcheck)
+  end
+
+  context 'when everything is OK' do
+    before do
+      get :index
+    end
+
+    it 'returns an HTTP Success status' do
+      expect(response).to be_success
+    end
+
+    it 'returns the healthcheck data as JSON' do
+      expect(parsed_body).to eq(
+        'database' => {
+          'description' => "Postgres database",
+          'ok' => true
+        },
+        'mailers' => {
+          'description' => "Email queue",
+          'ok' => true,
+          'oldest' => nil,
+          'count' => 0
+        },
+        'zendesk' => {
+          'description' => "Zendesk queue",
+          'ok' => true,
+          'oldest' => nil,
+          'count' => 0
+        },
+        'ok' => true
+      )
+    end
+  end
+
+  context 'when the healthcheck is not OK' do
+    before do
+      allow(healthcheck).to receive(:ok?).and_return(false)
+      get :index
+    end
+
+    it 'returns an HTTP Bad Gateway status' do
+      expect(response).to have_http_status(:bad_gateway)
+    end
+  end
+
+  context 'when there are no queue items' do
+    before do
+      get :index
+    end
+
+    it 'reports empty queue statuses' do
+      expect(parsed_body).to include(
+        'mailers' => include('oldest' => nil, 'count' => 0),
+        'zendesk' => include('oldest' => nil, 'count' => 0)
+      )
+    end
+  end
+
+  context 'when there are queue items' do
+    let(:mq_created_at) { Time.at(1_440_685_647).utc }
+    let(:zq_created_at) { Time.at(1_440_685_724).utc }
+
+    before do
+      allow(healthcheck).to receive(:checks).and_return(
+        database: {
+          description: "Postgres database", ok: true
+        },
+        mailers: {
+          description: "Email queue", ok: true,
+          oldest: mq_created_at, count: 1
+        },
+        zendesk: {
+          description: "Zendesk queue", ok: true,
+          oldest: zq_created_at, count: 2
+        },
+        ok: true
+      )
+      get :index
+    end
+
+    it 'reports timestamps in RFC 3339 format' do
+      expect(parsed_body).to include(
+        'mailers' => include('oldest' => '2015-08-27T14:27:27.000Z'),
+        'zendesk' => include('oldest' => '2015-08-27T14:28:44.000Z')
+      )
+    end
+  end
+end

--- a/spec/services/healthcheck/database_check_spec.rb
+++ b/spec/services/healthcheck/database_check_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe Healthcheck::DatabaseCheck do
+  subject { described_class.new('Database check') }
+
+  context 'with a working connection' do
+    before do
+      allow(ActiveRecord::Base.connection).
+        to receive(:active?).
+        and_return(true)
+    end
+
+    it { is_expected.to be_ok }
+
+    it 'reports the status' do
+      expect(subject.report).to eq(
+        description: 'Database check',
+        ok: true
+      )
+    end
+  end
+
+  context 'with an inactive database' do
+    before do
+      allow(ActiveRecord::Base.connection).
+        to receive(:active?).
+        and_return(false)
+    end
+
+    it { is_expected.not_to be_ok }
+
+    it 'reports the status' do
+      expect(subject.report).to eq(
+        description: 'Database check',
+        ok: false
+      )
+    end
+  end
+
+  context 'with an unreachable database' do
+    before do
+      allow(ActiveRecord::Base.connection).
+        to receive(:active?).
+        and_raise(PG::ConnectionBad, 'bad connection')
+    end
+
+    it { is_expected.not_to be_ok }
+
+    it 'reports the status' do
+      expect(subject.report).to eq(
+        description: 'Database check',
+        ok: false,
+        error: 'bad connection'
+      )
+    end
+  end
+
+  context 'with another database exception' do
+    before do
+      allow(ActiveRecord::Base.connection).
+        to receive(:active?).
+        and_raise(StandardError, 'some other exception')
+    end
+
+    it { is_expected.not_to be_ok }
+
+    it 'reports the status' do
+      expect(subject.report).to eq(
+        description: 'Database check',
+        ok: false,
+        error: 'some other exception'
+      )
+    end
+  end
+end

--- a/spec/services/healthcheck/queue_check_spec.rb
+++ b/spec/services/healthcheck/queue_check_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe Healthcheck::QueueCheck do
+  subject { described_class.new('Foo queue', queue_name: 'foo') }
+  let(:queue) { [] }
+
+  before do
+    allow(Sidekiq::Queue).to receive(:new).and_return queue
+  end
+
+  it 'connects to the specified queue' do
+    expect(Sidekiq::Queue).to receive(:new).with('foo').and_return queue
+    subject.report
+  end
+
+  context 'with an empty queue' do
+    it { is_expected.to be_ok }
+
+    it 'reports the status' do
+      expect(subject.report).to eq(
+        description: 'Foo queue',
+        ok: true,
+        oldest: nil,
+        count: 0
+      )
+    end
+  end
+
+  context 'with only fresh queue items' do
+    let(:created_at) { 9.minutes.ago }
+    let(:queue) { [double(Sidekiq::Job, created_at: created_at)] }
+
+    it { is_expected.to be_ok }
+
+    it 'reports the status' do
+      expect(subject.report).to eq(
+        description: 'Foo queue',
+        ok: true,
+        oldest: created_at,
+        count: 1
+      )
+    end
+  end
+
+  context 'when the Sidekiq API raises an exception' do
+    before do
+      allow(Sidekiq::Queue).to receive(:new).and_raise('queue problem')
+    end
+
+    it { is_expected.not_to be_ok }
+
+    it 'reports the status' do
+      expect(subject.report).to eq(
+        description: 'Foo queue',
+        ok: false,
+        error: 'queue problem'
+      )
+    end
+  end
+
+  context 'with stale queue items' do
+    let(:created_at) { 11.minutes.ago }
+    let(:queue) { [double(Sidekiq::Job, created_at: created_at)] }
+
+    it { is_expected.not_to be_ok }
+
+    it 'reports the status' do
+      expect(subject.report).to eq(
+        description: 'Foo queue',
+        ok: false,
+        oldest: created_at,
+        count: 1
+      )
+    end
+  end
+end

--- a/spec/services/healthcheck/smtp_check_spec.rb
+++ b/spec/services/healthcheck/smtp_check_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+RSpec.describe Healthcheck::SmtpCheck do
+  subject {
+    described_class.new('SMTP connection', smtp_settings: smtp_settings)
+  }
+  let(:smtp_settings) { { address: 'smtp.example.com', port: 587 } }
+
+  it 'connects to the specified host and port' do
+    expect(Net::SMTP).to receive(:start).with('smtp.example.com', 587)
+    subject.report
+  end
+
+  context 'when it connects' do
+    let(:smtp) { double(enable_starttls_auto: nil, ehlo: nil, finish: nil) }
+
+    before do
+      allow(Net::SMTP).to receive(:start).and_yield(smtp)
+    end
+
+    it { is_expected.to be_ok }
+
+    it 'reports the status' do
+      expect(subject.report).to eq(
+        description: 'SMTP connection',
+        ok: true
+      )
+    end
+  end
+
+  context 'when it times out' do
+    before do
+      allow(Net::SMTP).to receive(:start).
+        and_raise(Net::OpenTimeout, 'timed out')
+    end
+
+    it { is_expected.not_to be_ok }
+
+    it 'reports the status' do
+      expect(subject.report).to eq(
+        description: 'SMTP connection',
+        ok: false,
+        error: 'timed out'
+      )
+    end
+  end
+
+  context 'when the port is closed' do
+    before do
+      allow(Net::SMTP).to receive(:start).
+        and_raise(Errno::ECONNREFUSED, 'port closed')
+    end
+
+    it { is_expected.not_to be_ok }
+
+    it 'reports the status' do
+      expect(subject.report).to eq(
+        description: 'SMTP connection',
+        ok: false,
+        error: 'Connection refused - port closed'
+      )
+    end
+  end
+
+  context 'when the hostname cannot be resolved' do
+    before do
+      allow(Net::SMTP).to receive(:start).
+        and_raise(SocketError, 'hostname not resolved')
+    end
+
+    it { is_expected.not_to be_ok }
+
+    it 'reports the status' do
+      expect(subject.report).to eq(
+        description: 'SMTP connection',
+        ok: false,
+        error: 'hostname not resolved'
+      )
+    end
+  end
+end

--- a/spec/services/healthcheck_spec.rb
+++ b/spec/services/healthcheck_spec.rb
@@ -1,0 +1,194 @@
+require 'rails_helper'
+
+RSpec.describe Healthcheck do
+  subject { described_class.new }
+
+  let(:mailers_queue) { [] }
+  let(:zendesk_queue) { [] }
+
+  before do
+    allow(Sidekiq::Queue).
+      to receive(:new).
+      with('mailers').
+      and_return mailers_queue
+    allow(Sidekiq::Queue).
+      to receive(:new).
+      with('zendesk').
+      and_return zendesk_queue
+  end
+
+  shared_examples 'everything is OK' do
+    it { is_expected.to be_ok }
+
+    it 'reports the overall status as OK' do
+      expect(subject.checks).to include(ok: true)
+    end
+  end
+
+  shared_examples 'everything is not OK' do
+    it { is_expected.not_to be_ok }
+
+    it 'reports the overall status as not OK' do
+      expect(subject.checks).to include(ok: false)
+    end
+  end
+
+  context 'when everything is OK' do
+    it 'describes each service' do
+      expect(subject.checks).to include(
+        database: include(description: 'Postgres database'),
+        mailers: include(description: 'Email queue'),
+        zendesk: include(description: 'Zendesk queue')
+      )
+    end
+
+    context 'with empty queues' do
+      it_behaves_like 'everything is OK'
+
+      it 'reports all services as OK' do
+        expect(subject.checks).to include(
+          database: include(ok: true),
+          mailers: include(ok: true),
+          zendesk: include(ok: true)
+        )
+      end
+
+      it 'reports the queue status' do
+        expect(subject.checks).to include(
+          mailers: include(oldest: nil, count: 0),
+          zendesk: include(oldest: nil, count: 0)
+        )
+      end
+    end
+
+    context 'with only fresh queue items' do
+      let(:mq_created_at) { 9.minutes.ago }
+      let(:zq_created_at) { 8.minutes.ago }
+      let(:mailers_queue) {
+        [double(Sidekiq::Job, created_at: mq_created_at)]
+      }
+      let(:zendesk_queue) {
+        [double(Sidekiq::Job, created_at: zq_created_at)]
+      }
+
+      it_behaves_like 'everything is OK'
+
+      it 'reports all services as OK' do
+        expect(subject.checks).to include(
+          database: include(ok: true),
+          mailers: include(ok: true),
+          zendesk: include(ok: true)
+        )
+      end
+
+      it 'reports the queue status' do
+        expect(subject.checks).to include(
+          mailers: include(oldest: mq_created_at, count: 1),
+          zendesk: include(oldest: zq_created_at, count: 1)
+        )
+      end
+    end
+  end
+
+  context 'when there is a problem' do
+    context 'with stale mailers queue items' do
+      let(:mq_created_at) { 11.minutes.ago }
+      let(:mailers_queue) {
+        [double(Sidekiq::Job, created_at: mq_created_at)]
+      }
+
+      it_behaves_like 'everything is not OK'
+
+      it 'reports the mailers check as false' do
+        expect(subject.checks).to include(mailers: include(ok: false))
+      end
+
+      it 'reports the mailers queue status' do
+        expect(subject.checks).to include(
+          mailers: include(oldest: mq_created_at, count: 1)
+        )
+      end
+    end
+
+    context 'with stale zendesk queue items' do
+      let(:zq_created_at) { 11.minutes.ago }
+      let(:zendesk_queue) {
+        [double(Sidekiq::Job, created_at: zq_created_at)]
+      }
+
+      it_behaves_like 'everything is not OK'
+
+      it 'reports the zendesk check as false' do
+        expect(subject.checks).to include(zendesk: include(ok: false))
+      end
+
+      it 'reports the zendesk queue status' do
+        expect(subject.checks).to include(
+          zendesk: include(oldest: zq_created_at, count: 1)
+        )
+      end
+    end
+
+    context 'with an inactive database' do
+      before do
+        allow(ActiveRecord::Base.connection).
+          to receive(:active?).
+          and_return(false)
+      end
+
+      it_behaves_like 'everything is not OK'
+
+      it 'reports the database check as false' do
+        expect(subject.checks).to include(database: include(ok: false))
+      end
+    end
+
+    context 'with an unreachable database' do
+      before do
+        allow(ActiveRecord::Base.connection).
+          to receive(:active?).
+          and_raise(PG::ConnectionBad)
+      end
+
+      it_behaves_like 'everything is not OK'
+
+      it 'reports the database check as false' do
+        expect(subject.checks).to include(database: include(ok: false))
+      end
+    end
+
+    context 'with another database exception' do
+      before do
+        allow(ActiveRecord::Base.connection).
+          to receive(:active?).
+          and_raise(StandardError)
+      end
+
+      it_behaves_like 'everything is not OK'
+
+      it 'reports the database check as false' do
+        expect(subject.checks).to include(database: include(ok: false))
+      end
+    end
+
+    context 'with the Sidekiq API' do
+      before do
+        allow(Sidekiq::Queue).to receive(:new).and_raise('queue problem')
+      end
+
+      it 'reports the queue checks as false' do
+        expect(subject.checks).to include(
+          mailers: include(ok: false),
+          zendesk: include(ok: false)
+        )
+      end
+
+      it 'reports the queue status' do
+        expect(subject.checks).to include(
+          mailers: include(oldest: nil, count: 0),
+          zendesk: include(oldest: nil, count: 0)
+        )
+      end
+    end
+  end
+end

--- a/spec/services/healthcheck_spec.rb
+++ b/spec/services/healthcheck_spec.rb
@@ -10,10 +10,14 @@ RSpec.describe Healthcheck do
   let(:mailers_check) {
     instance_double(Healthcheck::QueueCheck, ok?: mailers_ok, report: mailers_report)
   }
+  let(:smtp_check) {
+    instance_double(Healthcheck::SmtpCheck, ok?: smtp_ok, report: smtp_report)
+  }
 
   let(:database_report) { { description: 'database', ok: database_ok } }
   let(:zendesk_report) { { description: 'zendesk', ok: zendesk_ok } }
   let(:mailers_report) { { description: 'mailers', ok: mailers_ok } }
+  let(:smtp_report) { { description: 'smtp', ok: smtp_ok } }
 
   before do
     allow(Healthcheck::DatabaseCheck).to receive(:new).
@@ -22,12 +26,15 @@ RSpec.describe Healthcheck do
       with(anything, queue_name: 'zendesk').and_return(zendesk_check)
     allow(Healthcheck::QueueCheck).to receive(:new).
       with(anything, queue_name: 'mailers').and_return(mailers_check)
+    allow(Healthcheck::SmtpCheck).to receive(:new).
+      and_return(smtp_check)
   end
 
   context 'when everything is OK' do
     let(:database_ok) { true }
     let(:zendesk_ok) { true }
     let(:mailers_ok) { true }
+    let(:smtp_ok) { true }
 
     it { is_expected.to be_ok }
 
@@ -36,7 +43,8 @@ RSpec.describe Healthcheck do
         ok: true,
         zendesk: zendesk_report,
         mailers: mailers_report,
-        database: database_report
+        database: database_report,
+        smtp: smtp_report
       )
     end
   end
@@ -45,6 +53,7 @@ RSpec.describe Healthcheck do
     let(:database_ok) { false }
     let(:zendesk_ok) { true }
     let(:mailers_ok) { true }
+    let(:smtp_ok) { true }
 
     it { is_expected.not_to be_ok }
 
@@ -53,7 +62,8 @@ RSpec.describe Healthcheck do
         ok: false,
         zendesk: zendesk_report,
         mailers: mailers_report,
-        database: database_report
+        database: database_report,
+        smtp: smtp_report
       )
     end
   end

--- a/spec/services/healthcheck_spec.rb
+++ b/spec/services/healthcheck_spec.rb
@@ -1,194 +1,60 @@
 require 'rails_helper'
 
 RSpec.describe Healthcheck do
-  subject { described_class.new }
+  let(:database_check) {
+    instance_double(Healthcheck::DatabaseCheck, ok?: database_ok, report: database_report)
+  }
+  let(:zendesk_check) {
+    instance_double(Healthcheck::QueueCheck, ok?: zendesk_ok, report: zendesk_report)
+  }
+  let(:mailers_check) {
+    instance_double(Healthcheck::QueueCheck, ok?: mailers_ok, report: mailers_report)
+  }
 
-  let(:mailers_queue) { [] }
-  let(:zendesk_queue) { [] }
+  let(:database_report) { { description: 'database', ok: database_ok } }
+  let(:zendesk_report) { { description: 'zendesk', ok: zendesk_ok } }
+  let(:mailers_report) { { description: 'mailers', ok: mailers_ok } }
 
   before do
-    allow(Sidekiq::Queue).
-      to receive(:new).
-      with('mailers').
-      and_return mailers_queue
-    allow(Sidekiq::Queue).
-      to receive(:new).
-      with('zendesk').
-      and_return zendesk_queue
-  end
-
-  shared_examples 'everything is OK' do
-    it { is_expected.to be_ok }
-
-    it 'reports the overall status as OK' do
-      expect(subject.checks).to include(ok: true)
-    end
-  end
-
-  shared_examples 'everything is not OK' do
-    it { is_expected.not_to be_ok }
-
-    it 'reports the overall status as not OK' do
-      expect(subject.checks).to include(ok: false)
-    end
+    allow(Healthcheck::DatabaseCheck).to receive(:new).
+      and_return(database_check)
+    allow(Healthcheck::QueueCheck).to receive(:new).
+      with(anything, queue_name: 'zendesk').and_return(zendesk_check)
+    allow(Healthcheck::QueueCheck).to receive(:new).
+      with(anything, queue_name: 'mailers').and_return(mailers_check)
   end
 
   context 'when everything is OK' do
-    it 'describes each service' do
-      expect(subject.checks).to include(
-        database: include(description: 'Postgres database'),
-        mailers: include(description: 'Email queue'),
-        zendesk: include(description: 'Zendesk queue')
+    let(:database_ok) { true }
+    let(:zendesk_ok) { true }
+    let(:mailers_ok) { true }
+
+    it { is_expected.to be_ok }
+
+    it 'combines the reports' do
+      expect(subject.checks).to eq(
+        ok: true,
+        zendesk: zendesk_report,
+        mailers: mailers_report,
+        database: database_report
       )
-    end
-
-    context 'with empty queues' do
-      it_behaves_like 'everything is OK'
-
-      it 'reports all services as OK' do
-        expect(subject.checks).to include(
-          database: include(ok: true),
-          mailers: include(ok: true),
-          zendesk: include(ok: true)
-        )
-      end
-
-      it 'reports the queue status' do
-        expect(subject.checks).to include(
-          mailers: include(oldest: nil, count: 0),
-          zendesk: include(oldest: nil, count: 0)
-        )
-      end
-    end
-
-    context 'with only fresh queue items' do
-      let(:mq_created_at) { 9.minutes.ago }
-      let(:zq_created_at) { 8.minutes.ago }
-      let(:mailers_queue) {
-        [double(Sidekiq::Job, created_at: mq_created_at)]
-      }
-      let(:zendesk_queue) {
-        [double(Sidekiq::Job, created_at: zq_created_at)]
-      }
-
-      it_behaves_like 'everything is OK'
-
-      it 'reports all services as OK' do
-        expect(subject.checks).to include(
-          database: include(ok: true),
-          mailers: include(ok: true),
-          zendesk: include(ok: true)
-        )
-      end
-
-      it 'reports the queue status' do
-        expect(subject.checks).to include(
-          mailers: include(oldest: mq_created_at, count: 1),
-          zendesk: include(oldest: zq_created_at, count: 1)
-        )
-      end
     end
   end
 
   context 'when there is a problem' do
-    context 'with stale mailers queue items' do
-      let(:mq_created_at) { 11.minutes.ago }
-      let(:mailers_queue) {
-        [double(Sidekiq::Job, created_at: mq_created_at)]
-      }
+    let(:database_ok) { false }
+    let(:zendesk_ok) { true }
+    let(:mailers_ok) { true }
 
-      it_behaves_like 'everything is not OK'
+    it { is_expected.not_to be_ok }
 
-      it 'reports the mailers check as false' do
-        expect(subject.checks).to include(mailers: include(ok: false))
-      end
-
-      it 'reports the mailers queue status' do
-        expect(subject.checks).to include(
-          mailers: include(oldest: mq_created_at, count: 1)
-        )
-      end
-    end
-
-    context 'with stale zendesk queue items' do
-      let(:zq_created_at) { 11.minutes.ago }
-      let(:zendesk_queue) {
-        [double(Sidekiq::Job, created_at: zq_created_at)]
-      }
-
-      it_behaves_like 'everything is not OK'
-
-      it 'reports the zendesk check as false' do
-        expect(subject.checks).to include(zendesk: include(ok: false))
-      end
-
-      it 'reports the zendesk queue status' do
-        expect(subject.checks).to include(
-          zendesk: include(oldest: zq_created_at, count: 1)
-        )
-      end
-    end
-
-    context 'with an inactive database' do
-      before do
-        allow(ActiveRecord::Base.connection).
-          to receive(:active?).
-          and_return(false)
-      end
-
-      it_behaves_like 'everything is not OK'
-
-      it 'reports the database check as false' do
-        expect(subject.checks).to include(database: include(ok: false))
-      end
-    end
-
-    context 'with an unreachable database' do
-      before do
-        allow(ActiveRecord::Base.connection).
-          to receive(:active?).
-          and_raise(PG::ConnectionBad)
-      end
-
-      it_behaves_like 'everything is not OK'
-
-      it 'reports the database check as false' do
-        expect(subject.checks).to include(database: include(ok: false))
-      end
-    end
-
-    context 'with another database exception' do
-      before do
-        allow(ActiveRecord::Base.connection).
-          to receive(:active?).
-          and_raise(StandardError)
-      end
-
-      it_behaves_like 'everything is not OK'
-
-      it 'reports the database check as false' do
-        expect(subject.checks).to include(database: include(ok: false))
-      end
-    end
-
-    context 'with the Sidekiq API' do
-      before do
-        allow(Sidekiq::Queue).to receive(:new).and_raise('queue problem')
-      end
-
-      it 'reports the queue checks as false' do
-        expect(subject.checks).to include(
-          mailers: include(ok: false),
-          zendesk: include(ok: false)
-        )
-      end
-
-      it 'reports the queue status' do
-        expect(subject.checks).to include(
-          mailers: include(oldest: nil, count: 0),
-          zendesk: include(oldest: nil, count: 0)
-        )
-      end
+    it 'combines the reports' do
+      expect(subject.checks).to eq(
+        ok: false,
+        zendesk: zendesk_report,
+        mailers: mailers_report,
+        database: database_report
+      )
     end
   end
 end


### PR DESCRIPTION
This exposes a JSON document at `/healthcheck.json` that reports the state of queues, database connectivity, SMTP server, and overall health of the application.