### PR TITLE
Move NOMIS ID and finder slug to estate and seed estates separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,11 @@ looks like `85c83a07-dd6a-43ea-ae41-af79e4a756d4`.)
 
 To add a prison, create a new YAML file in `db/seeds/prisons` and add a line to
 the mapping file. To generate a new UUID for the prison, you can type `uuidgen`
-on the command line in Linux or OS X.
+on the command line in Linux or OS X, or use a rake task:
+
+```sh
+$ rake maintenance:prison_uuids
+```
 
 #### Renaming a prison
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ booking separately. This might be separate wings with different visiting hours,
 or the main and high-security parts of a prison that are handled by different
 booking teams.
 
+The estate stores the NOMIS ID and Prison Finder link.
+
 #### `Visit`
 
 This is the main table in the application, and contains the essential data for
@@ -269,9 +271,7 @@ build information to be returned by `/ping.json`. e.g.:
 }
 ```
 
-### Prisons
-
-#### Editing prison data
+## Prison data
 
 Prison details are stored in YAML files in the `db/seeds` directory, and are
 synchronised to the database on deployment (by running `rake db:seed`). This is
@@ -285,6 +285,42 @@ with edge cases, so be careful.
 For the purposes of this application, a **prison** is a visitable location
 within an **estate**. There will be more than one prison if different parts of
 the estate have different visiting times or booking teams.
+
+Estates are seeded via the `estates.yml` file.
+
+### Estates
+
+`estates.yml` is formatted thus:
+
+```yaml
+LNX: # NOMIS ID
+  name: Lunar Penal Colony
+  finder_slug: moonbase
+MRX:
+  name: Martian Correctional Facility
+```
+
+An estate can be added by adding a new entry to the file. The name or finder
+slug can be changed as long as the NOMIS ID remains the same.
+
+It is not possible to delete an estate: removing it from the seed data will not
+remove it from the database.
+
+#### Prison finder links
+
+When the service links to [Prison
+Finder](https://www.justice.gov.uk/contacts/prison-finder), it turns the estate
+name into part of the URL. For example, 'Drake Hall' becomes
+[drake-hall](https://www.justice.gov.uk/contacts/prison-finder/drake-hall).
+
+When the Prison Finder link does not simply match the estate name in lower
+case with spaces replaced with hyphens, use the `finder_slug` field:
+
+```yaml
+finder_slug: sheppey-cluster-standford-hill
+```
+
+### Prisons
 
 #### Prison visibility
 
@@ -300,6 +336,9 @@ To disable visit requests to a prison, set `enabled` to `false`.
   ...
 
 ```
+
+Each prison **must** have a `nomis_id` field that corresponds to an entry in
+`estates.yml`.
 
 #### Weekly visiting slots
 
@@ -374,20 +413,6 @@ weekends. This will allow visits to be requested 3 days ahead (or custom
 
 ```yaml
 works_weekends: true
-```
-
-#### Prison finder links
-
-When the service links to [Prison
-Finder](https://www.justice.gov.uk/contacts/prison-finder), it turns the prison
-name into part of the URL. For example, 'Drake Hall' becomes
-[drake-hall](https://www.justice.gov.uk/contacts/prison-finder/drake-hall).
-
-When the Prison Finder link does not simply match the prison name in lower
-case with spaces replaced with hyphens, use this.
-
-```yaml
-finder_slug: sheppey-cluster-standford-hill
 ```
 
 #### Adult age

--- a/app/models/estate.rb
+++ b/app/models/estate.rb
@@ -1,3 +1,5 @@
 class Estate < ActiveRecord::Base
   has_many :prisons
+
+  validates :name, :nomis_id, :finder_slug, presence: true
 end

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -8,13 +8,14 @@ class Prison < ActiveRecord::Base
   has_many :visits, dependent: :destroy
   belongs_to :estate
 
-  validates :estate, :name, :nomis_id, :slot_details, presence: true
+  validates :estate, :name, :slot_details, presence: true
   validates :enabled, inclusion: { in: [true, false] }
   validates :email_address, presence: true, if: :enabled?
   validate :validate_unbookable_dates
 
   delegate :recurring_slots, :anomalous_slots, :unbookable_dates,
     to: :parsed_slot_details
+  delegate :finder_slug, to: :estate
 
   def self.enabled
     where(enabled: true).order(name: :asc)

--- a/app/services/estate_seeder.rb
+++ b/app/services/estate_seeder.rb
@@ -1,0 +1,17 @@
+class EstateSeeder
+  ImportFailure = Class.new(StandardError)
+
+  def self.seed!(base_path)
+    estates = YAML.load(File.read(base_path.join('estates.yml')))
+    seeder = new
+    estates.each do |nomis_id, attributes|
+      seeder.import nomis_id, attributes
+    end
+  end
+
+  def import(nomis_id, attributes)
+    estate = Estate.find_or_initialize_by(nomis_id: nomis_id)
+    entry = EstateSeeder::SeedEntry.new(nomis_id, attributes)
+    estate.update! entry.to_h
+  end
+end

--- a/app/services/estate_seeder/seed_entry.rb
+++ b/app/services/estate_seeder/seed_entry.rb
@@ -1,0 +1,24 @@
+class EstateSeeder::SeedEntry
+  KEYS = %i[ nomis_id name finder_slug ]
+
+  def initialize(nomis_id, hash)
+    @nomis_id = nomis_id
+    @hash = hash
+  end
+
+  def to_h
+    KEYS.inject({}) { |a, e| a.merge(e => send(e)) }
+  end
+
+private
+
+  attr_reader :hash, :nomis_id
+
+  def finder_slug
+    hash.fetch('finder_slug') { hash.fetch('name').parameterize }
+  end
+
+  def name
+    hash.fetch('name')
+  end
+end

--- a/app/services/prison_seeder.rb
+++ b/app/services/prison_seeder.rb
@@ -19,7 +19,7 @@ class PrisonSeeder
   end
 
   def import(path, hash)
-    estate = Estate.find_or_create_by(name: hash.fetch('estate'))
+    estate = Estate.find_by!(nomis_id: hash.fetch('nomis_id'))
     prison = Prison.find_or_initialize_by(id: uuid_for_path(path))
     entry = PrisonSeeder::SeedEntry.new(hash)
     prison.update! entry.to_h.merge(estate: estate)

--- a/app/services/prison_seeder/seed_entry.rb
+++ b/app/services/prison_seeder/seed_entry.rb
@@ -4,8 +4,8 @@ class PrisonSeeder::SeedEntry
   DEFAULT_ADULT_AGE = 18
 
   KEYS = %i[
-    address adult_age booking_window email_address enabled estate finder_slug
-    lead_days name nomis_id phone_no slot_details weekend_processing
+    address adult_age booking_window email_address enabled lead_days name
+    phone_no slot_details weekend_processing
   ]
 
   def initialize(hash)
@@ -40,24 +40,12 @@ private
     hash.fetch('enabled', true)
   end
 
-  def estate
-    hash.fetch('estate')
-  end
-
-  def finder_slug
-    hash.fetch('finder_slug') { hash.fetch('name').parameterize }
-  end
-
   def lead_days
     hash.fetch('lead_days', DEFAULT_LEAD_DAYS)
   end
 
   def name
     hash.fetch('name')
-  end
-
-  def nomis_id
-    hash.fetch('nomis_id')
   end
 
   def phone_no

--- a/db/migrate/20160106165936_move_nomis_id_to_estate.rb
+++ b/db/migrate/20160106165936_move_nomis_id_to_estate.rb
@@ -1,0 +1,37 @@
+class MoveNomisIdToEstate < ActiveRecord::Migration
+  def up
+    add_column :estates, :nomis_id, :string, limit: 3
+    add_column :estates, :finder_slug, :string
+
+    execute  <<-SQL
+      UPDATE estates
+      SET nomis_id = prisons.nomis_id, finder_slug = prisons.finder_slug
+      FROM prisons
+      WHERE estates.id = prisons.estate_id
+    SQL
+
+    change_column_null :estates, :nomis_id, false
+    change_column_null :estates, :finder_slug, false
+
+    remove_column :prisons, :nomis_id
+    remove_column :prisons, :finder_slug
+  end
+
+  def down
+    add_column :prisons, :nomis_id, :string, limit: 3
+    add_column :prisons, :finder_slug, :string
+
+    execute  <<-SQL
+      UPDATE prisons
+      SET nomis_id = estates.nomis_id, finder_slug = estates.finder_slug
+      FROM estates
+      WHERE estate_id = estates.id
+    SQL
+
+    change_column_null :prisons, :nomis_id, false
+    change_column_null :prisons, :finder_slug, false
+
+    remove_column :estates, :nomis_id
+    remove_column :estates, :finder_slug
+  end
+end

--- a/db/migrate/20160106171414_fix_estate_timestamps.rb
+++ b/db/migrate/20160106171414_fix_estate_timestamps.rb
@@ -1,0 +1,12 @@
+class FixEstateTimestamps < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      UPDATE estates
+      SET created_at = now(), updated_at = now()
+      WHERE created_at IS NULL
+    SQL
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160106165936) do
+ActiveRecord::Schema.define(version: 20160106171414) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,16 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160106102516) do
+ActiveRecord::Schema.define(version: 20160106165936) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
   create_table "estates", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
-    t.string   "name",       null: false
+    t.string   "name",                  null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "nomis_id",    limit: 3, null: false
+    t.string   "finder_slug",           null: false
   end
 
   add_index "estates", ["name"], name: "index_estates_on_name", unique: true, using: :btree
@@ -44,21 +46,19 @@ ActiveRecord::Schema.define(version: 20160106102516) do
   end
 
   create_table "prisons", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
-    t.string   "name",                                         null: false
-    t.string   "nomis_id",           limit: 3,                 null: false
-    t.boolean  "enabled",                      default: true,  null: false
-    t.integer  "booking_window",               default: 28,    null: false
+    t.string   "name",                               null: false
+    t.boolean  "enabled",            default: true,  null: false
+    t.integer  "booking_window",     default: 28,    null: false
     t.text     "address"
     t.string   "email_address"
     t.string   "phone_no"
-    t.json     "slot_details",                 default: {},    null: false
-    t.datetime "created_at",                                   null: false
-    t.datetime "updated_at",                                   null: false
-    t.integer  "lead_days",                    default: 3,     null: false
-    t.boolean  "weekend_processing",           default: false, null: false
-    t.integer  "adult_age",                                    null: false
-    t.string   "finder_slug",                                  null: false
-    t.uuid     "estate_id",                                    null: false
+    t.json     "slot_details",       default: {},    null: false
+    t.datetime "created_at",                         null: false
+    t.datetime "updated_at",                         null: false
+    t.integer  "lead_days",          default: 3,     null: false
+    t.boolean  "weekend_processing", default: false, null: false
+    t.integer  "adult_age",                          null: false
+    t.uuid     "estate_id",                          null: false
   end
 
   add_index "prisons", ["estate_id"], name: "index_prisons_on_estate_id", using: :btree

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
 Prison.transaction do
-  PrisonSeeder.seed! Rails.root.join('db', 'seeds')
+  path = Rails.root.join('db', 'seeds')
+  EstateSeeder.seed! path
+  PrisonSeeder.seed! path
 end

--- a/db/seeds/estates.yml
+++ b/db/seeds/estates.yml
@@ -1,0 +1,261 @@
+ACI:
+  name: Altcourse
+AGI:
+  name: Askham Grange
+AKI:
+  name: Acklington
+  finder_slug: acklington2
+ALI:
+  name: Isle of Wight - Albany
+  finder_slug: isle-of-wight
+ASI:
+  name: Ashfield
+AYI:
+  name: Aylesbury
+BAI:
+  name: Belmarsh
+BCI:
+  name: Buckley Hall
+BFI:
+  name: Bedford
+BHI:
+  name: Blantyre House
+BLI:
+  name: Bristol
+BMI:
+  name: Birmingham
+BNI:
+  name: Bullingdon
+  finder_slug: bullingdon
+BRI:
+  name: Bure
+BSI:
+  name: Brinsford
+BXI:
+  name: Brixton
+BZI:
+  name: Bronzefield
+CDI:
+  name: Chelmsford
+CFI:
+  name: Cardiff
+CKI:
+  name: Cookham Wood
+CLI:
+  name: Coldingley
+CWI:
+  name: Channings Wood
+DAI:
+  name: Dartmoor
+DHI:
+  name: Drake Hall
+DMI:
+  name: Durham
+DNI:
+  name: Doncaster
+DTI:
+  name: Deerbolt
+DWI:
+  name: Downview
+EEI:
+  name: Erlestoke
+EHI:
+  name: Standford Hill
+  finder_slug: sheppey-cluster-standford-hill
+ESI:
+  name: East Sutton Park
+EVI:
+  name: Everthorpe
+EWI:
+  name: Eastwood Park
+EXI:
+  name: Exeter
+EYI:
+  name: Elmley
+  finder_slug: sheppey-cluster-elmley
+FBI:
+  name: Forest Bank
+FDI:
+  name: Ford
+FHI:
+  name: Foston Hall
+FKI:
+  name: Frankland
+FMI:
+  name: Feltham
+  finder_slug: feltham
+FNI:
+  name: Full Sutton
+FSI:
+  name: Featherstone
+GHI:
+  name: Garth
+GMI:
+  name: Guys Marsh
+GNI:
+  name: Grendon
+GPI:
+  name: Glen Parva
+GTI:
+  name: Gartree
+HBI:
+  name: Hollesley Bay Open
+HCI:
+  name: Huntercombe
+HDI:
+  name: Hatfield Open
+  finder_slug: hatfield
+HEI:
+  name: Hewell
+HHI:
+  name: Holme House
+HII:
+  name: Hindley
+HLI:
+  name: Hull
+HOI:
+  name: High Down
+HPI:
+  name: Highpoint
+  finder_slug: highpoint-south
+HVI:
+  name: Haverigg
+HYI:
+  name: Holloway
+ISI:
+  name: Isis
+IWI:
+  name: Isle of Wight - Parkhurst
+  finder_slug: isle-of-wight
+KMI:
+  name: Kirkham
+KTI:
+  name: Kennet
+KVI:
+  name: Kirklevington Grange
+LCI:
+  name: Leicester
+LEI:
+  name: Leeds
+LFI:
+  name: Lancaster Farms
+LGI:
+  name: Lowdham Grange
+LHI:
+  name: Lindholme
+LII:
+  name: Lincoln
+LLI:
+  name: Long Lartin
+LNI:
+  name: Low Newton
+LPI:
+  name: Liverpool
+  finder_slug: liverpool
+LTI:
+  name: Littlehey
+LWI:
+  name: Lewes
+LYI:
+  name: Leyhill
+MDI:
+  name: Moorland Closed
+  finder_slug: moorland
+MHI:
+  name: Morton Hall
+MRI:
+  name: Manchester
+MSI:
+  name: Maidstone
+MTI:
+  name: The Mount
+NHI:
+  name: New Hall
+NLI:
+  name: Northumberland
+NMI:
+  name: Nottingham
+NSI:
+  name: North Sea Camp
+NWI:
+  name: Norwich
+  finder_slug: norwich
+ONI:
+  name: Onley
+OWI:
+  name: Oakwood
+  finder_slug: hmp-oakwood
+PBI:
+  name: Peterborough
+PDI:
+  name: Portland
+PNI:
+  name: Preston
+PRI:
+  name: Parc
+PVI:
+  name: Pentonville
+RCI:
+  name: Rochester
+RHI:
+  name: Rye Hill
+RNI:
+  name: Ranby
+RSI:
+  name: Risley
+SDI:
+  name: Send
+SFI:
+  name: Stafford
+SHI:
+  name: Stoke Heath
+SKI:
+  name: Stocken
+SLI:
+  name: Swaleside
+SNI:
+  name: Swinfen Hall
+SPI:
+  name: Spring Hill
+STI:
+  name: Styal
+SUI:
+  name: Sudbury
+SWI:
+  name: Swansea
+TCI:
+  name: Thorn Cross
+UKI:
+  name: Usk
+  finder_slug: usk-prescoed-usk
+UPI:
+  name: Prescoed
+  finder_slug: usk-prescoed-prescoed
+WCI:
+  name: Winchester
+WDI:
+  name: Wakefield
+WEI:
+  name: Wealstun
+WHI:
+  name: Woodhill
+WII:
+  name: Warren Hill
+WLI:
+  name: Wayland
+WMI:
+  name: Wymott
+WNI:
+  name: Werrington
+WOI:
+  name: Wolds
+WRI:
+  name: Whitemoor
+WSI:
+  name: Wormwood Scrubs
+WTI:
+  name: Whatton
+WWI:
+  name: Wandsworth
+WYI:
+  name: Wetherby

--- a/db/seeds/prisons/ACI-altcourse.yml
+++ b/db/seeds/prisons/ACI-altcourse.yml
@@ -2,4 +2,3 @@
 name: Altcourse
 nomis_id: ACI
 enabled: false
-estate: Altcourse

--- a/db/seeds/prisons/AGI-askham-grange.yml
+++ b/db/seeds/prisons/AGI-askham-grange.yml
@@ -6,7 +6,6 @@ address:
 - YO23 3FT
 email: socialvisits.askhamgrange@hmps.gsi.gov.uk
 enabled: true
-estate: Askham Grange
 slots:
   sat:
   - 1345-1545

--- a/db/seeds/prisons/AKI-acklington.yml
+++ b/db/seeds/prisons/AKI-acklington.yml
@@ -2,5 +2,3 @@
 name: Acklington
 nomis_id: AKI
 enabled: false
-estate: Acklington
-finder_slug: acklington2

--- a/db/seeds/prisons/ALI-isle-of-wight-albany.yml
+++ b/db/seeds/prisons/ALI-isle-of-wight-albany.yml
@@ -6,7 +6,6 @@ address:
 - PO30 5RS
 email: socialvisitsisleofwight@hmps.gsi.gov.uk
 enabled: true
-estate: Isle of Wight - Albany
 phone: 01983 634218
 slots:
   fri:

--- a/db/seeds/prisons/ASI-ashfield.yml
+++ b/db/seeds/prisons/ASI-ashfield.yml
@@ -2,4 +2,3 @@
 name: Ashfield
 nomis_id: ASI
 enabled: false
-estate: Ashfield

--- a/db/seeds/prisons/AYI-aylesbury.yml
+++ b/db/seeds/prisons/AYI-aylesbury.yml
@@ -6,7 +6,6 @@ address:
 - HP20 1EH
 email: socialvisits.aylesbury@hmps.gsi.gov.uk
 enabled: true
-estate: Aylesbury
 phone: 01296 444099
 slots:
   mon:

--- a/db/seeds/prisons/BAI-belmarsh.yml
+++ b/db/seeds/prisons/BAI-belmarsh.yml
@@ -9,7 +9,6 @@ address:
 booking_window: 21
 email: belmarsh.visits@hmps.gsi.gov.uk
 enabled: true
-estate: Belmarsh
 lead_days: 3
 phone: 020 8331 4768
 slots:

--- a/db/seeds/prisons/BCI-buckley-hall.yml
+++ b/db/seeds/prisons/BCI-buckley-hall.yml
@@ -6,7 +6,6 @@ address:
 - OL12 9DP
 email: socialvisits.buckleyhall@hmps.gsi.gov.uk
 enabled: true
-estate: Buckley Hall
 phone: 01706 514350
 slots:
   mon:

--- a/db/seeds/prisons/BFI-bedford.yml
+++ b/db/seeds/prisons/BFI-bedford.yml
@@ -7,7 +7,6 @@ address:
 booking_window: 14
 email: socialvisits.bedford@hmps.gsi.gov.uk
 enabled: true
-estate: Bedford
 phone: 01234 373196
 slots:
   mon:

--- a/db/seeds/prisons/BHI-blantyre-house.yml
+++ b/db/seeds/prisons/BHI-blantyre-house.yml
@@ -6,7 +6,6 @@ address:
 - TN17 2NH
 email: socialvisits.blantyrehouse@hmps.gsi.gov.uk
 enabled: false
-estate: Blantyre House
 reason: it_issues
 slots:
   sat:

--- a/db/seeds/prisons/BLI-bristol.yml
+++ b/db/seeds/prisons/BLI-bristol.yml
@@ -7,7 +7,6 @@ address:
 - BS7 8PS
 email: socialvisits.bristol@hmps.gsi.gov.uk
 enabled: true
-estate: Bristol
 phone: 0117 372 3213
 slots:
   mon:

--- a/db/seeds/prisons/BMI-birmingham.yml
+++ b/db/seeds/prisons/BMI-birmingham.yml
@@ -2,4 +2,3 @@
 name: Birmingham
 nomis_id: BMI
 enabled: false
-estate: Birmingham

--- a/db/seeds/prisons/BNI-bullingdon-convicted-only.yml
+++ b/db/seeds/prisons/BNI-bullingdon-convicted-only.yml
@@ -6,8 +6,6 @@ address:
 - OX25 1PZ
 email: socialvisits.bullingdon@hmps.gsi.gov.uk
 enabled: true
-estate: Bullingdon
-finder_slug: bullingdon
 phone: 01869 353176
 slots:
   mon:

--- a/db/seeds/prisons/BNI-bullingdon-remand-only.yml
+++ b/db/seeds/prisons/BNI-bullingdon-remand-only.yml
@@ -6,8 +6,6 @@ address:
 - OX25 1PZ
 email: socialvisits.bullingdon@hmps.gsi.gov.uk
 enabled: true
-estate: Bullingdon
-finder_slug: bullingdon
 phone: 01869 353176
 slots:
   mon:

--- a/db/seeds/prisons/BRI-bure.yml
+++ b/db/seeds/prisons/BRI-bure.yml
@@ -6,7 +6,6 @@ address:
 - NR10 5GB
 email: socialvisits.bure@hmps.gsi.gov.uk
 enabled: true
-estate: Bure
 phone: 01603 326252
 slots:
   fri:

--- a/db/seeds/prisons/BSI-brinsford.yml
+++ b/db/seeds/prisons/BSI-brinsford.yml
@@ -9,7 +9,6 @@ address:
 adult_age: 10
 email: visitsbooking.westmidlands@noms.gsi.gov.uk
 enabled: true
-estate: Brinsford
 phone: 0300 060 6500
 slots:
   tue:

--- a/db/seeds/prisons/BXI-brixton.yml
+++ b/db/seeds/prisons/BXI-brixton.yml
@@ -6,7 +6,6 @@ address:
 - SW2 5XF
 email: socialvisits.brixton@hmps.gsi.gov.uk
 enabled: true
-estate: Brixton
 phone: 020 8678 1433
 slots:
   sat:

--- a/db/seeds/prisons/BZI-bronzefield.yml
+++ b/db/seeds/prisons/BZI-bronzefield.yml
@@ -2,4 +2,3 @@
 name: Bronzefield
 nomis_id: BZI
 enabled: false
-estate: Bronzefield

--- a/db/seeds/prisons/CDI-chelmsford.yml
+++ b/db/seeds/prisons/CDI-chelmsford.yml
@@ -6,7 +6,6 @@ address:
 - 'CM2 6LQ '
 email: socialvisits.chelmsford@hmps.gsi.gov.uk
 enabled: true
-estate: Chelmsford
 phone: 01245 552265
 slots:
   mon:

--- a/db/seeds/prisons/CFI-cardiff.yml
+++ b/db/seeds/prisons/CFI-cardiff.yml
@@ -8,7 +8,6 @@ address:
 booking_window: 14
 email: socialvisits.cardiff@hmps.gsi.gov.uk
 enabled: true
-estate: Cardiff
 phone: 029 20923327
 slots:
   mon:

--- a/db/seeds/prisons/CKI-cookham-wood.yml
+++ b/db/seeds/prisons/CKI-cookham-wood.yml
@@ -6,7 +6,6 @@ address:
 - ME1 3LU
 email: socialvisits.cookhamwood@hmps.gsi.gov.uk
 enabled: true
-estate: Cookham Wood
 phone: 01634 202557
 slots:
   wed:

--- a/db/seeds/prisons/CLI-coldingley.yml
+++ b/db/seeds/prisons/CLI-coldingley.yml
@@ -6,7 +6,6 @@ address:
 - GU24 9EX
 email: socialvisits.coldingley@hmps.gsi.gov.uk
 enabled: true
-estate: Coldingley
 phone: 01483 344418
 slots:
   mon:

--- a/db/seeds/prisons/CWI-channings-wood.yml
+++ b/db/seeds/prisons/CWI-channings-wood.yml
@@ -7,7 +7,6 @@ address:
 - TQ12 6DW
 email: socialvisits.channingswood@hmps.gsi.gov.uk
 enabled: true
-estate: Channings Wood
 phone: 01803 812060
 slots:
   wed:

--- a/db/seeds/prisons/DAI-dartmoor.yml
+++ b/db/seeds/prisons/DAI-dartmoor.yml
@@ -6,7 +6,6 @@ address:
 - PL20 6RR
 email: socvisdartmoor@hmps.gsi.gov.uk
 enabled: true
-estate: Dartmoor
 lead_days: 4
 phone: 01822 322022
 slots:

--- a/db/seeds/prisons/DHI-drake-hall.yml
+++ b/db/seeds/prisons/DHI-drake-hall.yml
@@ -7,7 +7,6 @@ address:
 - ST21 6LQ
 email: visitsbooking.westmidlands@noms.gsi.gov.uk
 enabled: true
-estate: Drake Hall
 phone: 0300 060 6501
 slots:
   tue:

--- a/db/seeds/prisons/DMI-durham.yml
+++ b/db/seeds/prisons/DMI-durham.yml
@@ -7,7 +7,6 @@ address:
 - DH1 3HU
 email: socialvisits.durham@hmps.gsi.gov.uk
 enabled: true
-estate: Durham
 phone: 0191 3323417
 slots:
   mon:

--- a/db/seeds/prisons/DNI-doncaster.yml
+++ b/db/seeds/prisons/DNI-doncaster.yml
@@ -2,4 +2,3 @@
 name: Doncaster
 nomis_id: DNI
 enabled: false
-estate: Doncaster

--- a/db/seeds/prisons/DTI-deerbolt.yml
+++ b/db/seeds/prisons/DTI-deerbolt.yml
@@ -6,7 +6,6 @@ address:
 - DL12 9BG
 email: socialvisits.deerbolt@hmps.gsi.gov.uk
 enabled: true
-estate: Deerbolt
 phone: 01833 633349
 slots:
   thu:

--- a/db/seeds/prisons/DWI-downview.yml
+++ b/db/seeds/prisons/DWI-downview.yml
@@ -6,7 +6,6 @@ address:
 - SM2 5PD
 email: socialvisits.downview@hmps.gsi.gov.uk
 enabled: false
-estate: Downview
 phone: 020 8196 6359
 reason: coming_soon
 slots:

--- a/db/seeds/prisons/EEI-erlestoke.yml
+++ b/db/seeds/prisons/EEI-erlestoke.yml
@@ -6,7 +6,6 @@ address:
 - SN10 5TU
 email: eecmbookavisit@hmps.gsi.gov.uk
 enabled: true
-estate: Erlestoke
 phone: 01380 814264
 slots:
   sat:

--- a/db/seeds/prisons/EHI-standford-hill.yml
+++ b/db/seeds/prisons/EHI-standford-hill.yml
@@ -6,8 +6,6 @@ address:
 - 'ME12 4AA '
 email: socialvisits.standfordhill@hmps.gsi.gov.uk
 enabled: true
-estate: Standford Hill
-finder_slug: sheppey-cluster-standford-hill
 phone: 0300 060 6603
 slots:
   wed:

--- a/db/seeds/prisons/ESI-east-sutton-park.yml
+++ b/db/seeds/prisons/ESI-east-sutton-park.yml
@@ -6,7 +6,6 @@ address:
 - ME17 3DF
 email: socialvisits.eastsuttonpark@hmps.gsi.gov.uk
 enabled: false
-estate: East Sutton Park
 reason: coming_soon
 slots:
   sat:

--- a/db/seeds/prisons/EVI-everthorpe.yml
+++ b/db/seeds/prisons/EVI-everthorpe.yml
@@ -6,7 +6,6 @@ address:
 - HU15 1RB
 email: socialvisits.everthorpe@hmps.gsi.gov.uk
 enabled: true
-estate: Everthorpe
 phone: 01430 426505
 slots:
   fri:

--- a/db/seeds/prisons/EWI-eastwood-park.yml
+++ b/db/seeds/prisons/EWI-eastwood-park.yml
@@ -6,7 +6,6 @@ address:
 - GL12 8DB
 email: socialvisits.eastwoodpark@hmps.gsi.gov.uk
 enabled: true
-estate: Eastwood Park
 phone: 01454 382159
 slots:
   tue:

--- a/db/seeds/prisons/EXI-exeter.yml
+++ b/db/seeds/prisons/EXI-exeter.yml
@@ -6,7 +6,6 @@ address:
 - EX4 4EX
 email: socialvisits.exeter@hmps.gsi.gov.uk
 enabled: true
-estate: Exeter
 phone: 01392 41 5833
 slots:
   mon:

--- a/db/seeds/prisons/EYI-elmley.yml
+++ b/db/seeds/prisons/EYI-elmley.yml
@@ -6,8 +6,6 @@ address:
 - ME12 4DZ
 email: socialvisits.elmley@hmps.gsi.gov.uk
 enabled: true
-estate: Elmley
-finder_slug: sheppey-cluster-elmley
 phone: 0300 060 6605
 slots:
   mon:

--- a/db/seeds/prisons/FBI-forest-bank.yml
+++ b/db/seeds/prisons/FBI-forest-bank.yml
@@ -2,4 +2,3 @@
 name: Forest Bank
 nomis_id: FBI
 enabled: false
-estate: Forest Bank

--- a/db/seeds/prisons/FDI-ford.yml
+++ b/db/seeds/prisons/FDI-ford.yml
@@ -6,7 +6,6 @@ address:
 - BN18 0BX
 email: socialvisits.ford@hmps.gsi.gov.uk
 enabled: true
-estate: Ford
 slots:
   wed:
   - 1800-2000

--- a/db/seeds/prisons/FHI-foston-hall.yml
+++ b/db/seeds/prisons/FHI-foston-hall.yml
@@ -8,7 +8,6 @@ address:
 - DE65 5DN
 email: socialvisits.fostonhall@hmps.gsi.gov.uk
 enabled: true
-estate: Foston Hall
 phone: 01283 584357
 slots:
   mon:

--- a/db/seeds/prisons/FKI-frankland.yml
+++ b/db/seeds/prisons/FKI-frankland.yml
@@ -2,7 +2,6 @@
 name: Frankland
 nomis_id: FKI
 enabled: true
-estate: Frankland
 address:
 - Brasside
 - Durham

--- a/db/seeds/prisons/FMI-feltham-young-adults-18-21-only.yml
+++ b/db/seeds/prisons/FMI-feltham-young-adults-18-21-only.yml
@@ -6,8 +6,6 @@ address:
 - TW13 4ND
 email: socialvisits.feltham@hmps.gsi.gov.uk
 enabled: true
-estate: Feltham
-finder_slug: feltham
 phone: 020 8844 5400
 slots:
   mon:

--- a/db/seeds/prisons/FMI-feltham-young-people-15-18-only.yml
+++ b/db/seeds/prisons/FMI-feltham-young-people-15-18-only.yml
@@ -6,8 +6,6 @@ address:
 - TW13 4ND
 email: socialvisits.feltham@hmps.gsi.gov.uk
 enabled: true
-estate: Feltham
-finder_slug: feltham
 phone: 020 8844 5400
 slots:
   tue:

--- a/db/seeds/prisons/FNI-full-sutton.yml
+++ b/db/seeds/prisons/FNI-full-sutton.yml
@@ -7,7 +7,6 @@ address:
 booking_window: 28
 email: socialvisits.fullsutton@hmps.gsi.gov.uk
 enabled: true
-estate: Full Sutton
 lead_days: 3
 phone: 01759 475355
 slots:

--- a/db/seeds/prisons/FSI-featherstone.yml
+++ b/db/seeds/prisons/FSI-featherstone.yml
@@ -8,7 +8,6 @@ address:
 - WV10 7PU
 email: visitsbooking.westmidlands@noms.gsi.gov.uk
 enabled: true
-estate: Featherstone
 phone: 0300 060 6502
 slots:
   mon:

--- a/db/seeds/prisons/GHI-garth.yml
+++ b/db/seeds/prisons/GHI-garth.yml
@@ -2,4 +2,3 @@
 name: Garth
 nomis_id: GHI
 enabled: false
-estate: Garth

--- a/db/seeds/prisons/GMI-guys-marsh.yml
+++ b/db/seeds/prisons/GMI-guys-marsh.yml
@@ -6,7 +6,6 @@ address:
 - 'SP7 0AH '
 email: socialvisitsguysmarsh@hmps.gsi.gov.uk
 enabled: true
-estate: Guys Marsh
 phone: 01747 856586
 slots:
   fri:

--- a/db/seeds/prisons/GNI-grendon.yml
+++ b/db/seeds/prisons/GNI-grendon.yml
@@ -6,7 +6,6 @@ address:
 - HP18 0TL
 email: socialvisits.grendon@hmps.gsi.gov.uk
 enabled: true
-estate: Grendon
 phone: 01296 445000
 slots:
   sat:

--- a/db/seeds/prisons/GPI-glen-parva.yml
+++ b/db/seeds/prisons/GPI-glen-parva.yml
@@ -6,7 +6,6 @@ address:
 - 'LE8 4TN '
 email: socialvisits.glenparva@hmps.gsi.gov.uk
 enabled: true
-estate: Glen Parva
 phone: 0116 228 4366
 slots:
   mon:

--- a/db/seeds/prisons/GTI-gartree.yml
+++ b/db/seeds/prisons/GTI-gartree.yml
@@ -8,7 +8,6 @@ address:
 - LE16 7RP
 email: socialvisits.gartree@hmps.gsi.gov.uk
 enabled: true
-estate: Gartree
 phone: 01858 426 727
 slots:
   tue:

--- a/db/seeds/prisons/HBI-hollesley-bay-open.yml
+++ b/db/seeds/prisons/HBI-hollesley-bay-open.yml
@@ -6,7 +6,6 @@ address:
 - 'IP12 3JW '
 email: socialvisits.hollesleybay@hmps.gsi.gov.uk
 enabled: true
-estate: Hollesley Bay Open
 slots:
   sat:
   - 1400-1545

--- a/db/seeds/prisons/HCI-huntercombe.yml
+++ b/db/seeds/prisons/HCI-huntercombe.yml
@@ -6,7 +6,6 @@ address:
 - 'RG9 5SB '
 email: socialvisits.huntercombe@hmps.gsi.gov.uk
 enabled: true
-estate: Huntercombe
 phone: 01491 643151
 slots:
   mon:

--- a/db/seeds/prisons/HDI-hatfield-lakes.yml
+++ b/db/seeds/prisons/HDI-hatfield-lakes.yml
@@ -6,8 +6,6 @@ address:
 - DN7 6El
 email: socialvisitshatfield@hmps.gsi.gov.uk
 enabled: true
-estate: Hatfield Open
-finder_slug: hatfield
 phone: 01405 746611
 slots:
   fri:

--- a/db/seeds/prisons/HDI-hatfield-open.yml
+++ b/db/seeds/prisons/HDI-hatfield-open.yml
@@ -6,8 +6,6 @@ address:
 - DN7 6El
 email: socialvisitshatfield@hmps.gsi.gov.uk
 enabled: true
-estate: Hatfield Open
-finder_slug: hatfield
 phone: 01405 746611
 slots:
   thu:

--- a/db/seeds/prisons/HEI-hewell.yml
+++ b/db/seeds/prisons/HEI-hewell.yml
@@ -9,7 +9,6 @@ address:
 adult_age: 10
 email: visitsbooking.westmidlands@noms.gsi.gov.uk
 enabled: true
-estate: Hewell
 phone: 0300 060 6503
 slots:
   mon:

--- a/db/seeds/prisons/HHI-holme-house.yml
+++ b/db/seeds/prisons/HHI-holme-house.yml
@@ -6,7 +6,6 @@ address:
 - S18 2QU
 email: socialvisits.holmehouse@hmps.gsi.gov.uk
 enabled: true
-estate: Holme House
 phone: 03000 606602
 slots:
   fri:

--- a/db/seeds/prisons/HII-hindley.yml
+++ b/db/seeds/prisons/HII-hindley.yml
@@ -6,8 +6,6 @@ address:
 - WN2 5TH
 email: socialvisits.hindley@hmps.gsi.gov.uk
 enabled: true
-estate: Hindley
-finder_slug: hindley
 phone: 01942 663492
 slots:
   mon:

--- a/db/seeds/prisons/HLI-hull.yml
+++ b/db/seeds/prisons/HLI-hull.yml
@@ -6,7 +6,6 @@ address:
 - 'HU9 5LS '
 email: socialvisits.hull@hmps.gsi.gov.uk
 enabled: false
-estate: Hull
 phone: 01482 282016
 reason: coming_soon
 slots:

--- a/db/seeds/prisons/HOI-high-down.yml
+++ b/db/seeds/prisons/HOI-high-down.yml
@@ -6,7 +6,6 @@ address:
 - SM2 5PJ
 email: socialvisits.highdown@hmps.gsi.gov.uk
 enabled: true
-estate: High Down
 phone: 020 7147 6570
 slots:
   sat:

--- a/db/seeds/prisons/HPI-highpoint-north.yml
+++ b/db/seeds/prisons/HPI-highpoint-north.yml
@@ -6,7 +6,6 @@ address:
 - 'CB8 9YG '
 email: socialvisits.highpoint@hmps.gsi.gov.uk
 enabled: true
-estate: Highpoint
 phone: 01440 743134
 slots:
   fri:

--- a/db/seeds/prisons/HPI-highpoint-south.yml
+++ b/db/seeds/prisons/HPI-highpoint-south.yml
@@ -6,7 +6,6 @@ address:
 - 'CB8 9YG '
 email: socialvisits.highpoint@hmps.gsi.gov.uk
 enabled: true
-estate: Highpoint
 phone: 01440 743134
 slots:
   fri:

--- a/db/seeds/prisons/HVI-haverigg.yml
+++ b/db/seeds/prisons/HVI-haverigg.yml
@@ -7,7 +7,6 @@ address:
 adult_age: 10
 email: socialvisits.haverigg@hmps.gsi.gov.uk
 enabled: true
-estate: Haverigg
 phone: 01229713016
 slots:
   mon:

--- a/db/seeds/prisons/HYI-holloway.yml
+++ b/db/seeds/prisons/HYI-holloway.yml
@@ -7,7 +7,6 @@ address:
 - N7 0NU
 email: socialvisits.holloway@hmps.gsi.gov.uk
 enabled: true
-estate: Holloway
 phone: 020 7979 4751
 slots:
   mon:

--- a/db/seeds/prisons/ISI-isis.yml
+++ b/db/seeds/prisons/ISI-isis.yml
@@ -2,4 +2,3 @@
 name: Isis
 nomis_id: ISI
 enabled: false
-estate: Isis

--- a/db/seeds/prisons/IWI-isle-of-wight-parkhurst.yml
+++ b/db/seeds/prisons/IWI-isle-of-wight-parkhurst.yml
@@ -6,7 +6,6 @@ address:
 - 'PO30 5RS '
 email: socialvisitsisleofwight@hmps.gsi.gov.uk
 enabled: true
-estate: Isle of Wight - Parkhurst
 phone: 01983 634218
 slots:
   fri:

--- a/db/seeds/prisons/KMI-kirkham.yml
+++ b/db/seeds/prisons/KMI-kirkham.yml
@@ -7,7 +7,6 @@ address:
 - PR4 2RN
 email: socialvisits.kirkham@hmps.gsi.gov.uk
 enabled: true
-estate: Kirkham
 slots:
   fri:
   - 1300-1530

--- a/db/seeds/prisons/KTI-kennet.yml
+++ b/db/seeds/prisons/KTI-kennet.yml
@@ -6,7 +6,6 @@ address:
 - 'L31 1HX '
 email: socialvisits.kennet@hmps.gsi.gov.uk
 enabled: true
-estate: Kennet
 phone: 0151 213 3179
 slots:
   sat:

--- a/db/seeds/prisons/KVI-kirklevington-grange.yml
+++ b/db/seeds/prisons/KVI-kirklevington-grange.yml
@@ -2,5 +2,4 @@
 name: Kirklevington Grange
 nomis_id: KVI
 enabled: false
-estate: Kirklevington Grange
 reason: coming_soon

--- a/db/seeds/prisons/LCI-leicester.yml
+++ b/db/seeds/prisons/LCI-leicester.yml
@@ -6,7 +6,6 @@ address:
 - LE2 7AJ
 email: socialvisitsleiceste@hmps.gsi.gov.uk
 enabled: true
-estate: Leicester
 phone: 0116 228 3128
 slots:
   mon:

--- a/db/seeds/prisons/LEI-leeds.yml
+++ b/db/seeds/prisons/LEI-leeds.yml
@@ -6,7 +6,6 @@ address:
 - 'LS12 2TJ '
 email: socialvisits.leeds@hmps.gsi.gov.uk
 enabled: true
-estate: Leeds
 phone: 0113 203 2995
 slots:
   fri:

--- a/db/seeds/prisons/LFI-lancaster-farms.yml
+++ b/db/seeds/prisons/LFI-lancaster-farms.yml
@@ -6,7 +6,6 @@ address:
 - LA1 3QZ
 email: lancasterfarmsdomesticvisitsbooking@hmps.gsi.gov.uk
 enabled: true
-estate: Lancaster Farms
 phone: 01524 563636
 slots:
   sat:

--- a/db/seeds/prisons/LGI-lowdham-grange.yml
+++ b/db/seeds/prisons/LGI-lowdham-grange.yml
@@ -2,4 +2,3 @@
 name: Lowdham Grange
 nomis_id: LGI
 enabled: false
-estate: Lowdham Grange

--- a/db/seeds/prisons/LHI-lindholme.yml
+++ b/db/seeds/prisons/LHI-lindholme.yml
@@ -6,7 +6,6 @@ address:
 - 'DN7 6EE '
 email: socialvisits.lindholme@hmps.gsi.gov.uk
 enabled: true
-estate: Lindholme
 phone: 01302 524980
 slots:
   mon:

--- a/db/seeds/prisons/LII-lincoln.yml
+++ b/db/seeds/prisons/LII-lincoln.yml
@@ -6,7 +6,6 @@ address:
 - 'LN2 4BD '
 email: lincolnsocialvisits@hmps.gsi.gov.uk
 enabled: true
-estate: Lincoln
 phone: 01522 663172
 slots:
   sat:

--- a/db/seeds/prisons/LLI-long-lartin.yml
+++ b/db/seeds/prisons/LLI-long-lartin.yml
@@ -2,7 +2,6 @@
 name: Long Lartin
 nomis_id: LLI
 enabled: true
-estate: Long Lartin
 address:
 - South Littleton
 - Evesham

--- a/db/seeds/prisons/LNI-low-newton.yml
+++ b/db/seeds/prisons/LNI-low-newton.yml
@@ -6,7 +6,6 @@ address:
 - DH1 5YA
 email: socialvisits.lownewton@hmps.gsi.gov.uk
 enabled: true
-estate: Low Newton
 phone: 0191 376 4147
 slots:
   fri:

--- a/db/seeds/prisons/LPI-liverpool-closed-only.yml
+++ b/db/seeds/prisons/LPI-liverpool-closed-only.yml
@@ -6,8 +6,6 @@ address:
 - L9 3DF
 email: socialvisits.liverpool@hmps.gsi.gov.uk
 enabled: true
-estate: Liverpool
-finder_slug: liverpool
 phone: 0151 530 4050
 slots:
   mon:

--- a/db/seeds/prisons/LPI-liverpool-social-visits.yml
+++ b/db/seeds/prisons/LPI-liverpool-social-visits.yml
@@ -6,8 +6,6 @@ address:
 - L9 3DF
 email: socialvisits.liverpool@hmps.gsi.gov.uk
 enabled: true
-estate: Liverpool
-finder_slug: liverpool
 phone: 0151 530 4050
 slots:
   fri:

--- a/db/seeds/prisons/LTI-littlehey.yml
+++ b/db/seeds/prisons/LTI-littlehey.yml
@@ -6,7 +6,6 @@ address:
 - PE28 0SR
 email: socialvisits.littlehey@hmps.gsi.gov.uk
 enabled: true
-estate: Littlehey
 lead_days: 2
 phone: 01480 335650
 slots:

--- a/db/seeds/prisons/LWI-lewes.yml
+++ b/db/seeds/prisons/LWI-lewes.yml
@@ -6,7 +6,6 @@ address:
 - BN7 1EA
 email: socialvisits.lewes@hmps.gsi.gov.uk
 enabled: true
-estate: Lewes
 phone: 01273785277
 slots:
   mon:

--- a/db/seeds/prisons/LYI-leyhill.yml
+++ b/db/seeds/prisons/LYI-leyhill.yml
@@ -6,7 +6,6 @@ address:
 - GL12 8BT
 email: socialvisits.leyhill@hmps.gsi.gov.uk
 enabled: true
-estate: Leyhill
 phone: 01454 264211
 slots:
   tue:

--- a/db/seeds/prisons/MDI-moorland-closed.yml
+++ b/db/seeds/prisons/MDI-moorland-closed.yml
@@ -6,8 +6,6 @@ address:
 - DN7 6BW
 email: socialvisits.moorlandclosed@hmps.gsi.gov.uk
 enabled: true
-estate: Moorland Closed
-finder_slug: moorland
 lead_days: 1
 phone: 01302523289
 slots:

--- a/db/seeds/prisons/MHI-morton-hall.yml
+++ b/db/seeds/prisons/MHI-morton-hall.yml
@@ -2,4 +2,3 @@
 name: Morton Hall
 nomis_id: MHI
 enabled: false
-estate: Morton Hall

--- a/db/seeds/prisons/MRI-manchester.yml
+++ b/db/seeds/prisons/MRI-manchester.yml
@@ -2,4 +2,3 @@
 name: Manchester
 nomis_id: MRI
 enabled: false
-estate: Manchester

--- a/db/seeds/prisons/MSI-maidstone.yml
+++ b/db/seeds/prisons/MSI-maidstone.yml
@@ -6,7 +6,6 @@ address:
 - 'ME14 1UZ '
 email: socialvisits.maidstone@hmps.gsi.gov.uk
 enabled: true
-estate: Maidstone
 phone: 01622 775619
 slots:
   tue:

--- a/db/seeds/prisons/MTI-the-mount.yml
+++ b/db/seeds/prisons/MTI-the-mount.yml
@@ -6,7 +6,6 @@ address:
 - HP3 0NZ
 email: socialvisits.themount@hmps.gsi.gov.uk
 enabled: true
-estate: The Mount
 phone: 01442 836352
 slots:
   wed:

--- a/db/seeds/prisons/NHI-new-hall.yml
+++ b/db/seeds/prisons/NHI-new-hall.yml
@@ -6,7 +6,6 @@ address:
 - WF4 4XX
 email: socialvisits.newhall@hmps.gsi.gov.uk
 enabled: true
-estate: New Hall
 phone: 01924 803219
 slots:
   sat:

--- a/db/seeds/prisons/NLI-northumberland.yml
+++ b/db/seeds/prisons/NLI-northumberland.yml
@@ -2,4 +2,3 @@
 name: Northumberland
 nomis_id: NLI
 enabled: false
-estate: Northumberland

--- a/db/seeds/prisons/NMI-nottingham.yml
+++ b/db/seeds/prisons/NMI-nottingham.yml
@@ -6,7 +6,6 @@ address:
 - 'NG5 3AG '
 email: socialvisits.nottingham@hmps.gsi.gov.uk
 enabled: true
-estate: Nottingham
 phone: 0115 962 8980
 slots:
   fri:

--- a/db/seeds/prisons/NSI-north-sea-camp.yml
+++ b/db/seeds/prisons/NSI-north-sea-camp.yml
@@ -6,7 +6,6 @@ address:
 - PE22 0QX
 email: socialvisits.northseacamp@hmps.gsi.gov.uk
 enabled: true
-estate: North Sea Camp
 phone: 01205 769 368
 slots:
   sat:

--- a/db/seeds/prisons/NWI-norwich-a-b-c-e-m-only.yml
+++ b/db/seeds/prisons/NWI-norwich-a-b-c-e-m-only.yml
@@ -6,8 +6,6 @@ address:
 - 'NR1 4LU '
 email: socialvisits.norwich@hmps.gsi.gov.uk
 enabled: true
-estate: Norwich
-finder_slug: norwich
 phone: 01603 708795
 slots:
   tue:

--- a/db/seeds/prisons/NWI-norwich-britannia-house.yml
+++ b/db/seeds/prisons/NWI-norwich-britannia-house.yml
@@ -6,8 +6,6 @@ address:
 - NR1 4LU
 email: socialvisits.norwich@hmps.gsi.gov.uk
 enabled: true
-estate: Norwich
-finder_slug: norwich
 phone: 01603 708795
 slots:
   mon:

--- a/db/seeds/prisons/NWI-norwich-f-g-h-l-only.yml
+++ b/db/seeds/prisons/NWI-norwich-f-g-h-l-only.yml
@@ -6,8 +6,6 @@ address:
 - 'NR1 4LU '
 email: socialvisits.norwich@hmps.gsi.gov.uk
 enabled: true
-estate: Norwich
-finder_slug: norwich
 phone: 01603 708795
 slots:
   tue:

--- a/db/seeds/prisons/ONI-onley.yml
+++ b/db/seeds/prisons/ONI-onley.yml
@@ -7,7 +7,6 @@ address:
 adult_age: 10
 email: socialvisits.onley@hmps.gsi.gov.uk
 enabled: true
-estate: Onley
 phone: 01788 523 402
 slots:
   mon:

--- a/db/seeds/prisons/OWI-oakwood.yml
+++ b/db/seeds/prisons/OWI-oakwood.yml
@@ -2,5 +2,3 @@
 name: Oakwood
 nomis_id: OWI
 enabled: false
-estate: Oakwood
-finder_slug: hmp-oakwood

--- a/db/seeds/prisons/PBI-peterborough.yml
+++ b/db/seeds/prisons/PBI-peterborough.yml
@@ -2,4 +2,3 @@
 name: Peterborough
 nomis_id: PBI
 enabled: false
-estate: Peterborough

--- a/db/seeds/prisons/PDI-portland.yml
+++ b/db/seeds/prisons/PDI-portland.yml
@@ -7,7 +7,6 @@ address:
 adult_age: 11
 email: socialvisits.portland@hmps.gsi.gov.uk
 enabled: true
-estate: Portland
 phone: 01305 715775
 slots:
   sat:

--- a/db/seeds/prisons/PNI-preston.yml
+++ b/db/seeds/prisons/PNI-preston.yml
@@ -6,7 +6,6 @@ address:
 - 'PR1 5AB '
 email: socialvisits.preston@hmps.gsi.gov.uk
 enabled: true
-estate: Preston
 phone: 01772 444666
 slots:
   fri:

--- a/db/seeds/prisons/PRI-parc.yml
+++ b/db/seeds/prisons/PRI-parc.yml
@@ -2,4 +2,3 @@
 name: Parc
 nomis_id: PRI
 enabled: false
-estate: Parc

--- a/db/seeds/prisons/PVI-pentonville.yml
+++ b/db/seeds/prisons/PVI-pentonville.yml
@@ -6,7 +6,6 @@ address:
 - N7 8TT
 email: socialvisits.pentonville@hmps.gsi.gov.uk
 enabled: true
-estate: Pentonville
 phone: 020 70237251
 slots:
   mon:

--- a/db/seeds/prisons/RCI-rochester.yml
+++ b/db/seeds/prisons/RCI-rochester.yml
@@ -8,7 +8,6 @@ address:
 - ME1 3QS
 email: socialvisits.rochester@hmps.gsi.gov.uk
 enabled: true
-estate: Rochester
 phone: 01634 803100
 slots:
   mon:

--- a/db/seeds/prisons/RHI-rye-hill.yml
+++ b/db/seeds/prisons/RHI-rye-hill.yml
@@ -2,4 +2,3 @@
 name: Rye Hill
 nomis_id: RHI
 enabled: false
-estate: Rye Hill

--- a/db/seeds/prisons/RNI-ranby.yml
+++ b/db/seeds/prisons/RNI-ranby.yml
@@ -6,7 +6,6 @@ address:
 - DN22 8EU
 email: socialvisits.ranby@hmps.gsi.gov.uk
 enabled: true
-estate: Ranby
 phone: 01777 862107
 slots:
   fri:

--- a/db/seeds/prisons/RSI-risley.yml
+++ b/db/seeds/prisons/RSI-risley.yml
@@ -6,7 +6,6 @@ address:
 - WA3 6BP
 email: socialvisits.risley@hmps.gsi.gov.uk
 enabled: true
-estate: Risley
 phone: 01925 733284
 slots:
   sat:

--- a/db/seeds/prisons/SDI-send.yml
+++ b/db/seeds/prisons/SDI-send.yml
@@ -6,7 +6,6 @@ address:
 - 'GU23 7LJ '
 email: socialvisits.send@hmps.gsi.gov.uk
 enabled: true
-estate: Send
 phone: 01483 471033
 slots:
   thu:

--- a/db/seeds/prisons/SFI-stafford.yml
+++ b/db/seeds/prisons/SFI-stafford.yml
@@ -7,7 +7,6 @@ address:
 - ST16 3AW
 email: visitsbooking.westmidlands@noms.gsi.gov.uk
 enabled: true
-estate: Stafford
 phone: 0300 060 6505
 slots:
   wed:

--- a/db/seeds/prisons/SHI-stoke-heath.yml
+++ b/db/seeds/prisons/SHI-stoke-heath.yml
@@ -8,7 +8,6 @@ address:
 adult_age: 10
 email: visitsbooking.westmidlands@noms.gsi.gov.uk
 enabled: true
-estate: Stoke Heath
 phone: 0300 060 6506
 slots:
   mon:

--- a/db/seeds/prisons/SKI-stocken.yml
+++ b/db/seeds/prisons/SKI-stocken.yml
@@ -6,7 +6,6 @@ address:
 - LE15 7RD
 email: socialvisits.stocken@hmps.gsi.gov.uk
 enabled: true
-estate: Stocken
 phone: 01780 795156
 slots:
   fri:

--- a/db/seeds/prisons/SLI-swaleside.yml
+++ b/db/seeds/prisons/SLI-swaleside.yml
@@ -6,7 +6,6 @@ address:
 - ME12 4AX
 email: socialvisits.swaleside@hmps.gsi.gov.uk
 enabled: true
-estate: Swaleside
 phone: 0300 060 6604
 slots:
   mon:

--- a/db/seeds/prisons/SNI-swinfen-hall.yml
+++ b/db/seeds/prisons/SNI-swinfen-hall.yml
@@ -9,7 +9,6 @@ address:
 adult_age: 10
 email: visitsbooking.westmidlands@noms.gsi.gov.uk
 enabled: true
-estate: Swinfen Hall
 phone: 0300 060 6507
 slots:
   tue:

--- a/db/seeds/prisons/SPI-spring-hill.yml
+++ b/db/seeds/prisons/SPI-spring-hill.yml
@@ -6,7 +6,6 @@ address:
 - HP18 0TL
 email: socialvisits.springhill@hmps.gsi.gov.uk
 enabled: true
-estate: Spring Hill
 slots:
   sat:
   - 1345-1600

--- a/db/seeds/prisons/STI-styal.yml
+++ b/db/seeds/prisons/STI-styal.yml
@@ -6,7 +6,6 @@ address:
 - 'SK9 4HR '
 email: socialvisits.styal@hmps.gsi.gov.uk
 enabled: true
-estate: Styal
 phone: 01625553195
 slots:
   mon:

--- a/db/seeds/prisons/SUI-sudbury.yml
+++ b/db/seeds/prisons/SUI-sudbury.yml
@@ -7,7 +7,6 @@ address:
 - DE6 5HW
 email: socialvisitssudbury@hmps.gsi.gov.uk
 enabled: true
-estate: Sudbury
 phone: 01283 584066
 slots:
   wed:

--- a/db/seeds/prisons/SWI-swansea.yml
+++ b/db/seeds/prisons/SWI-swansea.yml
@@ -6,7 +6,6 @@ address:
 - SA1 3SR
 email: socialvisits.swansea@hmps.gsi.gov.uk
 enabled: true
-estate: Swansea
 phone: 01792 48 5322
 slots:
   mon:

--- a/db/seeds/prisons/TCI-thorn-cross.yml
+++ b/db/seeds/prisons/TCI-thorn-cross.yml
@@ -6,7 +6,6 @@ address:
 - NWA4 4RL
 email: socialvisits.thorncross@hmps.gsi.gov.uk
 enabled: true
-estate: Thorn Cross
 phone: 01925805018
 slots:
   sat:

--- a/db/seeds/prisons/UKI-usk.yml
+++ b/db/seeds/prisons/UKI-usk.yml
@@ -6,8 +6,6 @@ address:
 - NP15 1XP
 email: socialvisits.usk@hmps.gsi.gov.uk
 enabled: true
-estate: Usk
-finder_slug: usk-prescoed-usk
 phone: 01291 671730
 slots:
   mon:

--- a/db/seeds/prisons/UPI-prescoed.yml
+++ b/db/seeds/prisons/UPI-prescoed.yml
@@ -2,6 +2,4 @@
 name: Prescoed
 nomis_id: UPI
 enabled: false
-estate: Prescoed
-finder_slug: usk-prescoed-prescoed
 reason: coming_soon

--- a/db/seeds/prisons/WCI-winchester-convicted-only.yml
+++ b/db/seeds/prisons/WCI-winchester-convicted-only.yml
@@ -6,8 +6,6 @@ address:
 - SO22 5DF
 email: socialvisits.winchester@hmps.gsi.gov.uk
 enabled: true
-estate: Winchester
-finder_slug: winchester
 phone: 0845 223 5514
 slots:
   fri:

--- a/db/seeds/prisons/WCI-winchester-remand-only.yml
+++ b/db/seeds/prisons/WCI-winchester-remand-only.yml
@@ -6,8 +6,6 @@ address:
 - SO22 5DF
 email: socialvisits.winchester@hmps.gsi.gov.uk
 enabled: true
-estate: Winchester
-finder_slug: winchester
 phone: 0845 223 5514
 slots:
   fri:

--- a/db/seeds/prisons/WDI-wakefield.yml
+++ b/db/seeds/prisons/WDI-wakefield.yml
@@ -1,7 +1,6 @@
 ---
 name: Wakefield
 nomis_id: WDI
-estate: Wakefield
 address:
 - 5 Love Lane
 - Wakefield

--- a/db/seeds/prisons/WEI-wealstun.yml
+++ b/db/seeds/prisons/WEI-wealstun.yml
@@ -6,7 +6,6 @@ address:
 - LS23 7AZ
 email: socialvisits.wealstun@hmps.gsi.gov.uk
 enabled: true
-estate: Wealstun
 phone: 01937 444599
 slots:
   mon:

--- a/db/seeds/prisons/WHI-woodhill.yml
+++ b/db/seeds/prisons/WHI-woodhill.yml
@@ -2,7 +2,6 @@
 name: Woodhill
 nomis_id: WHI
 enabled: true
-estate: Woodhill
 address:
 - Tattenhoe Street
 - Milton Keynes

--- a/db/seeds/prisons/WII-warren-hill.yml
+++ b/db/seeds/prisons/WII-warren-hill.yml
@@ -6,7 +6,6 @@ address:
 - 'IP12 3JW '
 email: socialvisits.warrenhill@hmps.gsi.gov.uk
 enabled: true
-estate: Warren Hill
 phone: 01394 633633
 slots:
   sat:

--- a/db/seeds/prisons/WLI-wayland.yml
+++ b/db/seeds/prisons/WLI-wayland.yml
@@ -6,7 +6,6 @@ address:
 - IP25 6RL
 email: socialvisits.wayland@hmps.gsi.gov.uk
 enabled: true
-estate: Wayland
 phone: 01953 804152
 slots:
   tue:

--- a/db/seeds/prisons/WMI-wymott.yml
+++ b/db/seeds/prisons/WMI-wymott.yml
@@ -6,7 +6,6 @@ address:
 - PR26 8LW
 email: socialvisits.wymott@hmps.gsi.gov.uk
 enabled: true
-estate: Wymott
 phone: 01772 442234
 slots:
   mon:

--- a/db/seeds/prisons/WNI-werrington.yml
+++ b/db/seeds/prisons/WNI-werrington.yml
@@ -8,7 +8,6 @@ address:
 adult_age: 10
 email: visitsbooking.westmidlands@noms.gsi.gov.uk
 enabled: true
-estate: Werrington
 phone: 0300 060 6508
 slots:
   wed:

--- a/db/seeds/prisons/WOI-wolds.yml
+++ b/db/seeds/prisons/WOI-wolds.yml
@@ -6,7 +6,6 @@ address:
 - HU15 2JZ
 email: socialvisits.everthorpe@hmps.gsi.gov.uk
 enabled: true
-estate: Wolds
 phone: 01430 426505
 slots:
   fri:

--- a/db/seeds/prisons/WRI-whitemoor.yml
+++ b/db/seeds/prisons/WRI-whitemoor.yml
@@ -2,7 +2,6 @@
 name: Whitemoor
 nomis_id: WRI
 enabled: true
-estate: Whitemoor
 address:
 - Longhill Road
 - March

--- a/db/seeds/prisons/WSI-wormwood-scrubs.yml
+++ b/db/seeds/prisons/WSI-wormwood-scrubs.yml
@@ -6,7 +6,6 @@ address:
 - W12 0AE
 email: visitsbooking.westmidlands@noms.gsi.gov.uk
 enabled: true
-estate: Wormwood Scrubs
 phone: 020 8588 3564
 slots:
   mon:

--- a/db/seeds/prisons/WTI-whatton.yml
+++ b/db/seeds/prisons/WTI-whatton.yml
@@ -6,7 +6,6 @@ address:
 - 'NG13 9FQ '
 email: socialvisits.whatton@hmps.gsi.gov.uk
 enabled: true
-estate: Whatton
 phone: 01949 803564
 slots:
   fri:

--- a/db/seeds/prisons/WWI-wandsworth.yml
+++ b/db/seeds/prisons/WWI-wandsworth.yml
@@ -7,7 +7,6 @@ address:
 - SW18 3HS
 email: socialvisits.wandsworth@hmps.gsi.gov.uk
 enabled: true
-estate: Wandsworth
 phone: 020 8588 4002
 slots:
   mon:

--- a/db/seeds/prisons/WYI-wetherby.yml
+++ b/db/seeds/prisons/WYI-wetherby.yml
@@ -6,7 +6,6 @@ address:
 - 'LS22 5ED '
 email: socialvisits.wetherby@hmps.gsi.gov.uk
 enabled: true
-estate: Wetherby
 phone: 01937 544207
 slots:
   wed:

--- a/lib/tasks/maintenance.rake
+++ b/lib/tasks/maintenance.rake
@@ -1,4 +1,5 @@
 namespace :maintenance do
+  desc 'Generate UUID mapping entries for prisons that lack them'
   task prison_uuids: :environment do
     prison_uuid_mapping_path =
       Rails.root.join('db', 'seeds', 'prison_uuid_mappings.yml')

--- a/spec/factories/estates.rb
+++ b/spec/factories/estates.rb
@@ -3,5 +3,13 @@ FactoryGirl.define do
     name do
       FFaker::AddressUK.city
     end
+
+    sequence :nomis_id do |n|
+      ('%03d' % n).tr('0123456789', 'ABCDEFGHIJ')
+    end
+
+    finder_slug do |e|
+      e.name.parameterize
+    end
   end
 end

--- a/spec/factories/prisons.rb
+++ b/spec/factories/prisons.rb
@@ -6,15 +6,7 @@ FactoryGirl.define do
       "#{p.estate.name} Open Prison"
     end
 
-    sequence :nomis_id do |n|
-      ('%03d' % n).tr('0123456789', 'ABCDEFGHIJ')
-    end
-
     enabled true
-
-    finder_slug do |p|
-      p.name.parameterize
-    end
 
     address do
       FFaker::AddressUK.street_address

--- a/spec/features/prison_data_spec.rb
+++ b/spec/features/prison_data_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.feature 'Prison seed data' do
   scenario 'Importing all current prisons' do
-    PrisonSeeder.seed! Rails.root.join('db', 'seeds')
+    path = Rails.root.join('db', 'seeds')
+    EstateSeeder.seed! path
+    PrisonSeeder.seed! path
   end
 end

--- a/spec/fixtures/seeds/estates.yml
+++ b/spec/fixtures/seeds/estates.yml
@@ -1,0 +1,5 @@
+LNX:
+  name: Luna
+  finder_slug: moonbase
+MRX:
+  name: Mars

--- a/spec/fixtures/seeds/prisons/LNX-luna.yml
+++ b/spec/fixtures/seeds/prisons/LNX-luna.yml
@@ -8,7 +8,6 @@ address:
 booking_window: 28
 email: luna@hmps.gsi.gov.uk
 enabled: true
-estate: Luna
 phone: 0115 4960123
 slot_anomalies:
   2015-05-25:

--- a/spec/fixtures/seeds/prisons/MRX-mars.yml
+++ b/spec/fixtures/seeds/prisons/MRX-mars.yml
@@ -6,7 +6,6 @@ address:
 - Mars
 email: mars@hmps.gsi.gov.uk
 enabled: true
-estate: Mars
 id: 11
 phone: 0115 4960111
 slots:

--- a/spec/services/estate_seeder_spec.rb
+++ b/spec/services/estate_seeder_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe EstateSeeder do
+  context 'importing from disk' do
+    let(:base_path) { Rails.root.join('spec', 'fixtures', 'seeds') }
+
+    it 'creates estates' do
+      expect {
+        described_class.seed! base_path
+      }.to change(Estate, :count).by(2)
+    end
+  end
+
+  context 'successful import' do
+    let(:nomis_id) { 'LNX' }
+    let(:hash) { { 'name' => 'Lunar Penal Colony' } }
+
+    it 'creates a new estate record' do
+      expect {
+        subject.import nomis_id, hash
+      }.to change(Estate, :count).by(1)
+    end
+
+    it 'generates a default prison finder slug' do
+      subject.import nomis_id, hash
+      expect(Estate.find_by(nomis_id: nomis_id)).
+        to have_attributes(finder_slug: 'lunar-penal-colony')
+    end
+
+    it 'uses the supplied prison finder slug' do
+      subject.import nomis_id, hash.merge('finder_slug' => 'luna')
+      expect(Estate.find_by(nomis_id: nomis_id)).
+        to have_attributes(finder_slug: 'luna')
+    end
+  end
+end


### PR DESCRIPTION
As the Prison Finder slug and the NOMIS ID are per-estate rather than per-prison, it makes the data model more consistent if this information is stored on the estate. This also simplifies the seed data by reducing duplication.