### PR TITLE
Inhibit caching in browsers and proxies

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,8 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  before_action :do_not_cache
+
   helper LinksHelper
 
 private
@@ -13,5 +15,11 @@ private
 
   def http_user_agent
     request.headers['HTTP_USER_AGENT']
+  end
+
+  def do_not_cache
+    response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
+    response.headers['Pragma'] = 'no-cache'
+    response.headers['Expires'] = '0'
   end
 end


### PR DESCRIPTION
We don't want intermediates to cache booking requests, and we don't want other users of the same computer to be able to see what was previously booked.

See https://stackoverflow.com/questions/49547 for more detail about the headers used.

Tested in the browser: the headers are set, and attempting to go back re-requests the page as expected.