### PR TITLE
Fix linked redis container port

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -16,5 +16,5 @@ migrate)
     ;;
 esac
 bundle exec rake assets:precompile
-REDIS_URL="redis://redis:16379" bundle exec sidekiq -d -l /var/log/sidekiq.log --environment production
+REDIS_URL="redis://redis:6379" bundle exec sidekiq -d -l /var/log/sidekiq.log --environment production
 bundle exec rails server --binding 0.0.0.0


### PR DESCRIPTION
Turns out that linked container operates on it's "container" port, not the "host" redirected one.