### PR TITLE
Disable query caching for healthchecks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'uri_template'
 gem 'virtus'
 gem 'zendesk_api'
+gem 'optional_query_cache', github: 'ministryofjustice/rails-optional_query_cache'
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git://github.com/ministryofjustice/rails-optional_query_cache.git
+  revision: e19e5b260934aa2d2089093dce97b91ff01eb71e
+  specs:
+    optional_query_cache (0.1.0)
+      activerecord (~> 4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -336,6 +343,7 @@ DEPENDENCIES
   logstasher
   moj_template (= 0.21.0)
   netaddr
+  optional_query_cache!
   parser (~> 2.3.0.pre.6)
   pg
   phantomjs

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,7 @@ module PrisonVisits
             ENV.fetch('SMOKE_TEST_EMAIL_DOMAIN', 'digital.justice.gov.uk')
           )
       )
+
+      config.middleware.swap 'ActiveRecord::QueryCache', 'OptionalQueryCache::QueryCache'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
     get 'unsubscribe', action: :show, id: 'unsubscribe'
   end
 
-  constraints format: 'json' do
+  constraints format: 'json', defaults: {disable_query_cache: true} do
     get 'ping', to: 'ping#index'
     get 'healthcheck', to: 'healthcheck#index'
   end


### PR DESCRIPTION
By default, `ActiveRecord::QueryCache` will try to connect to the database before anything else happens to prepare cached queries, which breaks for the healthcheck. We don't need the database in `ping.json`, and `healthcheck.json` should be able to control when we connect to the database (so it can report on the outcome), so connecting before either isn't worth it.

In the old app, we got around this problem by completely disabling query-caching, but that seems like a bad idea for a database-backed app.