### PR TITLE
Track state changes with a has many association

### DIFF
--- a/app/models/visit_state_change.rb
+++ b/app/models/visit_state_change.rb
@@ -1,0 +1,8 @@
+class VisitStateChange < ActiveRecord::Base
+  belongs_to :visit
+
+  scope :booked, -> { where(visit_state: 'booked') }
+  scope :rejected, -> { where(visit_state: 'rejected') }
+  scope :withdrawn, -> { where(visit_state: 'withdrawn') }
+  scope :cancelled, -> { where(visit_state: 'cancelled') }
+end

--- a/db/migrate/20160105112652_create_visit_state_changes.rb
+++ b/db/migrate/20160105112652_create_visit_state_changes.rb
@@ -1,0 +1,10 @@
+class CreateVisitStateChanges < ActiveRecord::Migration
+  def change
+    create_table :visit_state_changes, id: :uuid do |t|
+      t.string :visit_state
+      t.uuid :visit_id, index: true, foreign_key: true, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160105150712_remove_datetimes_for_tracking_metrics_from_visit.rb
+++ b/db/migrate/20160105150712_remove_datetimes_for_tracking_metrics_from_visit.rb
@@ -1,0 +1,8 @@
+class RemoveDatetimesForTrackingMetricsFromVisit < ActiveRecord::Migration
+  def change
+    remove_column :visits, :accepted_at
+    remove_column :visits, :rejected_at
+    remove_column :visits, :withdrawn_at
+    remove_column :visits, :cancelled_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151222125110) do
+ActiveRecord::Schema.define(version: 20160105150712) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,15 @@ ActiveRecord::Schema.define(version: 20151222125110) do
 
   add_index "rejections", ["visit_id"], name: "index_rejections_on_visit_id", unique: true, using: :btree
 
+  create_table "visit_state_changes", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
+    t.string   "visit_state"
+    t.uuid     "visit_id",    null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
+  add_index "visit_state_changes", ["visit_id"], name: "index_visit_state_changes_on_visit_id", using: :btree
+
   create_table "visitors", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.uuid     "visit_id",      null: false
     t.string   "first_name",    null: false
@@ -95,10 +104,6 @@ ActiveRecord::Schema.define(version: 20151222125110) do
     t.string   "reference_no"
     t.boolean  "closed"
     t.uuid     "prisoner_id",                                   null: false
-    t.datetime "accepted_at"
-    t.datetime "rejected_at"
-    t.datetime "withdrawn_at"
-    t.datetime "cancelled_at"
   end
 
   add_index "visits", ["prison_id"], name: "index_visits_on_prison_id", using: :btree

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -61,35 +61,40 @@ RSpec.describe Visit, type: :model do
       expect(subject).not_to be_processable
     end
 
-    context 'transition time' do
-      let(:time) { Time.new(2015, 12, 01, 12, 00, 00).utc }
-
-      around do |example|
-        travel_to(time) do
-          example.run
-        end
-      end
+    context '.visit_state_changes' do
+      it { should have_many(:visit_state_changes) }
 
       it 'is recorded after accepting' do
-        expect { subject.accept! }.to change { subject.accepted_at }.
-          from(nil).to(time)
+        expect{
+          subject.accept!
+        }.to change {
+          subject.visit_state_changes.booked.count
+        }.by(1)
       end
 
       it 'is recorded after rejection' do
-        expect { subject.reject! }.to change { subject.rejected_at }.
-          from(nil).to(time)
+        expect{
+          subject.reject!
+        }.to change {
+          subject.visit_state_changes.rejected.count
+        }.by(1)
       end
 
       it 'is recorded after withdrawal' do
-        expect { subject.cancel! }.to change { subject.withdrawn_at }.
-          from(nil).to(time)
+        expect{
+          subject.cancel!
+        }.to change {
+          subject.visit_state_changes.withdrawn.count
+        }.by(1)
       end
 
       it 'is recorded after cancellation' do
         subject.accept!
-        subject.reload
-        expect { subject.cancel! }.
-          to change { subject.cancelled_at }.from(nil).to(time)
+        expect{
+          subject.cancel!
+        }.to change {
+          subject.visit_state_changes.cancelled.count
+        }.by(1)
       end
     end
   end

--- a/spec/models/visit_state_change_spec.rb
+++ b/spec/models/visit_state_change_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe VisitStateChange, type: :model do
+  it { should belong_to(:visit) }
+
+  describe 'scopes' do
+    let(:visit) { create(:visit) }
+
+    let(:booked) {
+      described_class.create(visit_state: 'booked', visit: visit)
+    }
+
+    let(:rejected) {
+      described_class.create(visit_state: 'rejected', visit: visit)
+    }
+
+    let(:cancelled) {
+      described_class.create(visit_state: 'cancelled', visit: visit)
+    }
+
+    let(:withdrawn) {
+      described_class.create(visit_state: 'withdrawn', visit: visit)
+    }
+
+    it 'has a booked scope' do
+      expect(described_class.booked).to match_array([booked])
+    end
+
+    it 'has a rejected scope' do
+      expect(described_class.rejected).to match_array([rejected])
+    end
+
+    it 'has a cancelled scope' do
+      expect(described_class.cancelled).to match_array([cancelled])
+    end
+
+    it 'has a withdrawn scope' do
+      expect(described_class.withdrawn).to match_array([withdrawn])
+    end
+  end
+end


### PR DESCRIPTION
Previously, I added named timestamps for each state.  After discussion
with Paul, it seemed more sensible to change this to use a has many
association where each change is tracked indiviudally. We can use the
created_at timestamp from VisitStateChange to calculate processing
times and this approach allows for new states to be added.