### PR TITLE
Remove import:all, which isn't necessary here

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -15,5 +15,5 @@ migrate)
     bundle exec rake db:schema:load
     ;;
 esac
-bundle exec import:all assets:precompile
+bundle exec rake assets:precompile
 bundle exec rails server --binding 0.0.0.0


### PR DESCRIPTION
... which turns out to be a leftover from the different project.