### PR TITLE
Extract estate to its own table

### DIFF
--- a/app/models/estate.rb
+++ b/app/models/estate.rb
@@ -1,0 +1,3 @@
+class Estate < ActiveRecord::Base
+  has_many :prisons
+end

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -6,6 +6,7 @@ class Prison < ActiveRecord::Base
   MIN_ADULTS = 1
 
   has_many :visits, dependent: :destroy
+  belongs_to :estate
 
   validates :estate, :name, :nomis_id, :slot_details, presence: true
   validates :enabled, inclusion: { in: [true, false] }

--- a/app/services/prison_seeder.rb
+++ b/app/services/prison_seeder.rb
@@ -19,9 +19,10 @@ class PrisonSeeder
   end
 
   def import(path, hash)
+    estate = Estate.find_or_create_by(name: hash.fetch('estate'))
     prison = Prison.find_or_initialize_by(id: uuid_for_path(path))
     entry = PrisonSeeder::SeedEntry.new(hash)
-    prison.update! entry.to_h
+    prison.update! entry.to_h.merge(estate: estate)
   rescue => err
     raise ImportFailure, "#{err} in #{path}"
   end

--- a/db/migrate/20160106102516_extract_estate_to_table.rb
+++ b/db/migrate/20160106102516_extract_estate_to_table.rb
@@ -1,0 +1,42 @@
+class ExtractEstateToTable < ActiveRecord::Migration
+  def up
+    create_table :estates, id: :uuid do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+
+    add_index :estates, :name, unique: true
+    add_column :prisons, :estate_id, :uuid
+
+    execute <<-SQL
+      INSERT INTO estates (name)
+      SELECT DISTINCT estate FROM prisons
+    SQL
+
+    execute <<-SQL
+      UPDATE prisons
+      SET estate_id = estates.id
+      FROM estates
+      WHERE estate = estates.name
+    SQL
+
+    change_column_null :prisons, :estate_id, false
+    remove_column :prisons, :estate
+    add_index :prisons, :estate_id
+    add_foreign_key :prisons, :estates
+  end
+
+  def down
+    add_column :prisons, :estate, :string
+
+    execute <<-SQL
+      UPDATE prisons
+      SET estate = estates.name
+      FROM estates
+      WHERE estate_id = estates.id
+    SQL
+
+    remove_column :prisons, :estate_id
+    drop_table :estates
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,11 +11,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160105150712) do
+ActiveRecord::Schema.define(version: 20160106102516) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
+
+  create_table "estates", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
+    t.string   "name",       null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "estates", ["name"], name: "index_estates_on_name", unique: true, using: :btree
 
   create_table "feedback_submissions", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.text     "body",          null: false
@@ -41,7 +49,6 @@ ActiveRecord::Schema.define(version: 20160105150712) do
     t.boolean  "enabled",                      default: true,  null: false
     t.integer  "booking_window",               default: 28,    null: false
     t.text     "address"
-    t.string   "estate"
     t.string   "email_address"
     t.string   "phone_no"
     t.json     "slot_details",                 default: {},    null: false
@@ -51,7 +58,10 @@ ActiveRecord::Schema.define(version: 20160105150712) do
     t.boolean  "weekend_processing",           default: false, null: false
     t.integer  "adult_age",                                    null: false
     t.string   "finder_slug",                                  null: false
+    t.uuid     "estate_id",                                    null: false
   end
+
+  add_index "prisons", ["estate_id"], name: "index_prisons_on_estate_id", using: :btree
 
   create_table "rejections", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.uuid     "visit_id",                        null: false
@@ -108,6 +118,7 @@ ActiveRecord::Schema.define(version: 20160105150712) do
 
   add_index "visits", ["prison_id"], name: "index_visits_on_prison_id", using: :btree
 
+  add_foreign_key "prisons", "estates"
   add_foreign_key "rejections", "visits"
   add_foreign_key "visitors", "visits"
   add_foreign_key "visits", "prisoners"

--- a/spec/factories/estates.rb
+++ b/spec/factories/estates.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :estate do
+    name do
+      FFaker::AddressUK.city
+    end
+  end
+end

--- a/spec/factories/prisons.rb
+++ b/spec/factories/prisons.rb
@@ -1,7 +1,9 @@
 FactoryGirl.define do
   factory :prison do
+    estate
+
     name do |p|
-      "#{p.estate} Open Prison"
+      "#{p.estate.name} Open Prison"
     end
 
     sequence :nomis_id do |n|
@@ -9,10 +11,6 @@ FactoryGirl.define do
     end
 
     enabled true
-
-    estate do
-      FFaker::AddressUK.city
-    end
 
     finder_slug do |p|
       p.name.parameterize


### PR DESCRIPTION
It makes reporting queries more straightforward if estate is normalised to a separate table rather than being a (possibly unique, possibly duplicated) string on each prison.