### PR TITLE
Require 'rails_helper' consistently

### DIFF
--- a/spec/services/available_slot_enumerator_spec.rb
+++ b/spec/services/available_slot_enumerator_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe AvailableSlotEnumerator do
   subject {
     described_class.new(

--- a/spec/services/ip_address_matcher_spec.rb
+++ b/spec/services/ip_address_matcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe IpAddressMatcher do
   it 'matches a single IP address' do

--- a/spec/services/link_directory_spec.rb
+++ b/spec/services/link_directory_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 RSpec.describe LinkDirectory do
   subject {

--- a/spec/services/mx_checker_spec.rb
+++ b/spec/services/mx_checker_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe MxChecker do
   subject { described_class.new(resolver) }
   let(:resolver) { double('Resolv::DNS') }

--- a/spec/services/parameter_pruner_spec.rb
+++ b/spec/services/parameter_pruner_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe ParameterPruner do
   it 'removes hashes with blank values' do
     input = { 'foo' => '', 'bar' => 'baz' }

--- a/spec/services/sendgrid_api_shared_context.rb
+++ b/spec/services/sendgrid_api_shared_context.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.shared_context 'sendgrid shared tools' do
   let(:logger) { Rails.logger }
   let(:body) { '[]' }

--- a/spec/services/slot_details_parser_spec.rb
+++ b/spec/services/slot_details_parser_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe SlotDetailsParser do
   subject { described_class.new(raw) }
 


### PR DESCRIPTION
Noticed that some specs here were requiring 'spec_helper' and some
weren't requiring anyting at all.  I changed them all to use
'rails_helper' as per standard practice.