### PR TITLE
Account for IPv6 when restricting admin access

### DIFF
--- a/app/services/ip_address_matcher.rb
+++ b/app/services/ip_address_matcher.rb
@@ -6,7 +6,13 @@ class IpAddressMatcher
   end
 
   def include?(addr)
-    @cidrs.any? { |cidr| cidr.matches?(addr) }
+    @cidrs.any? do |cidr|
+      begin
+        cidr.matches?(addr)
+      rescue NetAddr::ValidationError
+        false
+      end
+    end
   end
 
   alias_method :===, :include?

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,6 @@ module PrisonVisits
     config.action_dispatch.rescue_responses.merge!(
       'StateMachines::InvalidTransition' => :unprocessable_entity
     )
-
-    config.prison_ip_ranges = ENV.fetch('PRISON_ESTATE_IPS', '127.0.0.1')
+    config.prison_ip_ranges = ENV.fetch('PRISON_ESTATE_IPS', '127.0.0.1,::1')
   end
 end

--- a/spec/services/ip_address_matcher_spec.rb
+++ b/spec/services/ip_address_matcher_spec.rb
@@ -28,4 +28,22 @@ RSpec.describe IpAddressMatcher do
     expect(matcher).to include('127.0.0.1')
     expect(matcher).not_to include('12.33.44.44')
   end
+
+  it 'matches a single IPv6 address' do
+    matcher = described_class.new('2001:4860:4860::8888')
+    expect(matcher).to include('2001:4860:4860::8888')
+    expect(matcher).not_to include('2001:4860:4860::8844')
+  end
+
+  it 'matches both IPv4 and IPv6 addresses' do
+    matcher = described_class.new('12.34.56.78,2001:4860:4860::8888')
+    expect(matcher).to include('2001:4860:4860::8888')
+    expect(matcher).to include('12.34.56.78')
+  end
+
+  it 'can match the IPv6 loopback' do
+    matcher = described_class.new('::1')
+    expect(matcher).to include('::1')
+    expect(matcher).not_to include('2001:4860:4860::8844')
+  end
 end


### PR DESCRIPTION
This is unlikely to be a problem for a while, but I ran into trying to
smoke test the app on my development machine. As it was, the constraint
would raise an exception when it encountered an IPv6 address.  Now, it
treats them exactly the same as IPv4 addresses.