### PR TITLE
Validate the return status for requested pages

### DIFF
--- a/smoke_test/helpers/http_status_validation.rb
+++ b/smoke_test/helpers/http_status_validation.rb
@@ -1,0 +1,12 @@
+module HttpStatusValidation
+module_function
+
+  def validate_response_status!
+    if (400..599).include?(page.status_code)
+      puts "Failed: bad status #{page.status_code} for #{page.current_path}"
+      fail
+    end
+  end
+
+  private_class_method :validate_response_status!
+end

--- a/smoke_test/smoke_test.rb
+++ b/smoke_test/smoke_test.rb
@@ -4,6 +4,7 @@ require 'phantomjs/poltergeist'
 require 'capybara/poltergeist'
 
 require_relative 'helpers/imap_processor'
+require_relative 'helpers/http_status_validation'
 require_relative 'state'
 require_relative 'mail_box'
 require_relative 'steps/base_step'

--- a/smoke_test/steps/cancel_booking_page.rb
+++ b/smoke_test/steps/cancel_booking_page.rb
@@ -1,9 +1,13 @@
 module SmokeTest
   module Steps
     class CancelBookingPage < BaseStep
+      include HttpStatusValidation
+
       PAGE_PATH = %r{\A/visits/([0-9a-f-]){36}}
 
       def validate!
+        validate_response_status!
+
         unless PAGE_PATH.match page.current_path
           fail "expected #{PAGE_PATH}, got #{page.current_path}"
         end

--- a/smoke_test/steps/check_your_request_page.rb
+++ b/smoke_test/steps/check_your_request_page.rb
@@ -1,9 +1,13 @@
 module SmokeTest
   module Steps
     class CheckYourRequestPage < BaseStep
+      include HttpStatusValidation
+
       PAGE_PATH = '/request'
 
       def validate!
+        validate_response_status!
+
         if page.current_path != PAGE_PATH
           fail "expected #{PAGE_PATH}, got #{page.current_path}"
         end

--- a/smoke_test/steps/prisoner_page.rb
+++ b/smoke_test/steps/prisoner_page.rb
@@ -1,9 +1,13 @@
 module SmokeTest
   module Steps
     class PrisonerPage < BaseStep
+      include HttpStatusValidation
+
       PAGE_PATH = '/request'
 
       def validate!
+        validate_response_status!
+
         if page.current_path != PAGE_PATH
           fail "expected #{PAGE_PATH}, got #{page.current_path}"
         end

--- a/smoke_test/steps/process_visit_request_page.rb
+++ b/smoke_test/steps/process_visit_request_page.rb
@@ -1,9 +1,13 @@
 module SmokeTest
   module Steps
     class ProcessVisitRequestPage < BaseStep
+      include HttpStatusValidation
+
       PAGE_PATH = %r{/prison/visits/([0-9a-f-]){36}}
 
       def validate!
+        validate_response_status!
+
         unless page.current_path.match(PAGE_PATH)
           fail "expected #{PAGE_PATH} to match #{page.current_path}"
         end

--- a/smoke_test/steps/slots_page.rb
+++ b/smoke_test/steps/slots_page.rb
@@ -1,9 +1,13 @@
 module SmokeTest
   module Steps
     class SlotsPage < BaseStep
+      include HttpStatusValidation
+
       PAGE_PATH = '/request'
 
       def validate!
+        validate_response_status!
+
         if page.current_path != PAGE_PATH
           fail "expected #{PAGE_PATH}, got #{page.current_path}"
         end

--- a/smoke_test/steps/visitors_page.rb
+++ b/smoke_test/steps/visitors_page.rb
@@ -1,9 +1,13 @@
 module SmokeTest
   module Steps
     class VisitorsPage < BaseStep
+      include HttpStatusValidation
+
       PAGE_PATH = '/request'
 
       def validate!
+        validate_response_status!
+
         if page.current_path != PAGE_PATH
           fail "expected #{PAGE_PATH}, got #{page.current_path}"
         end


### PR DESCRIPTION
The smoke tests previously assumed that requests never failed. This
resulted in test failures where Capayabara could not find the trigger
content for the next step in the returned error page.

This fixes that by checking the return status as well as the current
path.