### PR TITLE
Add missing date in ack email

### DIFF
--- a/app/views/visitor_mailer/request_acknowledged.html.erb
+++ b/app/views/visitor_mailer/request_acknowledged.html.erb
@@ -12,7 +12,8 @@
         when: format_date_without_year(@visit.confirm_by)) %>
 </p>
 <p>
-  <%= t('.when_to_check_spam', when: 'TODO') %>
+  <%= t('.when_to_check_spam',
+        when: format_date_without_year(@visit.confirm_by)) %>
 </p>
 <h1>
   <%= t('.avoid_spam_filtering') %>


### PR DESCRIPTION
The date for checking the spam folder is the same as the date by which the applicant should expect a response.