### PR TITLE
Show a proper thank you/info page after a request is processed

### DIFF
--- a/app/views/prison/visits/update.html.erb
+++ b/app/views/prison/visits/update.html.erb
@@ -1,1 +1,7 @@
-<p>TODO success message</p>
+<% content_for :header do %>
+  <%= t('.title') %>
+<% end %>
+
+<p>
+  <%= t(".#{@booking_response.processing_state_name}") %>
+</p>

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -152,6 +152,10 @@ en:
     visits:
       calendar:
         today: Today
+      update:
+        title: Thank you
+        booked: A confirmation email has been sent to the visitor.
+        rejected: A rejection email has been sent to the visitor.
       show:
         title: Process a visit request
         introduction_html: |

--- a/spec/features/override_sendgrid_spec.rb
+++ b/spec/features/override_sendgrid_spec.rb
@@ -27,11 +27,11 @@ RSpec.feature "overriding Sendgrid", js: true do
       check 'Tick this box to confirm you’d like us to try sending messages to you again'
       click_button 'Continue'
 
-      expect(page).to have_content('When do you want to visit?')
+      expect(page).to have_text('When do you want to visit?')
       select_slots
       click_button 'Continue'
 
-      expect(page).to have_content('Check your request')
+      expect(page).to have_text('Check your request')
 
       expect(SendgridApi).to receive(:remove_from_spam_list).
         with(expected_email_address).
@@ -41,7 +41,7 @@ RSpec.feature "overriding Sendgrid", js: true do
 
       click_button 'Send request'
 
-      expect(page).to have_content('Your request is being processed')
+      expect(page).to have_text('Your request is being processed')
     end
   end
 
@@ -59,11 +59,11 @@ RSpec.feature "overriding Sendgrid", js: true do
       check 'Tick this box to confirm you’d like us to try sending messages to you again'
       click_button 'Continue'
 
-      expect(page).to have_content('When do you want to visit?')
+      expect(page).to have_text('When do you want to visit?')
       select_slots
       click_button 'Continue'
 
-      expect(page).to have_content('Check your request')
+      expect(page).to have_text('Check your request')
 
       expect(SendgridApi).to receive(:remove_from_bounce_list).
         with(expected_email_address).
@@ -73,7 +73,7 @@ RSpec.feature "overriding Sendgrid", js: true do
 
       click_button 'Send request'
 
-      expect(page).to have_content('Your request is being processed')
+      expect(page).to have_text('Your request is being processed')
     end
   end
 
@@ -84,17 +84,17 @@ RSpec.feature "overriding Sendgrid", js: true do
     enter_visitor_information email_address: expected_email_address
     click_button 'Continue'
 
-    expect(page).to have_content('When do you want to visit?')
+    expect(page).to have_text('When do you want to visit?')
     select_slots
     click_button 'Continue'
 
-    expect(page).to have_content('Check your request')
+    expect(page).to have_text('Check your request')
 
     expect(SendgridApi).to_not receive(:remove_from_bounce_list)
     expect(SendgridApi).to_not receive(:remove_from_spam_list)
 
     click_button 'Send request'
 
-    expect(page).to have_content('Your request is being processed')
+    expect(page).to have_text('Your request is being processed')
   end
 end

--- a/spec/features/process_a_request_spec.rb
+++ b/spec/features/process_a_request_spec.rb
@@ -33,8 +33,8 @@ RSpec.feature 'Processing a request', js: true do
     let(:vst) { create(:withdrawn_visit) }
 
     scenario 'is not allowed' do
-      expect(page.body).to have_content('The visitor has withdrawn this request')
-      expect(page.body).not_to have_content('Send email')
+      expect(page).to have_text('The visitor has withdrawn this request')
+      expect(page).not_to have_text('Send email')
     end
   end
 
@@ -42,8 +42,8 @@ RSpec.feature 'Processing a request', js: true do
     let(:vst) { create(:cancelled_visit) }
 
     scenario 'is not allowed' do
-      expect(page.body).to have_content('The visitor has cancelled this booking')
-      expect(page.body).not_to have_content('Send email')
+      expect(page).to have_text('The visitor has cancelled this booking')
+      expect(page).not_to have_text('Send email')
     end
   end
 
@@ -51,8 +51,8 @@ RSpec.feature 'Processing a request', js: true do
     let(:vst) { create(:booked_visit) }
 
     scenario 'is not allowed' do
-      expect(page.body).to have_content('This request has already been accepted')
-      expect(page.body).not_to have_content('Send email')
+      expect(page).to have_text('This request has already been accepted')
+      expect(page).not_to have_text('Send email')
     end
   end
 
@@ -60,8 +60,8 @@ RSpec.feature 'Processing a request', js: true do
     let(:vst) { create(:rejected_visit) }
 
     scenario 'is not allowed' do
-      expect(page.body).to have_content('This request has already been rejected')
-      expect(page.body).not_to have_content('Send email')
+      expect(page).to have_text('This request has already been rejected')
+      expect(page).not_to have_text('Send email')
     end
   end
 

--- a/spec/features/process_a_request_spec.rb
+++ b/spec/features/process_a_request_spec.rb
@@ -71,6 +71,8 @@ RSpec.feature 'Processing a request', js: true do
 
     click_button 'Send email'
 
+    expect(page).to have_text('A confirmation email has been sent to the visitor')
+
     vst.reload
     expect(vst).to be_booked
     expect(vst.reference_no).to eq('12345678')
@@ -89,6 +91,8 @@ RSpec.feature 'Processing a request', js: true do
     choose 'None of the chosen times are available'
 
     click_button 'Send email'
+
+    expect(page).to have_text('A rejection email has been sent to the visitor')
 
     vst.reload
     expect(vst).to be_rejected
@@ -113,6 +117,8 @@ RSpec.feature 'Processing a request', js: true do
 
     click_button 'Send email'
 
+    expect(page).to have_text('A rejection email has been sent to the visitor')
+
     vst.reload
     expect(vst).to be_rejected
     expect(vst.rejection_reason).to eq('no_allowance')
@@ -134,6 +140,8 @@ RSpec.feature 'Processing a request', js: true do
 
     click_button 'Send email'
 
+    expect(page).to have_text('A rejection email has been sent to the visitor')
+
     vst.reload
     expect(vst.rejection_reason).to eq('prisoner_details_incorrect')
     expect(vst).to be_rejected
@@ -152,6 +160,8 @@ RSpec.feature 'Processing a request', js: true do
     choose 'Prisoner no longer at the prison'
 
     click_button 'Send email'
+
+    expect(page).to have_text('A rejection email has been sent to the visitor')
 
     vst.reload
     expect(vst.rejection_reason).to eq('prisoner_moved')
@@ -175,6 +185,8 @@ RSpec.feature 'Processing a request', js: true do
 
     click_button 'Send email'
 
+    expect(page).to have_text('A rejection email has been sent to the visitor')
+
     vst.reload
     expect(vst.rejection_reason).to eq('visitor_not_on_list')
     expect(vst).to be_rejected
@@ -197,6 +209,8 @@ RSpec.feature 'Processing a request', js: true do
     end
 
     click_button 'Send email'
+
+    expect(page).to have_text('A rejection email has been sent to the visitor')
 
     vst.reload
     expect(vst.rejection_reason).to eq('visitor_banned')


### PR DESCRIPTION
This was just a TODO. It now thanks the operator and informs them of what the system is doing.