### PR TITLE
Add missing '/en' to validation path

### DIFF
--- a/smoke_test/steps/check_your_request_page.rb
+++ b/smoke_test/steps/check_your_request_page.rb
@@ -3,7 +3,7 @@ module SmokeTest
     class CheckYourRequestPage < BaseStep
       include HttpStatusValidation
 
-      PAGE_PATH = '/request'
+      PAGE_PATH = '/en/request'
 
       def validate!
         validate_response_status!

--- a/smoke_test/steps/prisoner_page.rb
+++ b/smoke_test/steps/prisoner_page.rb
@@ -3,7 +3,7 @@ module SmokeTest
     class PrisonerPage < BaseStep
       include HttpStatusValidation
 
-      PAGE_PATH = '/request'
+      PAGE_PATH = '/en/request'
 
       def validate!
         validate_response_status!


### PR DESCRIPTION
These got missed when the `switch-language` branch was merged.