### PR TITLE
Switch interface language, part 1

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :do_not_cache
+  before_action :set_locale
 
   helper LinksHelper
 
@@ -21,5 +22,13 @@ private
     response.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate'
     response.headers['Pragma'] = 'no-cache'
     response.headers['Expires'] = '0'
+  end
+
+  def default_url_options(*)
+    { locale: I18n.locale }
+  end
+
+  def set_locale
+    I18n.locale = params.fetch(:locale, I18n.default_locale)
   end
 end

--- a/app/helpers/calendar_helper.rb
+++ b/app/helpers/calendar_helper.rb
@@ -29,13 +29,14 @@ module CalendarHelper
   end
 
   def calendar_day(date, bookable)
-    day = content_tag(:span, date.strftime('%-e'), class: 'BookingCalendar-day')
+    day = content_tag(
+      :span, I18n.l(date, format: :day_of_month),
+      class: 'BookingCalendar-day'
+    )
     return day if bookable == false
     content_tag(
-      :a,
-      day,
-      class: 'BookingCalendar-dateLink',
-      'data-date': date.iso8601,
+      :a, day,
+      class: 'BookingCalendar-dateLink', 'data-date': date.iso8601,
       href: "#date-#{date.iso8601}"
     )
   end

--- a/app/views/booking_requests/_booking_calendar.html.erb
+++ b/app/views/booking_requests/_booking_calendar.html.erb
@@ -8,7 +8,7 @@
     <thead>
       <tr>
         <% each_day_of_week do |day| %>
-          <th><%= day.strftime('%a') %></th>
+          <th><%= I18n.l(day, format: :day_of_week) %></th>
         <% end %>
       </tr>
     </thead>

--- a/app/views/prison/visits/_calendar.html.erb
+++ b/app/views/prison/visits/_calendar.html.erb
@@ -3,7 +3,7 @@
     <thead>
       <tr>
         <% each_day_of_week do |day| %>
-          <th><%= day.strftime('%a') %></th>
+          <th><%= I18n.l(day, format: :day_of_week) %></th>
         <% end %>
       </tr>
     </thead>
@@ -14,7 +14,7 @@
             <td class="BookingCalendar-date--<%= (future?(day) ? 'bookable' : 'unbookable') %>">
               <div class="BookingCalendar-content <%= (tagged?(day)) ? 'has-tag' : '' %>">
                 <span class="BookingCalendar-day">
-                  <%= day.strftime('%e') %>
+                  <%= I18n.l(day, format: :day_of_month) %>
                 </span>
                 <% if today?(day) %>
                   <span class="BookingCalendar-tag BookingCalendar-tag--today"
@@ -23,15 +23,15 @@
                 <% if first_day_of_month?(day) %>
                   <span
                     class="BookingCalendar-tag"
-                    id="month-<%= day.strftime('%Y-%m') %>"
-                    ><%= day.strftime('%b') %></span>
+                    id="month-<%= I18n.l(day, format: :year_and_month_internal) %>"
+                    ><%= I18n.l(day, format: :short_month_name) %></span>
                 <% end %>
                 <% if future?(day) %>
                   <label
                     class="BookingCalendar-dateLink"
                     data-date="<%= day %>"
                     for="<%= sanitize_to_id(name) %>_<%= day.iso8601 %>"
-                    href="#date-<%= day.strftime('%Y-%m-%d') %>"
+                    href="#date-<%= I18n.l(day, format: :date_internal) %>"
                     >
                     <%= radio_button_tag(name, day.iso8601) %>
                   </label>

--- a/app/views/prison_mailer/request_received.html.erb
+++ b/app/views/prison_mailer/request_received.html.erb
@@ -44,7 +44,8 @@
 <% end %>
 
 <p class="cta">
-  <%= link_to(t('.process_booking'), prison_visit_url(@visit)) %>
+  <%= link_to(t('.process_booking'),
+              prison_visit_url(@visit, locale: I18n.locale)) %>
 </p>
 
 <p>
@@ -52,7 +53,7 @@
 </p>
 
 <div>
-  <%= prison_visit_url(@visit) %>
+  <%= prison_visit_url(@visit, locale: I18n.locale) %>
 </div>
 
 <p>

--- a/app/views/visitor_mailer/booked.html.erb
+++ b/app/views/visitor_mailer/booked.html.erb
@@ -40,7 +40,7 @@
 <h1><%= t('.cancel_change_title') %></h1>
 
 <p>
-  <%= t('.cancel_html', url: visit_url(@visit)) %>
+  <%= t('.cancel_html', url: visit_url(id: @visit, locale: I18n.locale)) %>
 </p>
 
 <p><%= t(".want_to_change") %></p>
@@ -97,7 +97,8 @@
 
 <h1><%= t(".need_help_title") %></h1>
 
-<p><%= t(".need_help_body_html", url: new_feedback_submission_url) %></p>
+<p><%= t(".need_help_body_html",
+         url: new_feedback_submission_url(locale: I18n.locale)) %></p>
 
 <p>
   <small><%= t(".visit_id") %> <%= @visit.id %></small>

--- a/app/views/visitor_mailer/request_acknowledged.html.erb
+++ b/app/views/visitor_mailer/request_acknowledged.html.erb
@@ -5,7 +5,8 @@
   <%= t('.status') %>
 </h1>
 <p>
-  <%= t('.where_to_check_status_html', url: visit_url(@visit)) %>
+  <%= t('.where_to_check_status_html',
+        url: visit_url(@visit, locale: I18n.locale)) %>
 </p>
 <p>
   <%= t('.when_to_expect_response',
@@ -50,7 +51,7 @@
   <%= t('.cancel_title') %>
 </h1>
 <p>
-  <%= t('.cancel_html', url: visit_url(@visit)) %>
+  <%= t('.cancel_html', url: visit_url(@visit, locale: I18n.locale)) %>
 </p>
 <ul>
   <li>
@@ -63,5 +64,6 @@
   </li>
 </ul>
 <p>
-  <%= t('.feedback_html', url: new_feedback_submission_url) %>
+  <%= t('.feedback_html',
+        url: new_feedback_submission_url(locale: I18n.locale)) %>
 </p>

--- a/config/locales/en/defaults.yml
+++ b/config/locales/en/defaults.yml
@@ -8,6 +8,11 @@ en:
     formats:
       date_of_birth: "%-d %B %Y" # 24 July 2014
       date_without_year: "%A %-d %B" # Thursday 24 July
+      day_of_month: "%-e"
+      day_of_week: "%a"
+      short_month_name: "%b"
+      year_and_month_internal: "%Y-%m"
+      date_internal: "%Y-%m-%d"
   time:
     formats:
       twelve_hour: "%-l:%M%P"   # 1:30pm

--- a/config/locales/en/defaults.yml
+++ b/config/locales/en/defaults.yml
@@ -13,10 +13,60 @@ en:
       short_month_name: "%b"
       year_and_month_internal: "%Y-%m"
       date_internal: "%Y-%m-%d"
+    day_names:
+      - Sunday
+      - Monday
+      - Tuesday
+      - Wednesday
+      - Thursday
+      - Friday
+      - Saturday
+    abbr_day_names:
+      - Sun
+      - Mon
+      - Tue
+      - Wed
+      - Thu
+      - Fri
+      - Sat
+    month_names:
+      - ~
+      - January
+      - February
+      - March
+      - April
+      - May
+      - June
+      - July
+      - August
+      - September
+      - October
+      - November
+      - December
+    abbr_month_names:
+      - ~
+      - Jan
+      - Feb
+      - Mar
+      - Apr
+      - May
+      - Jun
+      - Jul
+      - Aug
+      - Sep
+      - Oct
+      - Nov
+      - Dec
+    order:
+      - day
+      - month
+      - year
   time:
     formats:
       twelve_hour: "%-l:%M%P"   # 1:30pm
       twenty_four_hour: "%H:%M" # 13:30
+    am: am
+    pm: pm
   formats:
     slot:
       public:

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -306,7 +306,7 @@ en:
       remove: Remove
       today: Today
       choose_two_alternatives: >-
-        Choose two alternative dates in case your first choice isn‘t available.
+        Choose two alternative dates in case your first choice isn’t available.
     validation:
       heading: You need to fix the errors on this page before continuing.
       see_below: See highlighted errors below.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,12 +2,7 @@ Rails.application.routes.draw do
   prison_ip_matcher =
     IpAddressMatcher.new(Rails.configuration.prison_ip_ranges)
 
-  get '/', to: redirect(ENV.fetch('GOVUK_START_PAGE', '/request'))
-
-  resources :booking_requests, path: 'request', only: %i[ index create ]
-  resources :visits, only: %i[ show ]
-  resources :cancellations, path: 'cancel', only: %i[ create ]
-  resources :feedback_submissions, path: 'feedback', only: %i[ new create ]
+  get '/', to: redirect(ENV.fetch('GOVUK_START_PAGE', '/en/request'))
 
   constraints ip: prison_ip_matcher do
     namespace :prison do
@@ -15,14 +10,21 @@ Rails.application.routes.draw do
     end
   end
 
-  controller 'high_voltage/pages' do
-    get 'cookies', action: :show, id: 'cookies'
-    get 'terms-and-conditions', action: :show, id: 'terms_and_conditions'
-    get 'unsubscribe', action: :show, id: 'unsubscribe'
-  end
-
   constraints format: 'json' do
     get 'ping', to: 'ping#index'
     get 'healthcheck', to: 'healthcheck#index'
+  end
+
+  scope '/:locale' do
+    resources :booking_requests, path: 'request', only: %i[ index create ]
+    resources :visits, only: %i[ show ]
+    resources :cancellations, path: 'cancel', only: %i[ create ]
+    resources :feedback_submissions, path: 'feedback', only: %i[ new create ]
+
+    controller 'high_voltage/pages' do
+      get 'cookies', action: :show, id: 'cookies'
+      get 'terms-and-conditions', action: :show, id: 'terms_and_conditions'
+      get 'unsubscribe', action: :show, id: 'unsubscribe'
+    end
   end
 end

--- a/smoke_test/smoke_test.rb
+++ b/smoke_test/smoke_test.rb
@@ -58,7 +58,7 @@ module SmokeTest
     def run
       puts 'Beginning Smoke Test..'
       Capybara.reset_sessions!
-      visit '/request'
+      visit '/en/request'
       STEPS.map do |step|
         puts "Step: #{step_name(step)}"
         complete(step)

--- a/smoke_test/steps/cancel_booking_page.rb
+++ b/smoke_test/steps/cancel_booking_page.rb
@@ -3,7 +3,7 @@ module SmokeTest
     class CancelBookingPage < BaseStep
       include HttpStatusValidation
 
-      PAGE_PATH = %r{\A/visits/([0-9a-f-]){36}}
+      PAGE_PATH = %r{\A/en/visits/([0-9a-f-]){36}}
 
       def validate!
         validate_response_status!

--- a/smoke_test/steps/slots_page.rb
+++ b/smoke_test/steps/slots_page.rb
@@ -3,7 +3,7 @@ module SmokeTest
     class SlotsPage < BaseStep
       include HttpStatusValidation
 
-      PAGE_PATH = '/request'
+      PAGE_PATH = '/en/request'
 
       def validate!
         validate_response_status!

--- a/smoke_test/steps/visitors_page.rb
+++ b/smoke_test/steps/visitors_page.rb
@@ -3,7 +3,7 @@ module SmokeTest
     class VisitorsPage < BaseStep
       include HttpStatusValidation
 
-      PAGE_PATH = '/request'
+      PAGE_PATH = '/en/request'
 
       def validate!
         validate_response_status!

--- a/spec/controllers/booking_requests_controller_spec.rb
+++ b/spec/controllers/booking_requests_controller_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe BookingRequestsController do
 
   context 'on the first prisoner details page' do
     before do
-      get :index
+      get :index, locale: 'en'
     end
 
     it 'assigns a new PrisonerStep' do
@@ -78,7 +78,9 @@ RSpec.describe BookingRequestsController do
   context 'after submitting prisoner details' do
     context 'with missing prisoner details' do
       before do
-        post :create, prisoner_step: { first_name: 'Oscar' }
+        post :create,
+          prisoner_step: { first_name: 'Oscar' },
+          locale: 'en'
       end
 
       it 'renders the prisoner template' do
@@ -97,7 +99,9 @@ RSpec.describe BookingRequestsController do
 
     context 'with complete prisoner details' do
       before do
-        post :create, prisoner_step: prisoner_details
+        post :create,
+          prisoner_step: prisoner_details,
+          locale: 'en'
       end
 
       it 'renders the visitors template' do
@@ -124,7 +128,8 @@ RSpec.describe BookingRequestsController do
       before do
         post :create,
           prisoner_step: prisoner_details,
-          visitors_step: { phone_no: '01154960222' }
+          visitors_step: { phone_no: '01154960222' },
+          locale: 'en'
       end
 
       it 'renders the visitors template' do
@@ -154,7 +159,8 @@ RSpec.describe BookingRequestsController do
       before do
         post :create,
           prisoner_step: prisoner_details,
-          visitors_step: visitors_details
+          visitors_step: visitors_details,
+          locale: 'en'
       end
 
       it 'renders the slots template' do
@@ -191,7 +197,8 @@ RSpec.describe BookingRequestsController do
         post :create,
           prisoner_step: prisoner_details,
           visitors_step: visitors_details,
-          slots_step: slots_details
+          slots_step: slots_details,
+          locale: 'en'
       end
 
       it 'renders the confirmation template' do
@@ -231,7 +238,8 @@ RSpec.describe BookingRequestsController do
         post :create,
           prisoner_step: prisoner_details,
           visitors_step: visitors_details,
-          slots_step: { option_0: '' }
+          slots_step: { option_0: '' },
+          locale: 'en'
       end
 
       it 'renders the slots template' do
@@ -268,7 +276,8 @@ RSpec.describe BookingRequestsController do
         prisoner_step: prisoner_details,
         visitors_step: visitors_details,
         slots_step: slots_details,
-        confirmation_step: confirmation_details
+        confirmation_step: confirmation_details,
+        locale: 'en'
       }
     }
 

--- a/spec/controllers/cancellations_controller_spec.rb
+++ b/spec/controllers/cancellations_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe CancellationsController, type: :controller do
   describe 'create' do
     context 'when confirm is checked' do
-      let(:params) { { id: visit.id, confirmed: '1' } }
+      let(:params) { { id: visit.id, confirmed: '1', locale: 'en' } }
 
       context 'when the visit has been requested' do
         let(:visit) { create(:visit) }
@@ -15,7 +15,7 @@ RSpec.describe CancellationsController, type: :controller do
 
         it 'redirects to the visit page' do
           post :create, params
-          expect(response).to redirect_to(visit_path(visit))
+          expect(response).to redirect_to(visit_path(visit, locale: 'en'))
         end
       end
 
@@ -29,7 +29,7 @@ RSpec.describe CancellationsController, type: :controller do
 
         it 'redirects to the visit page' do
           post :create, params
-          expect(response).to redirect_to(visit_path(visit))
+          expect(response).to redirect_to(visit_path(visit, locale: 'en'))
         end
       end
 
@@ -43,7 +43,7 @@ RSpec.describe CancellationsController, type: :controller do
 
         it 'redirects to the visit page' do
           post :create, params
-          expect(response).to redirect_to(visit_path(visit))
+          expect(response).to redirect_to(visit_path(visit, locale: 'en'))
         end
       end
 
@@ -66,14 +66,14 @@ RSpec.describe CancellationsController, type: :controller do
 
         it 'redirects to the visit page' do
           post :create, params
-          expect(response).to redirect_to(visit_path(visit))
+          expect(response).to redirect_to(visit_path(visit, locale: 'en'))
         end
       end
     end
 
     context 'when confirm is not checked' do
       let(:visit) { create(:visit) }
-      let(:params) { { id: visit.id } }
+      let(:params) { { id: visit.id, locale: 'en' } }
 
       it 'does not change the visit' do
         post :create, params
@@ -82,7 +82,7 @@ RSpec.describe CancellationsController, type: :controller do
 
       it 'redirects to the visit page' do
         post :create, params
-        expect(response).to redirect_to(visit_path(visit))
+        expect(response).to redirect_to(visit_path(visit, locale: 'en'))
       end
     end
   end

--- a/spec/controllers/feedback_submissions_controller_spec.rb
+++ b/spec/controllers/feedback_submissions_controller_spec.rb
@@ -8,25 +8,31 @@ RSpec.describe FeedbackSubmissionsController, type: :controller do
   end
 
   context 'new' do
+    let(:params) { { locale: 'en' } }
     it 'responds with success' do
-      get :new
+      get :new, params
       expect(response).to be_success
     end
 
     it 'renders the new template' do
-      get :new
+      get :new, params
       expect(response).to render_template('new')
     end
   end
 
   context 'create' do
     context 'with a successful feedback submission' do
-      let(:feedback_params) {
-        { email_address: 'test@maildrop.dsd.io', body: 'feedback', referrer: 'ref' }
+      let(:params) {
+        {
+          feedback_submission: {
+            email_address: 'test@maildrop.dsd.io', body: 'feedback', referrer: 'ref'
+          },
+          locale: 'en'
+        }
       }
 
       it 'renders the create template' do
-        post :create, feedback_submission: feedback_params
+        post :create, params
         expect(response).to render_template('create')
       end
 
@@ -35,27 +41,32 @@ RSpec.describe FeedbackSubmissionsController, type: :controller do
           expect(feedback.email_address).to eq('test@maildrop.dsd.io')
           expect(feedback.body).to eq('feedback')
         end
-        post :create, feedback_submission: feedback_params
+        post :create, params
       end
     end
 
     context 'with no body entered' do
-      let(:feedback_params) {
-        { email_address: 'test@maildrop.dsd.io', body: '', referrer: 'ref' }
+      let(:params) {
+        {
+          feedback_submission: {
+            email_address: 'test@maildrop.dsd.io', body: '', referrer: 'ref'
+          },
+          locale: 'en'
+        }
       }
 
       it 'responds with success' do
-        post :create, feedback_submission: feedback_params
+        post :create, params
         expect(response).to be_success
       end
 
       it 'does not send to ZenDesk' do
         expect(ZendeskTicketsJob).to receive(:perform_later).never
-        post :create, feedback_submission: feedback_params
+        post :create, params
       end
 
       it 're-renders the new template' do
-        post :create, feedback_submission: feedback_params
+        post :create, params
         expect(response).to render_template('new')
       end
     end

--- a/spec/controllers/visits_controller_spec.rb
+++ b/spec/controllers/visits_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe VisitsController, type: :controller do
     let(:visit) { create(:visit) }
 
     it 'assigns the visit to @visit' do
-      get :show, id: visit.id
+      get :show, id: visit.id, locale: 'en'
       expect(assigns(:visit)).to eq(visit)
     end
   end

--- a/spec/features/maintaining_a_visit_spec.rb
+++ b/spec/features/maintaining_a_visit_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Maintaining a visit', js: true do
 
   scenario 'viewing and withdrawing a visit request' do
     vst = create(:visit)
-    visit visit_path(vst)
+    visit visit_path(id: vst, locale: 'en')
     expect(page).to have_text('Your visit is not booked yet')
 
     check 'Yes, I want to cancel this visit'
@@ -19,7 +19,7 @@ RSpec.feature 'Maintaining a visit', js: true do
 
   scenario 'viewing and cancelling a booked visit' do
     vst = create(:booked_visit)
-    visit visit_path(vst)
+    visit visit_path(id: vst, locale: 'en')
     expect(page).to have_text('Your visit has been confirmed')
 
     check 'Yes, I want to cancel this visit'
@@ -33,28 +33,28 @@ RSpec.feature 'Maintaining a visit', js: true do
 
   scenario 'viewing a rejected visit' do
     vst = create(:rejected_visit)
-    visit visit_path(vst)
+    visit visit_path(id: vst, locale: 'en')
     expect(page).to have_text('Your visit request cannot take place')
 
     click_link 'new visit'
-    expect(current_path).to eq(booking_requests_path)
+    expect(current_path).to eq(booking_requests_path(locale: 'en'))
   end
 
   scenario 'viewing a withdrawn visit and trying again' do
     vst = create(:withdrawn_visit)
-    visit visit_path(vst)
+    visit visit_path(id: vst, locale: 'en')
     expect(page).to have_text('You cancelled this visit request')
 
     click_link 'new visit'
-    expect(current_path).to eq(booking_requests_path)
+    expect(current_path).to eq(booking_requests_path(locale: 'en'))
   end
 
   scenario 'viewing a cancelled visit and trying again' do
     vst = create(:cancelled_visit)
-    visit visit_path(vst)
+    visit visit_path(id: vst, locale: 'en')
     expect(page).to have_text('You cancelled this visit')
 
     click_link 'new visit'
-    expect(current_path).to eq(booking_requests_path)
+    expect(current_path).to eq(booking_requests_path(locale: 'en'))
   end
 end

--- a/spec/features/override_sendgrid_spec.rb
+++ b/spec/features/override_sendgrid_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "overriding Sendgrid", js: true do
     include_context 'sendgrid reports spam'
 
     scenario 'overriding spam report' do
-      visit booking_requests_path
+      visit booking_requests_path(locale: 'en')
       enter_prisoner_information
       click_button 'Continue'
       enter_visitor_information email_address: expected_email_address
@@ -49,7 +49,7 @@ RSpec.feature "overriding Sendgrid", js: true do
     include_context 'sendgrid reports a bounce'
 
     scenario 'overriding bounce' do
-      visit booking_requests_path
+      visit booking_requests_path(locale: 'en')
       enter_prisoner_information
       click_button 'Continue'
       enter_visitor_information email_address: expected_email_address
@@ -78,7 +78,7 @@ RSpec.feature "overriding Sendgrid", js: true do
   end
 
   scenario 'when no overrides are present' do
-    visit booking_requests_path
+    visit booking_requests_path(locale: 'en')
     enter_prisoner_information
     click_button 'Continue'
     enter_visitor_information email_address: expected_email_address

--- a/spec/features/request_a_visit_spec.rb
+++ b/spec/features/request_a_visit_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Booking a visit', js: true do
   let(:visitor_email) { 'ado@test.example.com' }
 
   scenario 'happy path' do
-    visit booking_requests_path
+    visit booking_requests_path(locale: 'en')
 
     enter_prisoner_information \
       prison_name: 'Reading Gaol', first_name: 'Oscar', last_name: 'Wilde'
@@ -42,7 +42,7 @@ RSpec.feature 'Booking a visit', js: true do
   end
 
   scenario 'validation errors' do
-    visit booking_requests_path
+    visit booking_requests_path(locale: 'en')
     click_button 'Continue'
     expect(page).to have_text('Prisoner first name is required')
 
@@ -56,7 +56,7 @@ RSpec.feature 'Booking a visit', js: true do
   end
 
   scenario 'review and edit' do
-    visit booking_requests_path
+    visit booking_requests_path(locale: 'en')
 
     enter_prisoner_information
     click_button 'Continue'

--- a/spec/features/submit_feedback_spec.rb
+++ b/spec/features/submit_feedback_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Submit feedback', js: true do
     text = 'How many times did the Batmobile catch a flat?'
     email_address = 'user@test.example.com'
 
-    visit booking_requests_path
+    visit booking_requests_path(locale: 'en')
     click_link 'Contact us'
 
     fill_in 'Your question', with: text
@@ -18,7 +18,7 @@ RSpec.feature 'Submit feedback', js: true do
       expect(fb.body).to eq(text)
       expect(fb.email_address).to eq(email_address)
       expect(fb.user_agent).to match('Mozilla')
-      expect(fb.referrer).to match(booking_requests_path)
+      expect(fb.referrer).to match(booking_requests_path(locale: 'en'))
     end
 
     click_button 'Send'

--- a/spec/features/unsubscribe_spec.rb
+++ b/spec/features/unsubscribe_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Booking a visit', js: true do
   include ActiveJobHelper
 
   scenario 'happy path' do
-    visit unsubscribe_path
+    visit unsubscribe_path(locale: 'en')
     expect(page).to have_text('Why did I receive this email?')
     expect(page).to have_text('because you requested a prison visit.')
   end


### PR DESCRIPTION
This is preparatory work for adding Welsh: it moves all public-facing paths under `/en/` and makes the code locale-aware. This enables us to go live with a URL structure that supports Welsh.