### PR TITLE
Remove personal information after one month

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,20 @@ $ bundle exec rackup sidekiq-admin.ru
 
 This requires the `SESSION_SECRET_KEY` environment variable (see below).
 
+## Removing old personal information
+
+The agreed privacy impact assessment for this service states that personal
+details will be purged after one month. To achieve this, a Rake task must be
+run at least once a day:
+
+```sh
+$ bundle exec rake remove_old_personal_information
+```
+
+This will anonymise all personal data in database rows that are more than a
+month old by replacing the sensitive fields with `REMOVED` or 1 January in the
+year 1 CE.
+
 ## Configuration
 
 ### Development

--- a/app/models/concerns/freshness_calculations.rb
+++ b/app/models/concerns/freshness_calculations.rb
@@ -1,0 +1,5 @@
+module FreshnessCalculations
+  def older_than(date)
+    where(arel_table[:created_at].lt(date))
+  end
+end

--- a/app/models/prisoner.rb
+++ b/app/models/prisoner.rb
@@ -1,5 +1,6 @@
 class Prisoner < ActiveRecord::Base
   include Person
+  extend FreshnessCalculations
 
   has_many :visits, dependent: :destroy
   validates :number, presence: true

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -1,4 +1,6 @@
 class Visit < ActiveRecord::Base
+  extend FreshnessCalculations
+
   belongs_to :prison
   belongs_to :prisoner
   has_many :visitors, dependent: :destroy

--- a/app/models/visitor.rb
+++ b/app/models/visitor.rb
@@ -1,5 +1,6 @@
 class Visitor < ActiveRecord::Base
   include Person
+  extend FreshnessCalculations
 
   belongs_to :visit
   validates :visit, :sort_index, presence: true

--- a/app/services/depersonalizer.rb
+++ b/app/services/depersonalizer.rb
@@ -1,0 +1,16 @@
+class Depersonalizer
+  STRING = 'REMOVED'
+  DATE = Date.new(1, 1, 1)
+
+  def remove_personal_information(cutoff_date)
+    Prisoner.older_than(cutoff_date).update_all \
+      first_name: STRING, last_name: STRING,
+      number: STRING, date_of_birth: DATE
+
+    Visitor.older_than(cutoff_date).update_all \
+      first_name: STRING, last_name: STRING, date_of_birth: DATE
+
+    Visit.older_than(cutoff_date).update_all \
+      contact_email_address: STRING, contact_phone_no: STRING
+  end
+end

--- a/lib/tasks/personal_information.rake
+++ b/lib/tasks/personal_information.rake
@@ -1,0 +1,4 @@
+task remove_old_personal_information: :environment do
+  cutoff = Time.zone.now - 1.month
+  Depersonalizer.new.remove_personal_information cutoff
+end

--- a/spec/services/depersonalizer_spec.rb
+++ b/spec/services/depersonalizer_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe Depersonalizer do
+  let(:cutoff_date) { Time.zone.now - 30.days }
+
+  context 'when processing prisoners' do
+    let!(:prisoner) {
+      create(
+        :prisoner,
+        first_name: 'Oscar',
+        last_name: 'Wilde',
+        date_of_birth: Date.new(1980, 1, 1),
+        number: 'ABC1234'
+      )
+    }
+
+    it 'anonymises prisoners older than the cutoff date' do
+      subject.remove_personal_information(Time.zone.now + 1.day)
+      expect(prisoner.reload).to have_attributes(
+        first_name: 'REMOVED',
+        last_name: 'REMOVED',
+        date_of_birth: Date.new(1, 1, 1),
+        number: 'REMOVED'
+      )
+    end
+
+    it 'does not anonymise prisoners newer than the cutoff date' do
+      subject.remove_personal_information(Time.zone.now - 1.day)
+      expect(prisoner.reload).to have_attributes(
+        first_name: 'Oscar',
+        last_name: 'Wilde',
+        date_of_birth: Date.new(1980, 1, 1),
+        number: 'ABC1234'
+      )
+    end
+  end
+
+  context 'when processing visitors' do
+    let!(:visitor) {
+      create(
+        :visitor,
+        first_name: 'Ada',
+        last_name: 'Lovelace',
+        date_of_birth: Date.new(1970, 2, 3)
+      )
+    }
+
+    it 'anonymises visitors older than the cutoff date' do
+      subject.remove_personal_information(Time.zone.now + 1.day)
+      expect(visitor.reload).to have_attributes(
+        first_name: 'REMOVED',
+        last_name: 'REMOVED',
+        date_of_birth: Date.new(1, 1, 1)
+      )
+    end
+
+    it 'does not anonymise visitors newer than the cutoff date' do
+      subject.remove_personal_information(Time.zone.now - 1.day)
+      expect(visitor.reload).to have_attributes(
+        first_name: 'Ada',
+        last_name: 'Lovelace',
+        date_of_birth: Date.new(1970, 2, 3)
+      )
+    end
+  end
+
+  context 'when processing visits' do
+    let!(:visit) {
+      create(
+        :visit,
+        contact_email_address: 'user@example.com',
+        contact_phone_no: '0115 4960123'
+      )
+    }
+
+    it 'anonymises visits older than the cutoff date' do
+      subject.remove_personal_information(Time.zone.now + 1.day)
+      expect(visit.reload).to have_attributes(
+        contact_email_address: 'REMOVED',
+        contact_phone_no: 'REMOVED'
+      )
+    end
+
+    it 'does not anonymise visits newer than the cutoff date' do
+      subject.remove_personal_information(Time.zone.now - 1.day)
+      expect(visit.reload).to have_attributes(
+        contact_email_address: 'user@example.com',
+        contact_phone_no: '0115 4960123'
+      )
+    end
+  end
+end


### PR DESCRIPTION
In order to meet the agreed privacy requirements, we want to eliminate personal data from the database after a month.

Personal data is defined for these purposes as:

* Prisoner Name
* Prisoner DOB
* Prisoner Number
* Prisoner Location
* Visitor Name
* Visitor DOB
* Visitor Phone No.
* Visitor Email
* Visitor IP Address

Of these, the application does not record IP addresses. Location is required for metrics, but ceases to be personal when all the other prisoner information has been scrubbed.

To retain information for metrics and so that we can continue to rely on database constraints, we do this by replacing the sensitive data with `REMOVED` or 1 January in the year 1 CE.  (There is, of course, no year zero in our calendar.)