### PR TITLE
Let visitors edit their request before confirming

### DIFF
--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -20,4 +20,9 @@ private
     @steps.fetch(:prisoner_step).prison
   end
   helper_method :prison
+
+  def reviewing?
+    params.key?(:review_step)
+  end
+  helper_method :reviewing?
 end

--- a/app/services/steps_processor.rb
+++ b/app/services/steps_processor.rb
@@ -5,7 +5,7 @@ class StepsProcessor
   end
 
   def template_name
-    incomplete_step_name || :completed
+    review_step_name || incomplete_step_name || :completed
   end
 
   def execute!
@@ -22,6 +22,10 @@ class StepsProcessor
 private
 
   attr_reader :params
+
+  def review_step_name
+    steps.keys.find { |name| name.to_s == params[:review_step].to_s }
+  end
 
   def incomplete_step_name
     steps.keys.find { |name| incomplete_step?(name) }

--- a/app/views/booking_requests/_hidden_inputs_for_calendars.html.erb
+++ b/app/views/booking_requests/_hidden_inputs_for_calendars.html.erb
@@ -1,15 +1,14 @@
 <div class="hidden--js-enabled">
   <% 3.times do |i| %>
-    <div class="group">
-      <label for="slot_step_option_<%= i %>"><%= t('.option', n: i) %></label>
-      <select class="SlotPicker-input" name='slots_step[option_<%= i %>]' id="slots_step_<%= i %>">
-        <option value=''><%= t('.none') %></option>
-        <% f.object.available_slots.each do |slot| %>
-          <option value="<%= slot.iso8601 %>">
-            <%= format_slot_begin_time_for_public(slot) %>
-          </option>
-         <% end %>
-      </select>
-    </div>
+     <%=
+       single_field(
+         f, :"option_#{i}", :select,
+         f.object.available_slots.map { |s|
+           [format_slot_begin_time_for_public(s), s.iso8601]
+         },
+         { include_blank: true },
+         class: 'SlotPicker-input'
+       )
+     %>
   <% end %>
 </div>

--- a/app/views/booking_requests/confirmation_step.html.erb
+++ b/app/views/booking_requests/confirmation_step.html.erb
@@ -33,9 +33,16 @@
     <strong><%= prisoner_step.prison_name %></strong>
   </p>
 
-  <p class="edit-link">
-    <%= link_to(t('.change_prisoner_details'), '/TODO') %>
-  </p>
+  <%= form_for(confirmation_step, url: booking_requests_path) do |f| %>
+    <%= render(partial: 'hidden_prisoner_step') %>
+    <%= render(partial: 'hidden_visitors_step') %>
+    <%= render(partial: 'hidden_slots_step') %>
+    <%= hidden_field_tag('review_step', 'prisoner_step') %>
+
+    <p class="edit-link">
+      <%= f.submit(t('.change_prisoner_details'), class: 'button') %>
+    </p>
+  <% end %>
 </div>
 
 <div class="divider compact">
@@ -57,9 +64,16 @@
     </p>
   <% end %>
 
-  <p class="edit-link">
-    <%= link_to(t('.change_visitor_details'), '/TODO') %>
-  </p>
+  <%= form_for(confirmation_step, url: booking_requests_path) do |f| %>
+    <%= render(partial: 'hidden_prisoner_step') %>
+    <%= render(partial: 'hidden_visitors_step') %>
+    <%= render(partial: 'hidden_slots_step') %>
+    <%= hidden_field_tag('review_step', 'visitors_step') %>
+
+    <p class="edit-link">
+      <%= f.submit(t('.change_visitor_details'), class: 'button') %>
+    </p>
+  <% end %>
 </div>
 
 <div class="divider compact visit-details">
@@ -91,9 +105,16 @@
     </ol>
   <% end %>
 
-  <p class="edit-link">
-    <%= link_to(t('.change_visit_details'), '/TODO') %>
-  </p>
+  <%= form_for(confirmation_step, url: booking_requests_path) do |f| %>
+    <%= render(partial: 'hidden_prisoner_step') %>
+    <%= render(partial: 'hidden_visitors_step') %>
+    <%= render(partial: 'hidden_slots_step') %>
+    <%= hidden_field_tag('review_step', 'slots_step') %>
+
+    <p class="edit-link">
+      <%= f.submit(t('.change_visit_details'), class: 'button') %>
+    </p>
+  <% end %>
 </div>
 
 <div class="divider">

--- a/app/views/booking_requests/prisoner_step.html.erb
+++ b/app/views/booking_requests/prisoner_step.html.erb
@@ -5,6 +5,11 @@
     <%= t('.information_html') %>
 
     <%= form_for(@steps.fetch(:prisoner_step), url: booking_requests_path) do |f| %>
+      <% if reviewing? %>
+        <%= render(partial: 'hidden_visitors_step') %>
+        <%= render(partial: 'hidden_slots_step') %>
+      <% end %>
+
       <h2>
         <%= t('.prisoner_details') %>
       </h2>

--- a/app/views/booking_requests/visitors_step.html.erb
+++ b/app/views/booking_requests/visitors_step.html.erb
@@ -4,6 +4,9 @@
   <div class="Grid-2-3">
     <%= form_for(@steps.fetch(:visitors_step), url: booking_requests_path) do |f| %>
       <%= render(partial: 'hidden_prisoner_step') %>
+      <% if reviewing? %>
+        <%= render(partial: 'hidden_slots_step') %>
+      <% end %>
 
       <h2>
         <%= t('.your_details') %>

--- a/spec/features/request_a_visit_spec.rb
+++ b/spec/features/request_a_visit_spec.rb
@@ -54,4 +54,48 @@ RSpec.feature 'Booking a visit', js: true do
 
     expect(page).to have_text('There must be at least one adult visitor')
   end
+
+  scenario 'review and edit' do
+    visit booking_requests_path
+
+    enter_prisoner_information
+    click_button 'Continue'
+
+    enter_visitor_information
+    click_button 'Continue'
+
+    select_slots 1
+    click_button 'Continue'
+
+    expect(page).to have_text('Check your request')
+
+    click_button 'Change prisoner details'
+
+    fill_in 'Prisoner last name', with: 'Featherstone-Haugh'
+    click_button 'Continue'
+
+    expect(page).to have_text('Check your request')
+    expect(page).to have_text('Featherstone-Haugh')
+
+    click_button 'Change visitor details'
+
+    fill_in 'Your last name', with: 'Colquhoun'
+    click_button 'Continue'
+
+    expect(page).to have_text('Check your request')
+    expect(page).to have_text('Colquhoun')
+
+    click_button 'Change visit details'
+
+    select_nth_slot 2
+    click_button 'Continue'
+
+    expect(page).to have_text('Check your request')
+    expect(page).to have_text('First choice')
+    expect(page).to have_text('Alternatives')
+
+    click_button 'Send request'
+
+    expect(page).to have_text('Your request is being processed')
+  end
 end

--- a/spec/services/steps_processor_spec.rb
+++ b/spec/services/steps_processor_spec.rb
@@ -1,0 +1,293 @@
+require 'rails_helper'
+
+RSpec.describe StepsProcessor do
+  let(:prisoner_details) {
+    {
+      first_name: 'Oscar',
+      last_name: 'Wilde',
+      date_of_birth: {
+        day: '31',
+        month: '12',
+        year: '1980'
+      },
+      number: 'a1234bc',
+      prison_id: 1
+    }
+  }
+
+  let(:visitors_details) {
+    {
+      email_address: 'ada@test.example.com',
+      phone_no: '01154960222',
+      visitors_attributes: {
+        0 => {
+          first_name: 'Ada',
+          last_name: 'Lovelace',
+          date_of_birth: {
+            day: '30',
+            month: '11',
+            year: '1970'
+          }
+        }
+      }
+    }
+  }
+
+  let(:slots_details) {
+    {
+      option_0: '2015-01-02T09:00/10:00',
+      option_1: '2015-01-03T09:00/10:00',
+      option_2: '2015-01-04T09:00/10:00'
+    }
+  }
+
+  let(:confirmation_details) {
+    { confirmed: 'true' }
+  }
+
+  let(:prison) {
+    double(
+      Prison,
+      available_slots: [
+        ConcreteSlot.new(2015, 1, 2, 9, 0, 10, 0),
+        ConcreteSlot.new(2015, 1, 3, 9, 0, 10, 0),
+        ConcreteSlot.new(2015, 1, 4, 9, 0, 10, 0)
+      ],
+      validate_visitor_ages_on: nil
+    )
+  }
+
+  before do
+    allow(Prison).to receive(:find_by).with(id: 1).and_return(prison)
+  end
+
+  subject { described_class.new(HashWithIndifferentAccess.new(params)) }
+
+  shared_examples 'it has all steps' do
+    it 'has a PrisonerStep' do
+      expect(subject.steps[:prisoner_step]).to be_a(PrisonerStep)
+    end
+
+    it 'has a VisitorsStep' do
+      expect(subject.steps[:visitors_step]).to be_a(VisitorsStep)
+    end
+
+    it 'has a SlotsStep' do
+      expect(subject.steps[:slots_step]).to be_a(SlotsStep)
+    end
+  end
+
+  shared_examples 'it is incomplete' do
+    it 'does not tell BookingRequestCreator to create a Visit record' do
+      allow(BookingRequestCreator).to receive(:new).never
+      subject.execute!
+    end
+  end
+
+  context 'with no params' do
+    let(:params) { {} }
+
+    it 'chooses the prisoner_step template' do
+      expect(subject.template_name).to eq(:prisoner_step)
+    end
+
+    it_behaves_like 'it has all steps'
+    it_behaves_like 'it is incomplete'
+  end
+
+  context 'with incomplete prisoner details' do
+    let(:params) { { prisoner_step: { first_name: 'Oscar' } } }
+
+    it 'chooses the prisoner_step template' do
+      expect(subject.template_name).to eq(:prisoner_step)
+    end
+
+    it 'returns a PrisonerStep with the supplied attributes' do
+      expect(subject.steps[:prisoner_step]).
+        to have_attributes(first_name: 'Oscar')
+    end
+
+    it_behaves_like 'it has all steps'
+    it_behaves_like 'it is incomplete'
+  end
+
+  context 'with complete prisoner details' do
+    let(:params) { { prisoner_step: prisoner_details } }
+
+    it 'chooses the visitors_step template' do
+      expect(subject.template_name).to eq(:visitors_step)
+    end
+
+    it 'initialises the PrisonerStep with the supplied attributes' do
+      expect(subject.steps[:prisoner_step]).
+        to have_attributes(first_name: 'Oscar')
+    end
+
+    it_behaves_like 'it has all steps'
+    it_behaves_like 'it is incomplete'
+  end
+
+  context 'with incomplete visitor details' do
+    let(:params) {
+      {
+        prisoner_step: prisoner_details,
+        visitors_step: { phone_no: '01154960222' }
+      }
+    }
+
+    it 'chooses the visitors_step template' do
+      expect(subject.template_name).to eq(:visitors_step)
+    end
+
+    it 'initialises the PrisonerStep with the supplied attributes' do
+      expect(subject.steps[:prisoner_step]).
+        to have_attributes(first_name: 'Oscar')
+    end
+
+    it 'initialises the VisitorsStep with the supplied attributes' do
+      expect(subject.steps[:visitors_step]).
+        to have_attributes(phone_no: '01154960222')
+    end
+
+    it_behaves_like 'it has all steps'
+    it_behaves_like 'it is incomplete'
+  end
+
+  context 'with complete visitor details' do
+    let(:params) {
+      {
+        prisoner_step: prisoner_details,
+        visitors_step: visitors_details
+      }
+    }
+
+    it 'chooses the slots_step template' do
+      expect(subject.template_name).to eq(:slots_step)
+    end
+
+    it 'initialises the PrisonerStep with the supplied attributes' do
+      expect(subject.steps[:prisoner_step]).
+        to have_attributes(first_name: 'Oscar')
+    end
+
+    it 'initialises the VisitorsStep with the supplied attributes' do
+      expect(subject.steps[:visitors_step]).
+        to have_attributes(phone_no: '01154960222')
+    end
+
+    it_behaves_like 'it has all steps'
+    it_behaves_like 'it is incomplete'
+  end
+
+  context 'with at least one slot' do
+    let(:params) {
+      {
+        prisoner_step: prisoner_details,
+        visitors_step: visitors_details,
+        slots_step: slots_details
+      }
+    }
+
+    it 'chooses the confirmation template' do
+      expect(subject.template_name).to eq(:confirmation_step)
+    end
+
+    it 'initialises the PrisonerStep with the supplied attributes' do
+      expect(subject.steps[:prisoner_step]).
+        to have_attributes(first_name: 'Oscar')
+    end
+
+    it 'initialises the VisitorsStep with the supplied attributes' do
+      expect(subject.steps[:visitors_step]).
+        to have_attributes(phone_no: '01154960222')
+    end
+
+    it 'initialises the SlotsStep with the supplied attributes' do
+      expect(subject.steps[:slots_step]).
+        to have_attributes(option_0: '2015-01-02T09:00/10:00')
+    end
+
+    it_behaves_like 'it has all steps'
+    it_behaves_like 'it is incomplete'
+  end
+
+  context 'with no slots selected' do
+    let(:params) {
+      {
+        prisoner_step: prisoner_details,
+        visitors_step: visitors_details,
+        slots_step: { option_0: '' }
+      }
+    }
+
+    it 'chooses the slots_step template' do
+      expect(subject.template_name).to eq(:slots_step)
+    end
+
+    it 'initialises the PrisonerStep with the supplied attributes' do
+      expect(subject.steps[:prisoner_step]).
+        to have_attributes(first_name: 'Oscar')
+    end
+
+    it 'initialises the VisitorsStep with the supplied attributes' do
+      expect(subject.steps[:visitors_step]).
+        to have_attributes(phone_no: '01154960222')
+    end
+
+    it_behaves_like 'it has all steps'
+    it_behaves_like 'it is incomplete'
+  end
+
+  context 'after confirming' do
+    let(:params) {
+      {
+        prisoner_step: prisoner_details,
+        visitors_step: visitors_details,
+        slots_step: slots_details,
+        confirmation_step: confirmation_details
+      }
+    }
+
+    let(:booking_request_creator) {
+      double(BookingRequestCreator)
+    }
+
+    it 'chooses the completed template' do
+      expect(subject.template_name).to eq(:completed)
+    end
+
+    it 'tells BookingRequestCreator to create a Visit record' do
+      allow(BookingRequestCreator).to receive(:new).
+        and_return(booking_request_creator)
+      allow(booking_request_creator).to receive(:create!)
+      expect(booking_request_creator).
+        to receive(:create!).
+        with(
+          an_object_having_attributes(
+            prison_id: 1,
+            first_name: 'Oscar',
+            last_name: 'Wilde',
+            date_of_birth: Date.new(1980, 12, 31),
+            number: 'a1234bc'
+          ),
+          an_object_having_attributes(
+            email_address: 'ada@test.example.com',
+            phone_no: '01154960222',
+            visitors: [
+              an_object_having_attributes(
+                first_name: 'Ada',
+                last_name: 'Lovelace',
+                date_of_birth: Date.new(1970, 11, 30)
+              )
+            ]
+          ),
+          an_object_having_attributes(
+            option_0: '2015-01-02T09:00/10:00',
+            option_1: '2015-01-03T09:00/10:00',
+            option_2: '2015-01-04T09:00/10:00'
+          )
+        )
+      subject.execute!
+    end
+  end
+end

--- a/spec/services/steps_processor_spec.rb
+++ b/spec/services/steps_processor_spec.rb
@@ -125,6 +125,14 @@ RSpec.describe StepsProcessor do
 
     it_behaves_like 'it has all steps'
     it_behaves_like 'it is incomplete'
+
+    context 'and the intention to go to the prisoner step' do
+      let(:params) { super().merge(review_step: :prisoner_step) }
+
+      it 'chooses the prisoner_step template' do
+        expect(subject.template_name).to eq(:prisoner_step)
+      end
+    end
   end
 
   context 'with incomplete visitor details' do
@@ -177,6 +185,14 @@ RSpec.describe StepsProcessor do
 
     it_behaves_like 'it has all steps'
     it_behaves_like 'it is incomplete'
+
+    context 'and the intention to go to the prisoner step' do
+      let(:params) { super().merge(review_step: :prisoner_step) }
+
+      it 'chooses the prisoner_step template' do
+        expect(subject.template_name).to eq(:prisoner_step)
+      end
+    end
   end
 
   context 'with at least one slot' do

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -49,10 +49,14 @@ module FeaturesHelper
 
   def select_slots(how_many = 3)
     how_many.times do |n|
-      all(".BookingCalendar-date--bookable .BookingCalendar-dateLink")[n].
-        trigger('click')
-      first('.SlotPicker-slot').trigger('click')
+      select_nth_slot n
     end
+  end
+
+  def select_nth_slot(n)
+    all(".BookingCalendar-date--bookable .BookingCalendar-dateLink")[n].
+      trigger('click')
+    first('.SlotPicker-slot').trigger('click')
   end
 
   def select_prison(name)


### PR DESCRIPTION
This adds a `review_step` parameter that will override the default behaviour of the `StepsProcessor` and be shown instead of the first incomplete step.

In order to distinguish incomplete from not-yet-filled steps (necessary to avoid showing validation errors on the first try), the hidden fields for later steps are only shown when reviewing.

The option selectors for visit slots are returned to using Rails's `FormBuilder` methods, reverting the change made in a2ca599, as this ignored existing selections. As the correct CSS class is applied, the
JavaScript enhanced selector continues to work.

To implement the edit, there is a form with hidden fields for each step on the confirmation page. As there are three editable steps, this means that the fields are replicated three times. This is slightly
unfortunate, but works well.