### PR TITLE
Update Nokogiri to 1.6.7.1 for security fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     netaddr (1.5.0)
-    nokogiri (1.6.7)
+    nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
     parser (2.2.3.0)
       ast (>= 1.1, < 3.0)


### PR DESCRIPTION
This fixes the following CVEs:

* CVE-2015-5312
* CVE-2015-7497
* CVE-2015-7498
* CVE-2015-7499
* CVE-2015-7500
* CVE-2015-8241
* CVE-2015-8242
* CVE-2015-8317