### PR TITLE
Legal pages

### DIFF
--- a/app/views/booking_requests/confirmation_step.html.erb
+++ b/app/views/booking_requests/confirmation_step.html.erb
@@ -97,7 +97,7 @@
 </div>
 
 <div class="divider">
-  <%= link_to(t('.ts_and_cs'), '/TODO') %>
+  <%= link_to(t('.ts_and_cs'), terms_and_conditions_path) %>
 
     <%= form_for(confirmation_step, url: booking_requests_path) do |f| %>
       <%= render(partial: 'hidden_prisoner_step') %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
 
 <% content_for :cookie_message do %>
   <%= t('.cookies_intro') %>
-  <%= link_to(t('.cookies_find_out_more'), '/TODO-cookies') %>
+  <%= link_to(t('.cookies_find_out_more'), cookies_path) %>
 <% end %>
 
 <% content_for :content_override do %>
@@ -49,7 +49,7 @@
 
 <% content_for :footer_support_links do %>
   <li>
-    <%= link_to(t('.cookies'), '/TODO-cookies') %>
+    <%= link_to(t('.cookies'), cookies_path) %>
   </li>
   <li>
     <%= link_to(t('.ts_and_cs'), terms_and_conditions_path) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
     <%= link_to(t('.cookies'), '/TODO-cookies') %>
   </li>
   <li>
-    <%= link_to(t('.ts_and_cs'), '/TODO-terms-and-conditions') %>
+    <%= link_to(t('.ts_and_cs'), terms_and_conditions_path) %>
   </li>
   <li>
     <%= link_to(t('.contact_us'), new_feedback_submission_path) %>

--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,0 +1,9 @@
+<% content_for :header, t('.title') %>
+
+<div class='Grid'>
+  <div class='Grid-2-3'>
+    <article>
+      <%= t('.body_html') %>
+    </article>
+  </div>
+</div>

--- a/app/views/pages/terms_and_conditions.html.erb
+++ b/app/views/pages/terms_and_conditions.html.erb
@@ -1,0 +1,9 @@
+<% content_for :header, t('.title') %>
+
+<div class='Grid'>
+  <div class='Grid-2-3'>
+    <article>
+      <%= t('.body_html') %>
+    </article>
+  </div>
+</div>

--- a/app/views/pages/unsubscribe.html.erb
+++ b/app/views/pages/unsubscribe.html.erb
@@ -1,7 +1,7 @@
-<% content_for :header, "Why did I receive this email?" %>
+<% content_for :header, t('.title') %>
+
 <p>
-<%= t('.you_received_an_email',
-      email: address_book.no_reply) %>
+  <%= t('.you_received_an_email', email: address_book.no_reply) %>
 </p>
 <p>
   <%= t('.why') %>

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -240,3 +240,138 @@ en:
         Digital Services, 11.51<br />
         102 Petty France<br />
         London SW1H 9AJ United Kingdom</p>
+    cookies:
+      title: Cookies
+      body_html: |
+        <p>Prison Visits Booking (PVB) puts small files (known as
+        ‘cookies’) onto your computer to collect information about how
+        you browse the site.</p>
+
+        <p>Cookies are used to:</p>
+
+        <ul>
+          <li>measure how you use the website so it can be updated and
+          improved based on your needs</li>
+
+          <li>remember the notifications you’ve seen so that we don’t
+          show them to you again</li>
+        </ul>
+
+        <p>PVB cookies aren’t used to identify you personally.</p>
+
+        <p>You’ll normally see a message on the site before we store a
+        cookie on your computer.</p>
+
+        <p>Find out more about
+        <a href="http://www.aboutcookies.org/" rel="external">how to manage
+        cookies.</a></p>
+
+        <h2>How cookies are used on PVB</h2>
+
+        <h3>Measuring website usage (Google Analytics)</h3>
+
+        <p>We use Google Analytics software to collect information about
+        how you use PVB. We do this to help make sure the site is meeting
+        the needs of its users and to help us make improvements.</p>
+
+        <p>Google Analytics stores information about:</p>
+
+        <ul>
+          <li>the pages you visit on PVB – how long you spend on each
+          PVB page</li>
+
+          <li>how you got to the site</li>
+
+          <li>what you click on while you’re visiting the site</li>
+        </ul>
+
+        <p>We don’t collect or store your personal information (eg your
+        name or address) so this information can’t be used to identify
+        who you are.</p>
+
+        <p>We don’t allow Google to use or share our analytics data.</p>
+
+        <p>Google Analytics sets the following cookies:</p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+
+              <th>Purpose</th>
+
+              <th>Expires</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <tr>
+              <td>_ga</td>
+
+              <td>Determines the number of unique visitors to the
+              site</td>
+
+              <td>2 years</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p>You can <a href="https://tools.google.com/dlpage/gaoptout"
+        rel="external">opt out of Google Analytics cookies.</a></p>
+
+        <h3>Our introductory message</h3>
+
+        <p>You may see a pop-up welcome message when you first visit PVB.
+        We’ll store a cookie so that your computer knows you’ve seen it
+        and knows not to show it again.</p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+
+              <th>Purpose</th>
+
+              <th>Expires</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <tr>
+              <td>seen_cookie_message</td>
+
+              <td>Saves a message to let us know that you have seen our
+              cookie message</td>
+
+              <td>1 month</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>Session</h3>
+
+        <p>The PVB service does not store your prisoner and visitor
+        information. The details you enter are encrypted and temporarily
+        stored on your computer until your booking request is sent.</p>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+
+              <th>Purpose</th>
+
+              <th>Expires</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <tr>
+              <td>pvbs</td>
+
+              <td>Store prisoner, visitor and visit details</td>
+
+              <td>20 minutes</td>
+            </tr>
+          </tbody>
+        </table>

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -7,3 +7,236 @@ en:
       confirmation: >-
         We’ll confirm your visit by email, so make sure you add this email
         address to your address book or safe senders list.
+    terms_and_conditions:
+      title: Terms and conditions and privacy policy
+      body_html: |
+        <p>By using this digital prison visit request service you agree
+        to our privacy policy and to these terms and conditions. Please
+        read them carefully.</p>
+
+        <h2>Terms and conditions</h2>
+
+        <h3>General</h3>
+
+        <p>These terms and conditions affect your rights and liabilities
+        under the law. They govern your use of, and relationship with,
+        the digital prison visit request service. They don’t apply to
+        other services provided by the Ministry of Justice (HM Prison
+        Service), or to any other department or service which is linked
+        to in this service.</p>
+
+        <p>We may occasionally update these terms and conditions. This
+        might happen if there’s a change in the law or to the way this
+        service works. If there’s a change, you’ll be asked to agree to
+        the new terms and conditions the next time you sign in, so you
+        can continue to use this service.</p>
+
+        <p>If you don’t agree to the terms and conditions and privacy
+        policy set out in this document, you should not use this
+        service.</p>
+
+        <h3>Applicable law</h3>
+
+        <p>Your use of this service and any dispute arising from its use
+        will be governed by and construed in accordance with the laws of
+        England and Wales, including but not limited to the:</p>
+
+        <ul>
+          <li>Computer Misuse Act 1990</li>
+          <li>Data Protection Act 1998</li>
+          <li>Mental Capacity Act 2005</li>
+        </ul>
+
+        <h3>How to use this service responsibly</h3>
+
+        <p>There are risks in using a shared computer, such as in an
+        internet café, to use this service. It’s your responsibility to
+        be aware of these risks and to avoid using any computer which may
+        leave your personal information accessible to others. You are
+        responsible if you choose to leave a computer unprotected while
+        in the process of making a prison visit request.</p>
+
+        <p>We make every effort to check and test this service whenever
+        we amend or update it. However, you must take your own
+        precautions to ensure that the way you access this service does
+        not expose you to the risk of viruses, malicious computer code or
+        other forms of interference which may damage your own computer
+        system.</p>
+
+        <p>You must not misuse our service by knowingly introducing
+        viruses, trojans, worms, logic bombs or other material which is
+        malicious or technologically harmful. You must not attempt to
+        gain unauthorised access to our service, the system on which our
+        service is stored or any server, computer or database connected
+        to our service. You must not attack our site via a
+        denial-of-service attack or a distributed denial-of-service
+        attack.</p>
+
+        <h2>Privacy policy</h2>
+
+        <h3>Information provided by this service</h3>
+
+        <p>We work hard to ensure that information within this prison
+        visit request service is accurate. However, we can’t guarantee
+        the accuracy and completeness of any information at all
+        times.</p>
+
+        <p>While we make every effort to ensure this service is
+        accessible at all times, we are not liable if it is unavailable
+        for any period of time.</p>
+
+        <h3>How we use your information</h3>
+
+        <p>The Ministry of Justice (HM Prison Service) uses and retains
+        the personal data of visitors for the purposes of the safe and
+        secure provision of Prison Services, including those related to
+        the management and rehabilitation of offenders.</p>
+
+        <p>Access to the establishment can only be granted by supplying
+        the prescribed information in order to ensure and maintain a safe
+        and secure environment for all.</p>
+
+        <p>You have the right to request details as to the personal
+        information we hold for you; and subsequently request that we
+        correct any personal information if it is found to be inaccurate
+        or out of date. We will not share your information with other
+        organisations unless it is required for the purposes of
+        prevention, detection of crime, apprehension, prosecution, and
+        management of offenders; prevention of terrorism; national
+        security; or required to do by law.</p>
+
+        <p>Separately from the information entered by those using this
+        service, we also collect site-usage information which allows us
+        to see how the service is being used in order to allow us to
+        improve it. This information does not contain any personal
+        data.</p>
+
+        <p>It includes:</p>
+
+        <ul>
+          <li>questions, queries or feedback you leave, including your
+          email address if you send a message via feedback</li>
+
+          <li>your IP address, and details of which version of web
+          browser you used</li>
+
+          <li>information on how you use the site, using cookies and page
+          tagging techniques to help us improve the website</li>
+        </ul>
+
+        <p>This helps us to:</p>
+
+        <ul>
+          <li>improve the site by monitoring how you use it</li>
+
+          <li>respond to any feedback you send us, if you’ve asked us
+          to</li>
+
+          <li>provide you with information about local services if you
+          want it</li>
+        </ul>
+
+        <p>We can’t personally identify you using your data.</p>
+
+        <h3>Where your data is stored</h3>
+
+        <p>We store your data on our secure servers in the UK. However,
+        it may also be stored outside of Europe, where it could be viewed
+        by our staff or suppliers. By submitting your personal data, you
+        agree to this.</p>
+
+        <p>We also use other suppliers to provide this service:</p>
+
+        <ul>
+          <li><a href="http://sendgrid.com" rel="external">SendGrid</a> to
+          relay information to prisons. See the
+          <a href="http://sendgrid.com/tos" rel="external">terms &amp;
+          conditions</a> attached to this service.</li>
+
+          <li><a href="http://www.zendesk.com" rel="external">ZenDesk</a> to
+          handle any feedback that you leave. See the
+          <a href="http://www.zendesk.com/company/terms" rel="external">terms
+          &amp; conditions</a> attached to this service.</li>
+        </ul>
+
+        <h3>Keeping your data secure</h3>
+
+        <p>Transmitting information over the internet is generally not
+        completely secure, and we can’t guarantee the security of your
+        data. We do however use SSL in order to encrypt all data
+        transferred to and received from our server.</p>
+
+        <p>We take data security very seriously and we take every step to
+        ensure that your data remains private and secure.</p>
+
+        <h3>Any data you transmit is at your own risk.</h3>
+
+        <p>We have procedures and security features in place to try and
+        keep your data secure once we receive it.</p>
+
+        <p>We won’t share your information with any other organisations
+        for marketing, market research or commercial purposes, and we
+        don’t pass on your details to other websites.</p>
+
+        <h3>Disclosing your information</h3>
+
+        <p>We may pass on your personal information if we have a legal
+        obligation to do so.</p>
+
+        <h3>How we manage sessions</h3>
+
+        <p>This service can be used to make a prison visit request. Your
+        session is active for 20 minutes even if you close your browser,
+        or navigate away from this service. During this time, personal
+        information about you may be visible to anyone with access to
+        your computer.</p>
+
+        <p>Your data is held in memory during the duration of the
+        session; this is cleared after 20 minutes of inactivity.</p>
+
+        <h3>Data Protection Act 1998</h3>
+
+        <p>This service complies with all principles of the DPA 1998.</p>
+
+        <p>Ministry of Justice (MoJ) is the ‘data controller’ for the
+        purposes of the Act. However, the information you enter into this
+        service is not automatically transmitted to the Ministry of
+        Justice, but is stored in a secure database. No personal data
+        will be used in testing this service.</p>
+
+        <p>Our hosting provider, and MoJ staff responsible for supporting
+        this service, will have access to the server in which all
+        personal information entered into this service is momentarily
+        stored. All staff who have access to the secure data have MoJ
+        security clearance.</p>
+
+        <p>Anyone who believes their personal data is kept within this
+        service has the right to submit a subject access request to the
+        MoJ, who will give details of the information stored on the
+        server.</p>
+
+        <h3>Disclaimer</h3>
+
+        <p>We don’t accept liability for loss or damage incurred by users
+        of this service, whether direct, indirect or consequential,
+        whether caused by tort, breach of contract or otherwise. This
+        includes loss of income or revenue, business, profits or
+        contracts, anticipated savings, data, goodwill, tangible property
+        or wasted time in connection with this service or any websites
+        linked to it and any materials posted on it. This condition shall
+        not prevent claims for loss of or damage to your tangible
+        property or any other claims for direct financial loss that are
+        not excluded by any of the categories set out above.</p>
+
+        <p>This does not affect our liability for death or personal
+        injury arising from our negligence, nor our liability for
+        fraudulent misrepresentation or misrepresentation as to a
+        fundamental matter, nor any other liability which cannot be
+        excluded or limited under applicable law.</p>
+
+        <h3>Contact us</h3>
+
+        <p>Ministry of Justice<br />
+        Digital Services, 11.51<br />
+        102 Petty France<br />
+        London SW1H 9AJ United Kingdom</p>

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -1,6 +1,7 @@
 en:
   pages:
     unsubscribe:
+      title: Why did I receive this email?
       you_received_an_email: You’ve received an email from %{email}
       why: This is probably because you requested a prison visit.
       confirmation: >-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   end
 
   controller 'high_voltage/pages' do
+    get 'cookies', action: :show, id: 'cookies'
     get 'terms-and-conditions', action: :show, id: 'terms_and_conditions'
     get 'unsubscribe', action: :show, id: 'unsubscribe'
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,10 @@ Rails.application.routes.draw do
     end
   end
 
-  get 'unsubscribe' => 'high_voltage/pages#show', id: 'unsubscribe'
+  controller 'high_voltage/pages' do
+    get 'terms-and-conditions', action: :show, id: 'terms_and_conditions'
+    get 'unsubscribe', action: :show, id: 'unsubscribe'
+  end
 
   constraints format: 'json' do
     get 'ping', to: 'ping#index'


### PR DESCRIPTION
This adds the terms and conditions and cookie pages, ported from the previous app.

Dumping a load of HTML into the locale file doesn't seem ideal, but breaking down each paragraph of legalese would be pointlessly onerous.