### PR TITLE
Configure test metadata for CircleCI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development, :test do
   gem 'byebug'
   gem 'pry-byebug'
   gem 'pry-rails'
+  gem 'rspec_junit_formatter', '0.2.2'
   gem 'rspec-rails', '~> 3.0'
   gem 'rubocop'
   gem 'rubocop-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,6 +218,9 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    rspec_junit_formatter (0.2.2)
+      builder (< 4)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.35.1)
       astrolabe (~> 1.3)
       parser (>= 2.2.3.0, < 3.0)
@@ -343,6 +346,7 @@ DEPENDENCIES
   puma
   rails (~> 4.2.3)
   rspec-rails (~> 3.0)
+  rspec_junit_formatter (= 0.2.2)
   rubocop
   rubocop-rspec
   sass-rails (~> 5.0)


### PR DESCRIPTION
CircleCI is showing a large pink banner warning that it cannot collect metadata. This attempts to fix that.

See https://circleci.com/docs/test-metadata