### PR TITLE
Rationalise seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ To disable visit requests to a prison, set `enabled` to `false`.
 Each prison **must** have a `nomis_id` field that corresponds to an entry in
 `estates.yml`.
 
-#### Weekly visiting slots
+#### Recurring weekly visiting slots
 
 Slots are defined per prison via a weekly schedule. Only days listed here with
 a list of slots will appear on the slot picker.
@@ -349,7 +349,7 @@ Use 3 letter strings for days of the week. Times are entered in the 24 hour
 format.
 
 ```yaml
-slots:
+recurring:
   wed:
   - 1350-1450 # creates a 1 hour slot every Wednesday from 1:50pm
   sat:
@@ -361,12 +361,12 @@ slots:
 
 Use this to make exceptions to the weekly schedule.
 
-When a day is found in `slot_anomalies` the whole day is replaced with this
+When a day is found in `anomalous` the whole day is replaced with this
 data. Therefore if the weekday usually contains multiple slots and only a
 single slot is to be edited, the rest of the slots need to be re-entered.
 
 ```yaml
-slot_anomalies:
+anomalous:
   2015-01-10:
   - 0930-1130 # replaces Saturday 10 January 2015 with only one slot at 9:30am
 ```

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -10,7 +10,7 @@ class Prison < ActiveRecord::Base
 
   validates :estate, :name, :slot_details, presence: true
   validates :enabled, inclusion: { in: [true, false] }
-  validates :email_address, presence: true, if: :enabled?
+  validates :email_address, :phone_no, presence: true, if: :enabled?
   validate :validate_unbookable_dates
 
   delegate :recurring_slots, :anomalous_slots, :unbookable_dates,

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -10,7 +10,7 @@ class Prison < ActiveRecord::Base
 
   validates :estate, :name, :slot_details, presence: true
   validates :enabled, inclusion: { in: [true, false] }
-  validates :email_address, :phone_no, presence: true, if: :enabled?
+  validates :address, :email_address, :phone_no, presence: true, if: :enabled?
   validate :validate_unbookable_dates
 
   delegate :recurring_slots, :anomalous_slots, :unbookable_dates,

--- a/app/services/prison_seeder/seed_entry.rb
+++ b/app/services/prison_seeder/seed_entry.rb
@@ -21,7 +21,7 @@ private
   attr_reader :hash
 
   def address
-    hash.fetch('address', []).join("\n")
+    hash.fetch('address', nil)
   end
 
   def adult_age
@@ -33,7 +33,7 @@ private
   end
 
   def email_address
-    hash.fetch('email', nil)
+    hash.fetch('email_address', nil)
   end
 
   def enabled
@@ -49,13 +49,13 @@ private
   end
 
   def phone_no
-    hash.fetch('phone', nil)
+    hash.fetch('phone_no', nil)
   end
 
   def slot_details
     {
-      'recurring' => hash.fetch('slots', {}),
-      'anomalous' => hash.fetch('slot_anomalies', {}),
+      'recurring' => hash.fetch('recurring', {}),
+      'anomalous' => hash.fetch('anomalous', {}),
       'unbookable' => hash.fetch('unbookable', [])
     }
   end

--- a/db/seeds/prisons/AGI-askham-grange.yml
+++ b/db/seeds/prisons/AGI-askham-grange.yml
@@ -1,12 +1,12 @@
 ---
 name: Askham Grange
 nomis_id: AGI
-address:
-- Askham Richard
-- YO23 3FT
-email: socialvisits.askhamgrange@hmps.gsi.gov.uk
+address: |-
+  Askham Richard
+  YO23 3FT
+email_address: socialvisits.askhamgrange@hmps.gsi.gov.uk
 enabled: true
-slots:
+recurring:
   sat:
   - 1345-1545
   sun:

--- a/db/seeds/prisons/AGI-askham-grange.yml
+++ b/db/seeds/prisons/AGI-askham-grange.yml
@@ -5,6 +5,7 @@ address: |-
   Askham Richard
   YO23 3FT
 email_address: socialvisits.askhamgrange@hmps.gsi.gov.uk
+phone_no: 01904 772000
 enabled: true
 recurring:
   sat:

--- a/db/seeds/prisons/ALI-isle-of-wight-albany.yml
+++ b/db/seeds/prisons/ALI-isle-of-wight-albany.yml
@@ -1,13 +1,13 @@
 ---
 name: Isle of Wight - Albany
 nomis_id: ALI
-address:
-- 55 Parkhurst Road
-- PO30 5RS
-email: socialvisitsisleofwight@hmps.gsi.gov.uk
+address: |-
+  55 Parkhurst Road
+  PO30 5RS
+email_address: socialvisitsisleofwight@hmps.gsi.gov.uk
+phone_no: 01983 634218
 enabled: true
-phone: 01983 634218
-slots:
+recurring:
   fri:
   - 1400-1600
   mon:

--- a/db/seeds/prisons/AYI-aylesbury.yml
+++ b/db/seeds/prisons/AYI-aylesbury.yml
@@ -1,13 +1,13 @@
 ---
 name: Aylesbury
 nomis_id: AYI
-address:
-- Bierton Road
-- HP20 1EH
-email: socialvisits.aylesbury@hmps.gsi.gov.uk
+address: |-
+  Bierton Road
+  HP20 1EH
+email_address: socialvisits.aylesbury@hmps.gsi.gov.uk
+phone_no: 01296 444099
 enabled: true
-phone: 01296 444099
-slots:
+recurring:
   mon:
   - 1415-1615
   sat:

--- a/db/seeds/prisons/BAI-belmarsh.yml
+++ b/db/seeds/prisons/BAI-belmarsh.yml
@@ -1,17 +1,17 @@
 ---
 name: Belmarsh
 nomis_id: BAI
-address:
-- Western Way
-- Thamesmead
-- London
-- SE28 0EB
-booking_window: 21
-email: belmarsh.visits@hmps.gsi.gov.uk
+address: |-
+  Western Way
+  Thamesmead
+  London
+  SE28 0EB
+email_address: belmarsh.visits@hmps.gsi.gov.uk
+phone_no: 020 8331 4768
 enabled: true
+booking_window: 21
 lead_days: 3
-phone: 020 8331 4768
-slots:
+recurring:
   tue:
   - 0930-1100
   - 1430-1600

--- a/db/seeds/prisons/BCI-buckley-hall.yml
+++ b/db/seeds/prisons/BCI-buckley-hall.yml
@@ -1,13 +1,13 @@
 ---
 name: Buckley Hall
 nomis_id: BCI
-address:
-- Buckley Road
-- OL12 9DP
-email: socialvisits.buckleyhall@hmps.gsi.gov.uk
+address: |-
+  Buckley Road
+  OL12 9DP
+email_address: socialvisits.buckleyhall@hmps.gsi.gov.uk
+phone_no: 01706 514350
 enabled: true
-phone: 01706 514350
-slots:
+recurring:
   mon:
   - 1400-1600
   tue:

--- a/db/seeds/prisons/BFI-bedford.yml
+++ b/db/seeds/prisons/BFI-bedford.yml
@@ -1,14 +1,14 @@
 ---
 name: Bedford
 nomis_id: BFI
-address:
-- St. Loyes Street
-- MK40 1HG
-booking_window: 14
-email: socialvisits.bedford@hmps.gsi.gov.uk
+address: |-
+  St. Loyes Street
+  MK40 1HG
+email_address: socialvisits.bedford@hmps.gsi.gov.uk
+phone_no: 01234 373196
 enabled: true
-phone: 01234 373196
-slots:
+booking_window: 14
+recurring:
   mon:
   - 1345-1445
   - 1515-1615

--- a/db/seeds/prisons/BHI-blantyre-house.yml
+++ b/db/seeds/prisons/BHI-blantyre-house.yml
@@ -1,13 +1,12 @@
 ---
 name: Blantyre House
 nomis_id: BHI
-address:
-- Goudhurst
-- TN17 2NH
-email: socialvisits.blantyrehouse@hmps.gsi.gov.uk
+address: |-
+  Goudhurst
+  TN17 2NH
+email_address: socialvisits.blantyrehouse@hmps.gsi.gov.uk
 enabled: false
-reason: it_issues
-slots:
+recurring:
   sat:
   - 1345-1600
   sun:

--- a/db/seeds/prisons/BLI-bristol.yml
+++ b/db/seeds/prisons/BLI-bristol.yml
@@ -1,14 +1,14 @@
 ---
 name: Bristol
 nomis_id: BLI
-address:
-- 19 Cambridge Road
-- Bristol
-- BS7 8PS
-email: socialvisits.bristol@hmps.gsi.gov.uk
+address: |-
+  19 Cambridge Road
+  Bristol
+  BS7 8PS
+email_address: socialvisits.bristol@hmps.gsi.gov.uk
+phone_no: 0117 372 3213
 enabled: true
-phone: 0117 372 3213
-slots:
+recurring:
   mon:
   - 1400-1600
   tue:

--- a/db/seeds/prisons/BNI-bullingdon-convicted-only.yml
+++ b/db/seeds/prisons/BNI-bullingdon-convicted-only.yml
@@ -1,13 +1,13 @@
 ---
 name: Bullingdon (Convicted Only)
 nomis_id: BNI
-address:
-- Bicester
-- OX25 1PZ
-email: socialvisits.bullingdon@hmps.gsi.gov.uk
+address: |-
+  Bicester
+  OX25 1PZ
+email_address: socialvisits.bullingdon@hmps.gsi.gov.uk
+phone_no: 01869 353176
 enabled: true
-phone: 01869 353176
-slots:
+recurring:
   mon:
   - 1400-1610
   sat:

--- a/db/seeds/prisons/BNI-bullingdon-remand-only.yml
+++ b/db/seeds/prisons/BNI-bullingdon-remand-only.yml
@@ -1,13 +1,13 @@
 ---
 name: Bullingdon (Remand Only)
 nomis_id: BNI
-address:
-- Bicester
-- OX25 1PZ
-email: socialvisits.bullingdon@hmps.gsi.gov.uk
+address: |-
+  Bicester
+  OX25 1PZ
+email_address: socialvisits.bullingdon@hmps.gsi.gov.uk
+phone_no: 01869 353176
 enabled: true
-phone: 01869 353176
-slots:
+recurring:
   mon:
   - 1345-1545
   tue:

--- a/db/seeds/prisons/BRI-bure.yml
+++ b/db/seeds/prisons/BRI-bure.yml
@@ -1,13 +1,13 @@
 ---
 name: Bure
 nomis_id: BRI
-address:
-- Jaguar Drive
-- NR10 5GB
-email: socialvisits.bure@hmps.gsi.gov.uk
+address: |-
+  Jaguar Drive
+  NR10 5GB
+email_address: socialvisits.bure@hmps.gsi.gov.uk
+phone_no: 01603 326252
 enabled: true
-phone: 01603 326252
-slots:
+recurring:
   fri:
   - 1400-1600
   sat:

--- a/db/seeds/prisons/BSI-brinsford.yml
+++ b/db/seeds/prisons/BSI-brinsford.yml
@@ -1,16 +1,16 @@
 ---
 name: Brinsford
 nomis_id: BSI
-address:
-- New Road
-- Featherstone
-- Wolverhampton
-- WV10 7PY
-adult_age: 10
-email: visitsbooking.westmidlands@noms.gsi.gov.uk
+address: |-
+  New Road
+  Featherstone
+  Wolverhampton
+  WV10 7PY
+email_address: visitsbooking.westmidlands@noms.gsi.gov.uk
+phone_no: 0300 060 6500
 enabled: true
-phone: 0300 060 6500
-slots:
+adult_age: 10
+recurring:
   tue:
   - 1330-1615
   thu:

--- a/db/seeds/prisons/BXI-brixton.yml
+++ b/db/seeds/prisons/BXI-brixton.yml
@@ -1,13 +1,13 @@
 ---
 name: Brixton
 nomis_id: BXI
-address:
-- Jebb Avenue
-- SW2 5XF
-email: socialvisits.brixton@hmps.gsi.gov.uk
+address: |-
+  Jebb Avenue
+  SW2 5XF
+email_address: socialvisits.brixton@hmps.gsi.gov.uk
+phone_no: 020 8678 1433
 enabled: true
-phone: 020 8678 1433
-slots:
+recurring:
   sat:
   - 0900-1015
   - 1045-1200

--- a/db/seeds/prisons/CDI-chelmsford.yml
+++ b/db/seeds/prisons/CDI-chelmsford.yml
@@ -1,13 +1,13 @@
 ---
 name: Chelmsford
 nomis_id: CDI
-address:
-- 200 Springfield Road
-- 'CM2 6LQ '
-email: socialvisits.chelmsford@hmps.gsi.gov.uk
+address: |-
+  200 Springfield Road
+  CM2 6LQ
+email_address: socialvisits.chelmsford@hmps.gsi.gov.uk
+phone_no: 01245 552265
 enabled: true
-phone: 01245 552265
-slots:
+recurring:
   mon:
   - 1415-1600
   sat:

--- a/db/seeds/prisons/CFI-cardiff.yml
+++ b/db/seeds/prisons/CFI-cardiff.yml
@@ -1,15 +1,15 @@
 ---
 name: Cardiff
 nomis_id: CFI
-address:
-- Knox Road
-- Cardiff
-- CF24 0UG
-booking_window: 14
-email: socialvisits.cardiff@hmps.gsi.gov.uk
+address: |-
+  Knox Road
+  Cardiff
+  CF24 0UG
+email_address: socialvisits.cardiff@hmps.gsi.gov.uk
+phone_no: 029 20923327
 enabled: true
-phone: 029 20923327
-slots:
+booking_window: 14
+recurring:
   mon:
   - 1330-1430
   - 1445-1545

--- a/db/seeds/prisons/CKI-cookham-wood.yml
+++ b/db/seeds/prisons/CKI-cookham-wood.yml
@@ -1,13 +1,13 @@
 ---
 name: Cookham Wood
 nomis_id: CKI
-address:
-- Sir Evelyn Road
-- ME1 3LU
-email: socialvisits.cookhamwood@hmps.gsi.gov.uk
+address: |-
+  Sir Evelyn Road
+  ME1 3LU
+email_address: socialvisits.cookhamwood@hmps.gsi.gov.uk
+phone_no: 01634 202557
 enabled: true
-phone: 01634 202557
-slots:
+recurring:
   wed:
   - 1345-1615
   sat:

--- a/db/seeds/prisons/CLI-coldingley.yml
+++ b/db/seeds/prisons/CLI-coldingley.yml
@@ -1,13 +1,13 @@
 ---
 name: Coldingley
 nomis_id: CLI
-address:
-- Shaftesbury Road
-- GU24 9EX
-email: socialvisits.coldingley@hmps.gsi.gov.uk
+address: |-
+  Shaftesbury Road
+  GU24 9EX
+email_address: socialvisits.coldingley@hmps.gsi.gov.uk
+phone_no: 01483 344418
 enabled: true
-phone: 01483 344418
-slots:
+recurring:
   mon:
   - 1400-1545
   wed:

--- a/db/seeds/prisons/CWI-channings-wood.yml
+++ b/db/seeds/prisons/CWI-channings-wood.yml
@@ -1,14 +1,14 @@
 ---
 name: Channings Wood
 nomis_id: CWI
-address:
-- Denbury
-- Newton Abbot
-- TQ12 6DW
-email: socialvisits.channingswood@hmps.gsi.gov.uk
+address: |-
+  Denbury
+  Newton Abbot
+  TQ12 6DW
+email_address: socialvisits.channingswood@hmps.gsi.gov.uk
+phone_no: 01803 812060
 enabled: true
-phone: 01803 812060
-slots:
+recurring:
   wed:
   - 1400-1600
   fri:

--- a/db/seeds/prisons/DAI-dartmoor.yml
+++ b/db/seeds/prisons/DAI-dartmoor.yml
@@ -1,14 +1,14 @@
 ---
 name: Dartmoor
 nomis_id: DAI
-address:
-- Princetown
-- PL20 6RR
-email: socvisdartmoor@hmps.gsi.gov.uk
+address: |-
+  Princetown
+  PL20 6RR
+email_address: socvisdartmoor@hmps.gsi.gov.uk
+phone_no: 01822 322022
 enabled: true
 lead_days: 4
-phone: 01822 322022
-slots:
+recurring:
   tue:
   - 1400-1600
   sat:

--- a/db/seeds/prisons/DHI-drake-hall.yml
+++ b/db/seeds/prisons/DHI-drake-hall.yml
@@ -1,14 +1,14 @@
 ---
 name: Drake Hall
 nomis_id: DHI
-address:
-- Eccleshall
-- Staffordshire
-- ST21 6LQ
-email: visitsbooking.westmidlands@noms.gsi.gov.uk
+address: |-
+  Eccleshall
+  Staffordshire
+  ST21 6LQ
+email_address: visitsbooking.westmidlands@noms.gsi.gov.uk
+phone_no: 0300 060 6501
 enabled: true
-phone: 0300 060 6501
-slots:
+recurring:
   tue:
   - 1330-1545
   sat:

--- a/db/seeds/prisons/DMI-durham.yml
+++ b/db/seeds/prisons/DMI-durham.yml
@@ -1,14 +1,14 @@
 ---
 name: Durham
 nomis_id: DMI
-address:
-- Old Elvet
-- Durham
-- DH1 3HU
-email: socialvisits.durham@hmps.gsi.gov.uk
+address: |-
+  Old Elvet
+  Durham
+  DH1 3HU
+email_address: socialvisits.durham@hmps.gsi.gov.uk
+phone_no: 0191 3323417
 enabled: true
-phone: 0191 3323417
-slots:
+recurring:
   mon:
   - 1345-1545
   tue:

--- a/db/seeds/prisons/DTI-deerbolt.yml
+++ b/db/seeds/prisons/DTI-deerbolt.yml
@@ -1,13 +1,13 @@
 ---
 name: Deerbolt
 nomis_id: DTI
-address:
-- Bowes Road
-- DL12 9BG
-email: socialvisits.deerbolt@hmps.gsi.gov.uk
+address: |-
+  Bowes Road
+  DL12 9BG
+email_address: socialvisits.deerbolt@hmps.gsi.gov.uk
+phone_no: 01833 633349
 enabled: true
-phone: 01833 633349
-slots:
+recurring:
   thu:
   - 1345-1545
   sat:

--- a/db/seeds/prisons/DWI-downview.yml
+++ b/db/seeds/prisons/DWI-downview.yml
@@ -1,14 +1,13 @@
 ---
 name: Downview
 nomis_id: DWI
-address:
-- Sutton Lane
-- SM2 5PD
-email: socialvisits.downview@hmps.gsi.gov.uk
+address: |-
+  Sutton Lane
+  SM2 5PD
+email_address: socialvisits.downview@hmps.gsi.gov.uk
+phone_no: 020 8196 6359
 enabled: false
-phone: 020 8196 6359
-reason: coming_soon
-slots:
+recurring:
   sat:
   - 1330-1530
   sun:

--- a/db/seeds/prisons/EEI-erlestoke.yml
+++ b/db/seeds/prisons/EEI-erlestoke.yml
@@ -1,13 +1,13 @@
 ---
 name: Erlestoke
 nomis_id: EEI
-address:
-- DEVIZES
-- SN10 5TU
-email: eecmbookavisit@hmps.gsi.gov.uk
+address: |-
+  DEVIZES
+  SN10 5TU
+email_address: eecmbookavisit@hmps.gsi.gov.uk
+phone_no: 01380 814264
 enabled: true
-phone: 01380 814264
-slots:
+recurring:
   sat:
   - 0900-1130
   - 1315-1600

--- a/db/seeds/prisons/EHI-standford-hill.yml
+++ b/db/seeds/prisons/EHI-standford-hill.yml
@@ -1,13 +1,13 @@
 ---
 name: Standford Hill
 nomis_id: EHI
-address:
-- Church Road
-- 'ME12 4AA '
-email: socialvisits.standfordhill@hmps.gsi.gov.uk
+address: |-
+  Church Road
+  ME12 4AA
+email_address: socialvisits.standfordhill@hmps.gsi.gov.uk
+phone_no: 0300 060 6603
 enabled: true
-phone: 0300 060 6603
-slots:
+recurring:
   wed:
   - 1345-1545
   sat:

--- a/db/seeds/prisons/ESI-east-sutton-park.yml
+++ b/db/seeds/prisons/ESI-east-sutton-park.yml
@@ -1,13 +1,12 @@
 ---
 name: East Sutton Park
 nomis_id: ESI
-address:
-- Sutton Valence
-- ME17 3DF
-email: socialvisits.eastsuttonpark@hmps.gsi.gov.uk
+address: |-
+  Sutton Valence
+  ME17 3DF
+email_address: socialvisits.eastsuttonpark@hmps.gsi.gov.uk
 enabled: false
-reason: coming_soon
-slots:
+recurring:
   sat:
   - 1330-1530
   sun:

--- a/db/seeds/prisons/EVI-everthorpe.yml
+++ b/db/seeds/prisons/EVI-everthorpe.yml
@@ -1,13 +1,13 @@
 ---
 name: Everthorpe
 nomis_id: EVI
-address:
-- 1a Beck Road
-- HU15 1RB
-email: socialvisits.everthorpe@hmps.gsi.gov.uk
+address: |-
+  1a Beck Road
+  HU15 1RB
+email_address: socialvisits.everthorpe@hmps.gsi.gov.uk
+phone_no: 01430 426505
 enabled: true
-phone: 01430 426505
-slots:
+recurring:
   fri:
   - 1415-1615
   mon:

--- a/db/seeds/prisons/EWI-eastwood-park.yml
+++ b/db/seeds/prisons/EWI-eastwood-park.yml
@@ -1,13 +1,13 @@
 ---
 name: Eastwood Park
 nomis_id: EWI
-address:
-- Falfield
-- GL12 8DB
-email: socialvisits.eastwoodpark@hmps.gsi.gov.uk
+address: |-
+  Falfield
+  GL12 8DB
+email_address: socialvisits.eastwoodpark@hmps.gsi.gov.uk
+phone_no: 01454 382159
 enabled: true
-phone: 01454 382159
-slots:
+recurring:
   tue:
   - 1400-1500
   - 1530-1630

--- a/db/seeds/prisons/EXI-exeter.yml
+++ b/db/seeds/prisons/EXI-exeter.yml
@@ -1,13 +1,13 @@
 ---
 name: Exeter
 nomis_id: EXI
-address:
-- New North Road
-- EX4 4EX
-email: socialvisits.exeter@hmps.gsi.gov.uk
+address: |-
+  New North Road
+  EX4 4EX
+email_address: socialvisits.exeter@hmps.gsi.gov.uk
+phone_no: 01392 41 5833
 enabled: true
-phone: 01392 41 5833
-slots:
+recurring:
   mon:
   - 1415-1615
   tue:

--- a/db/seeds/prisons/EYI-elmley.yml
+++ b/db/seeds/prisons/EYI-elmley.yml
@@ -1,13 +1,13 @@
 ---
 name: Elmley
 nomis_id: EYI
-address:
-- Church Road
-- ME12 4DZ
-email: socialvisits.elmley@hmps.gsi.gov.uk
+address: |-
+  Church Road
+  ME12 4DZ
+email_address: socialvisits.elmley@hmps.gsi.gov.uk
+phone_no: 0300 060 6605
 enabled: true
-phone: 0300 060 6605
-slots:
+recurring:
   mon:
   - 1400-1530
   fri:

--- a/db/seeds/prisons/FDI-ford.yml
+++ b/db/seeds/prisons/FDI-ford.yml
@@ -5,6 +5,7 @@ address: |-
   Arundel
   BN18 0BX
 email_address: socialvisits.ford@hmps.gsi.gov.uk
+phone_no: 01903 663000
 enabled: true
 recurring:
   wed:

--- a/db/seeds/prisons/FDI-ford.yml
+++ b/db/seeds/prisons/FDI-ford.yml
@@ -1,12 +1,12 @@
 ---
 name: Ford
 nomis_id: FDI
-address:
-- Arundel
-- BN18 0BX
-email: socialvisits.ford@hmps.gsi.gov.uk
+address: |-
+  Arundel
+  BN18 0BX
+email_address: socialvisits.ford@hmps.gsi.gov.uk
 enabled: true
-slots:
+recurring:
   wed:
   - 1800-2000
   fri:

--- a/db/seeds/prisons/FHI-foston-hall.yml
+++ b/db/seeds/prisons/FHI-foston-hall.yml
@@ -1,15 +1,15 @@
 ---
 name: Foston Hall
 nomis_id: FHI
-address:
-- Foston Hall
-- Derby
-- Foston
-- DE65 5DN
-email: socialvisits.fostonhall@hmps.gsi.gov.uk
+address: |-
+  Foston Hall
+  Derby
+  Foston
+  DE65 5DN
+email_address: socialvisits.fostonhall@hmps.gsi.gov.uk
+phone_no: 01283 584357
 enabled: true
-phone: 01283 584357
-slots:
+recurring:
   mon:
   - 1400-1600
   wed:

--- a/db/seeds/prisons/FKI-frankland.yml
+++ b/db/seeds/prisons/FKI-frankland.yml
@@ -1,16 +1,16 @@
 ---
 name: Frankland
 nomis_id: FKI
+address: |-
+  Brasside
+  Durham
+  DH1 5YD
+email_address: SocialVisitsBooking.Frankland@hmps.gsi.gov.uk
+phone_no: 01913 765048
 enabled: true
-address:
-- Brasside
-- Durham
-- DH1 5YD
 booking_window: 28
-email: SocialVisitsBooking.Frankland@hmps.gsi.gov.uk
 lead_days: 3
-phone: 01913 765048
-slots:
+recurring:
   tue:
   - 1400-1600
   wed:

--- a/db/seeds/prisons/FMI-feltham-young-adults-18-21-only.yml
+++ b/db/seeds/prisons/FMI-feltham-young-adults-18-21-only.yml
@@ -1,13 +1,13 @@
 ---
 name: Feltham (Young Adults 18-21 only)
 nomis_id: FMI
-address:
-- Bedfont Road
-- TW13 4ND
-email: socialvisits.feltham@hmps.gsi.gov.uk
+address: |-
+  Bedfont Road
+  TW13 4ND
+email_address: socialvisits.feltham@hmps.gsi.gov.uk
+phone_no: 020 8844 5400
 enabled: true
-phone: 020 8844 5400
-slots:
+recurring:
   mon:
   - 1330-1500
   - 1500-1630

--- a/db/seeds/prisons/FMI-feltham-young-people-15-18-only.yml
+++ b/db/seeds/prisons/FMI-feltham-young-people-15-18-only.yml
@@ -1,13 +1,13 @@
 ---
 name: Feltham (Young People 15-18 only)
 nomis_id: FMI
-address:
-- Bedfont Road
-- TW13 4ND
-email: socialvisits.feltham@hmps.gsi.gov.uk
+address: |-
+  Bedfont Road
+  TW13 4ND
+email_address: socialvisits.feltham@hmps.gsi.gov.uk
+phone_no: 020 8844 5400
 enabled: true
-phone: 020 8844 5400
-slots:
+recurring:
   tue:
   - 1330-1500
   - 1500-1630

--- a/db/seeds/prisons/FNI-full-sutton.yml
+++ b/db/seeds/prisons/FNI-full-sutton.yml
@@ -1,15 +1,15 @@
 ---
 name: Full Sutton
 nomis_id: FNI
-address:
-- York
-- YO41 1PS
-booking_window: 28
-email: socialvisits.fullsutton@hmps.gsi.gov.uk
+address: |-
+  York
+  YO41 1PS
+email_address: socialvisits.fullsutton@hmps.gsi.gov.uk
+phone_no: 01759 475355
 enabled: true
+booking_window: 28
 lead_days: 3
-phone: 01759 475355
-slots:
+recurring:
   thu:
   - 1410-1615
   fri:

--- a/db/seeds/prisons/FSI-featherstone.yml
+++ b/db/seeds/prisons/FSI-featherstone.yml
@@ -1,15 +1,15 @@
 ---
 name: Featherstone
 nomis_id: FSI
-address:
-- New Road
-- Featherstone
-- Wolverhampton
-- WV10 7PU
-email: visitsbooking.westmidlands@noms.gsi.gov.uk
+address: |-
+  New Road
+  Featherstone
+  Wolverhampton
+  WV10 7PU
+email_address: visitsbooking.westmidlands@noms.gsi.gov.uk
+phone_no: 0300 060 6502
 enabled: true
-phone: 0300 060 6502
-slots:
+recurring:
   mon:
   - 1400-1630
   tue:

--- a/db/seeds/prisons/GMI-guys-marsh.yml
+++ b/db/seeds/prisons/GMI-guys-marsh.yml
@@ -1,13 +1,13 @@
 ---
 name: Guys Marsh
 nomis_id: GMI
-address:
-- SHAFTESBURY
-- 'SP7 0AH '
-email: socialvisitsguysmarsh@hmps.gsi.gov.uk
+address: |-
+  Shaftesbury
+  SP7 0AH
+email_address: socialvisitsguysmarsh@hmps.gsi.gov.uk
+phone_no: 01747 856586
 enabled: true
-phone: 01747 856586
-slots:
+recurring:
   fri:
   - 1400-1600
   sat:

--- a/db/seeds/prisons/GNI-grendon.yml
+++ b/db/seeds/prisons/GNI-grendon.yml
@@ -1,13 +1,13 @@
 ---
 name: Grendon
 nomis_id: GNI
-address:
-- Grendon Underwood
-- HP18 0TL
-email: socialvisits.grendon@hmps.gsi.gov.uk
+address: |-
+  Grendon Underwood
+  HP18 0TL
+email_address: socialvisits.grendon@hmps.gsi.gov.uk
+phone_no: 01296 445000
 enabled: true
-phone: 01296 445000
-slots:
+recurring:
   sat:
   - 1345-1545
   sun:

--- a/db/seeds/prisons/GPI-glen-parva.yml
+++ b/db/seeds/prisons/GPI-glen-parva.yml
@@ -1,13 +1,13 @@
 ---
 name: Glen Parva
 nomis_id: GPI
-address:
-- Tigers Road
-- 'LE8 4TN '
-email: socialvisits.glenparva@hmps.gsi.gov.uk
+address: |-
+  Tigers Road
+  LE8 4TN
+email_address: socialvisits.glenparva@hmps.gsi.gov.uk
+phone_no: 0116 228 4366
 enabled: true
-phone: 0116 228 4366
-slots:
+recurring:
   mon:
   - 1400-1545
   sat:

--- a/db/seeds/prisons/GTI-gartree.yml
+++ b/db/seeds/prisons/GTI-gartree.yml
@@ -1,15 +1,15 @@
 ---
 name: Gartree
 nomis_id: GTI
-address:
-- Gallow Field Rd
-- Market Harborough
-- Leicestershire
-- LE16 7RP
-email: socialvisits.gartree@hmps.gsi.gov.uk
+address: |-
+  Gallow Field Rd
+  Market Harborough
+  Leicestershire
+  LE16 7RP
+email_address: socialvisits.gartree@hmps.gsi.gov.uk
+phone_no: 01858 426 727
 enabled: true
-phone: 01858 426 727
-slots:
+recurring:
   tue:
   - 1400-1600
   thu:

--- a/db/seeds/prisons/HBI-hollesley-bay-open.yml
+++ b/db/seeds/prisons/HBI-hollesley-bay-open.yml
@@ -1,12 +1,12 @@
 ---
 name: Hollesley Bay Open
 nomis_id: HBI
-address:
-- WOODBRIDGE
-- 'IP12 3JW '
-email: socialvisits.hollesleybay@hmps.gsi.gov.uk
+address: |-
+  Woodbridge
+  IP12 3JW
+email_address: socialvisits.hollesleybay@hmps.gsi.gov.uk
 enabled: true
-slots:
+recurring:
   sat:
   - 1400-1545
   sun:

--- a/db/seeds/prisons/HBI-hollesley-bay-open.yml
+++ b/db/seeds/prisons/HBI-hollesley-bay-open.yml
@@ -5,6 +5,7 @@ address: |-
   Woodbridge
   IP12 3JW
 email_address: socialvisits.hollesleybay@hmps.gsi.gov.uk
+phone_no: 01394 412400
 enabled: true
 recurring:
   sat:

--- a/db/seeds/prisons/HCI-huntercombe.yml
+++ b/db/seeds/prisons/HCI-huntercombe.yml
@@ -1,13 +1,13 @@
 ---
 name: Huntercombe
 nomis_id: HCI
-address:
-- Huntercombe Place
-- 'RG9 5SB '
-email: socialvisits.huntercombe@hmps.gsi.gov.uk
+address: |-
+  Huntercombe Place
+  RG9 5SB
+email_address: socialvisits.huntercombe@hmps.gsi.gov.uk
+phone_no: 01491 643151
 enabled: true
-phone: 01491 643151
-slots:
+recurring:
   mon:
   - 1345-1615
   sat:

--- a/db/seeds/prisons/HDI-hatfield-lakes.yml
+++ b/db/seeds/prisons/HDI-hatfield-lakes.yml
@@ -1,13 +1,13 @@
 ---
 name: Hatfield Lakes
 nomis_id: HDI
-address:
-- Thorne Road
-- DN7 6El
-email: socialvisitshatfield@hmps.gsi.gov.uk
+address: |-
+  Thorne Road
+  DN7 6El
+email_address: socialvisitshatfield@hmps.gsi.gov.uk
+phone_no: 01405 746611
 enabled: true
-phone: 01405 746611
-slots:
+recurring:
   fri:
   - 1400-1600
   sat:

--- a/db/seeds/prisons/HDI-hatfield-open.yml
+++ b/db/seeds/prisons/HDI-hatfield-open.yml
@@ -1,13 +1,13 @@
 ---
 name: Hatfield Open
 nomis_id: HDI
-address:
-- Thorne Road
-- DN7 6El
-email: socialvisitshatfield@hmps.gsi.gov.uk
+address: |-
+  Thorne Road
+  DN7 6El
+email_address: socialvisitshatfield@hmps.gsi.gov.uk
+phone_no: 01405 746611
 enabled: true
-phone: 01405 746611
-slots:
+recurring:
   thu:
   - 1400-1600
   sat:

--- a/db/seeds/prisons/HEI-hewell.yml
+++ b/db/seeds/prisons/HEI-hewell.yml
@@ -1,16 +1,16 @@
 ---
 name: Hewell
 nomis_id: HEI
-address:
-- Hewell Lane
-- Redditch
-- Worcestershire
-- B97 6QS
-adult_age: 10
-email: visitsbooking.westmidlands@noms.gsi.gov.uk
+address: |-
+  Hewell Lane
+  Redditch
+  Worcestershire
+  B97 6QS
+email_address: visitsbooking.westmidlands@noms.gsi.gov.uk
+phone_no: 0300 060 6503
 enabled: true
-phone: 0300 060 6503
-slots:
+adult_age: 10
+recurring:
   mon:
   - 1400-1630
   tue:

--- a/db/seeds/prisons/HHI-holme-house.yml
+++ b/db/seeds/prisons/HHI-holme-house.yml
@@ -1,13 +1,13 @@
 ---
 name: Holme House
 nomis_id: HHI
-address:
-- Holme House Road
-- S18 2QU
-email: socialvisits.holmehouse@hmps.gsi.gov.uk
+address: |-
+  Holme House Road
+  S18 2QU
+email_address: socialvisits.holmehouse@hmps.gsi.gov.uk
+phone_no: 03000 606602
 enabled: true
-phone: 03000 606602
-slots:
+recurring:
   fri:
   - 1345-1545
   sat:

--- a/db/seeds/prisons/HII-hindley.yml
+++ b/db/seeds/prisons/HII-hindley.yml
@@ -1,13 +1,13 @@
 ---
 name: Hindley
 nomis_id: HII
-address:
-- Gibson Street
-- WN2 5TH
-email: socialvisits.hindley@hmps.gsi.gov.uk
+address: |-
+  Gibson Street
+  WN2 5TH
+email_address: socialvisits.hindley@hmps.gsi.gov.uk
+phone_no: 01942 663492
 enabled: true
-phone: 01942 663492
-slots:
+recurring:
   mon:
   - 1400-1600
   tue:

--- a/db/seeds/prisons/HLI-hull.yml
+++ b/db/seeds/prisons/HLI-hull.yml
@@ -1,14 +1,13 @@
 ---
 name: Hull
 nomis_id: HLI
-address:
-- Hedon Road
-- 'HU9 5LS '
-email: socialvisits.hull@hmps.gsi.gov.uk
+address: |-
+  Hedon Road
+  HU9 5LS
+email_address: socialvisits.hull@hmps.gsi.gov.uk
+phone_no: 01482 282016
 enabled: false
-phone: 01482 282016
-reason: coming_soon
-slots:
+recurring:
   fri:
   - 0930-1130
   - 1345-1545

--- a/db/seeds/prisons/HOI-high-down.yml
+++ b/db/seeds/prisons/HOI-high-down.yml
@@ -1,13 +1,13 @@
 ---
 name: High Down
 nomis_id: HOI
-address:
-- Sutton Lane
-- SM2 5PJ
-email: socialvisits.highdown@hmps.gsi.gov.uk
+address: |-
+  Sutton Lane
+  SM2 5PJ
+email_address: socialvisits.highdown@hmps.gsi.gov.uk
+phone_no: 020 7147 6570
 enabled: true
-phone: 020 7147 6570
-slots:
+recurring:
   sat:
   - 1400-1600
   sun:

--- a/db/seeds/prisons/HPI-highpoint-north.yml
+++ b/db/seeds/prisons/HPI-highpoint-north.yml
@@ -1,13 +1,13 @@
 ---
 name: Highpoint North
 nomis_id: HPI
-address:
-- Stradishall
-- 'CB8 9YG '
-email: socialvisits.highpoint@hmps.gsi.gov.uk
+address: |-
+  Stradishall
+  CB8 9YG
+email_address: socialvisits.highpoint@hmps.gsi.gov.uk
+phone_no: 01440 743134
 enabled: true
-phone: 01440 743134
-slots:
+recurring:
   fri:
   - 1430-1630
   sat:

--- a/db/seeds/prisons/HPI-highpoint-south.yml
+++ b/db/seeds/prisons/HPI-highpoint-south.yml
@@ -1,13 +1,13 @@
 ---
 name: Highpoint South
 nomis_id: HPI
-address:
-- Stradishall
-- 'CB8 9YG '
-email: socialvisits.highpoint@hmps.gsi.gov.uk
+address: |-
+  Stradishall
+  CB8 9YG
+email_address: socialvisits.highpoint@hmps.gsi.gov.uk
+phone_no: 01440 743134
 enabled: true
-phone: 01440 743134
-slots:
+recurring:
   fri:
   - 1430-1630
   mon:

--- a/db/seeds/prisons/HVI-haverigg.yml
+++ b/db/seeds/prisons/HVI-haverigg.yml
@@ -1,14 +1,14 @@
 ---
 name: Haverigg
 nomis_id: HVI
-address:
-- MILLOM
-- 'LA18 4NA '
-adult_age: 10
-email: socialvisits.haverigg@hmps.gsi.gov.uk
+address: |-
+  Millom
+  LA18 4NA
+email_address: socialvisits.haverigg@hmps.gsi.gov.uk
+phone_no: 01229713016
 enabled: true
-phone: 01229713016
-slots:
+adult_age: 10
+recurring:
   mon:
   - 1400-1545
   wed:

--- a/db/seeds/prisons/HYI-holloway.yml
+++ b/db/seeds/prisons/HYI-holloway.yml
@@ -1,14 +1,14 @@
 ---
 name: Holloway
 nomis_id: HYI
-address:
-- Pankhurst Road
-- London
-- N7 0NU
-email: socialvisits.holloway@hmps.gsi.gov.uk
+address: |-
+  Pankhurst Road
+  London
+  N7 0NU
+email_address: socialvisits.holloway@hmps.gsi.gov.uk
+phone_no: 020 7979 4751
 enabled: true
-phone: 020 7979 4751
-slots:
+recurring:
   mon:
   - 1430-1530
   tue:

--- a/db/seeds/prisons/IWI-isle-of-wight-parkhurst.yml
+++ b/db/seeds/prisons/IWI-isle-of-wight-parkhurst.yml
@@ -1,13 +1,13 @@
 ---
 name: Isle of Wight - Parkhurst
 nomis_id: IWI
-address:
-- 'Clissold Road '
-- 'PO30 5RS '
-email: socialvisitsisleofwight@hmps.gsi.gov.uk
+address: |-
+  Clissold Road
+  PO30 5RS
+email_address: socialvisitsisleofwight@hmps.gsi.gov.uk
+phone_no: 01983 634218
 enabled: true
-phone: 01983 634218
-slots:
+recurring:
   fri:
   - 1400-1600
   mon:

--- a/db/seeds/prisons/KMI-kirkham.yml
+++ b/db/seeds/prisons/KMI-kirkham.yml
@@ -6,6 +6,7 @@ address: |-
    Kirkham
   PR4 2RN
 email_address: socialvisits.kirkham@hmps.gsi.gov.uk
+phone_no: 01772 675400
 enabled: true
 recurring:
   fri:

--- a/db/seeds/prisons/KMI-kirkham.yml
+++ b/db/seeds/prisons/KMI-kirkham.yml
@@ -1,13 +1,13 @@
 ---
 name: Kirkham
 nomis_id: KMI
-address:
-- Freckleton Road
-- ' Kirkham'
-- PR4 2RN
-email: socialvisits.kirkham@hmps.gsi.gov.uk
+address: |-
+  Freckleton Road
+   Kirkham
+  PR4 2RN
+email_address: socialvisits.kirkham@hmps.gsi.gov.uk
 enabled: true
-slots:
+recurring:
   fri:
   - 1300-1530
   sat:

--- a/db/seeds/prisons/KTI-kennet.yml
+++ b/db/seeds/prisons/KTI-kennet.yml
@@ -1,13 +1,13 @@
 ---
 name: Kennet
 nomis_id: KTI
-address:
-- Parkbourn
-- 'L31 1HX '
-email: socialvisits.kennet@hmps.gsi.gov.uk
+address: |-
+  Parkbourn
+  L31 1HX
+email_address: socialvisits.kennet@hmps.gsi.gov.uk
+phone_no: 0151 213 3179
 enabled: true
-phone: 0151 213 3179
-slots:
+recurring:
   sat:
   - 0900-1000
   - 1030-1130

--- a/db/seeds/prisons/KVI-kirklevington-grange.yml
+++ b/db/seeds/prisons/KVI-kirklevington-grange.yml
@@ -2,4 +2,3 @@
 name: Kirklevington Grange
 nomis_id: KVI
 enabled: false
-reason: coming_soon

--- a/db/seeds/prisons/LCI-leicester.yml
+++ b/db/seeds/prisons/LCI-leicester.yml
@@ -1,13 +1,13 @@
 ---
 name: Leicester
 nomis_id: LCI
-address:
-- 116 Welford Road
-- LE2 7AJ
-email: socialvisitsleiceste@hmps.gsi.gov.uk
+address: |-
+  116 Welford Road
+  LE2 7AJ
+email_address: socialvisitsleiceste@hmps.gsi.gov.uk
+phone_no: 0116 228 3128
 enabled: true
-phone: 0116 228 3128
-slots:
+recurring:
   mon:
   - 1415-1615
   tue:

--- a/db/seeds/prisons/LEI-leeds.yml
+++ b/db/seeds/prisons/LEI-leeds.yml
@@ -1,13 +1,13 @@
 ---
 name: Leeds
 nomis_id: LEI
-address:
-- Gloucester Terrace
-- 'LS12 2TJ '
-email: socialvisits.leeds@hmps.gsi.gov.uk
+address: |-
+  Gloucester Terrace
+  LS12 2TJ
+email_address: socialvisits.leeds@hmps.gsi.gov.uk
+phone_no: 0113 203 2995
 enabled: true
-phone: 0113 203 2995
-slots:
+recurring:
   fri:
   - 1030-1130
   - 1400-1500

--- a/db/seeds/prisons/LFI-lancaster-farms.yml
+++ b/db/seeds/prisons/LFI-lancaster-farms.yml
@@ -1,13 +1,13 @@
 ---
 name: Lancaster Farms
 nomis_id: LFI
-address:
-- Stone Row Head
-- LA1 3QZ
-email: lancasterfarmsdomesticvisitsbooking@hmps.gsi.gov.uk
+address: |-
+  Stone Row Head
+  LA1 3QZ
+email_address: lancasterfarmsdomesticvisitsbooking@hmps.gsi.gov.uk
+phone_no: 01524 563636
 enabled: true
-phone: 01524 563636
-slots:
+recurring:
   sat:
   - 1400-1500
   - 1530-1630

--- a/db/seeds/prisons/LHI-lindholme.yml
+++ b/db/seeds/prisons/LHI-lindholme.yml
@@ -1,13 +1,13 @@
 ---
 name: Lindholme
 nomis_id: LHI
-address:
-- Bawtry Road
-- 'DN7 6EE '
-email: socialvisits.lindholme@hmps.gsi.gov.uk
+address: |-
+  Bawtry Road
+  DN7 6EE
+email_address: socialvisits.lindholme@hmps.gsi.gov.uk
+phone_no: 01302 524980
 enabled: true
-phone: 01302 524980
-slots:
+recurring:
   mon:
   - 1730-1900
   sat:

--- a/db/seeds/prisons/LII-lincoln.yml
+++ b/db/seeds/prisons/LII-lincoln.yml
@@ -1,13 +1,13 @@
 ---
 name: Lincoln
 nomis_id: LII
-address:
-- Greetwell Road
-- 'LN2 4BD '
-email: lincolnsocialvisits@hmps.gsi.gov.uk
+address: |-
+  Greetwell Road
+  LN2 4BD
+email_address: lincolnsocialvisits@hmps.gsi.gov.uk
+phone_no: 01522 663172
 enabled: true
-phone: 01522 663172
-slots:
+recurring:
   sat:
   - 0900-1100
   - 1400-1600

--- a/db/seeds/prisons/LLI-long-lartin.yml
+++ b/db/seeds/prisons/LLI-long-lartin.yml
@@ -1,17 +1,17 @@
 ---
 name: Long Lartin
 nomis_id: LLI
+address: |-
+  South Littleton
+  Evesham
+  Worcestershire
+  WR11 8TZ
+email_address: Socialvisits.longlartin@hmps.gsi.gov.uk
+phone_no: 01386 295188
 enabled: true
-address:
-- South Littleton
-- Evesham
-- Worcestershire
-- WR11 8TZ
 booking_window: 28
-email: Socialvisits.longlartin@hmps.gsi.gov.uk
 lead_days: 3
-phone: 01386 295188
-slots:
+recurring:
   tue:
   - 1400-1615
   thu:

--- a/db/seeds/prisons/LNI-low-newton.yml
+++ b/db/seeds/prisons/LNI-low-newton.yml
@@ -1,13 +1,13 @@
 ---
 name: Low Newton
 nomis_id: LNI
-address:
-- Brasside
-- DH1 5YA
-email: socialvisits.lownewton@hmps.gsi.gov.uk
+address: |-
+  Brasside
+  DH1 5YA
+email_address: socialvisits.lownewton@hmps.gsi.gov.uk
+phone_no: 0191 376 4147
 enabled: true
-phone: 0191 376 4147
-slots:
+recurring:
   fri:
   - 1415-1545
   sat:

--- a/db/seeds/prisons/LPI-liverpool-closed-only.yml
+++ b/db/seeds/prisons/LPI-liverpool-closed-only.yml
@@ -1,13 +1,13 @@
 ---
 name: Liverpool (Closed only)
 nomis_id: LPI
-address:
-- 68 Hornby Road
-- L9 3DF
-email: socialvisits.liverpool@hmps.gsi.gov.uk
+address: |-
+  68 Hornby Road
+  L9 3DF
+email_address: socialvisits.liverpool@hmps.gsi.gov.uk
+phone_no: 0151 530 4050
 enabled: true
-phone: 0151 530 4050
-slots:
+recurring:
   mon:
   - 1025-1125
   tue:

--- a/db/seeds/prisons/LPI-liverpool-social-visits.yml
+++ b/db/seeds/prisons/LPI-liverpool-social-visits.yml
@@ -1,13 +1,13 @@
 ---
 name: Liverpool Social Visits
 nomis_id: LPI
-address:
-- 68 Hornby Road
-- L9 3DF
-email: socialvisits.liverpool@hmps.gsi.gov.uk
+address: |-
+  68 Hornby Road
+  L9 3DF
+email_address: socialvisits.liverpool@hmps.gsi.gov.uk
+phone_no: 0151 530 4050
 enabled: true
-phone: 0151 530 4050
-slots:
+recurring:
   fri:
   - 0905-1005
   - 1030-1130

--- a/db/seeds/prisons/LTI-littlehey.yml
+++ b/db/seeds/prisons/LTI-littlehey.yml
@@ -1,14 +1,14 @@
 ---
 name: Littlehey
 nomis_id: LTI
-address:
-- Perry
-- PE28 0SR
-email: socialvisits.littlehey@hmps.gsi.gov.uk
+address: |-
+  Perry
+  PE28 0SR
+email_address: socialvisits.littlehey@hmps.gsi.gov.uk
+phone_no: 01480 335650
 enabled: true
 lead_days: 2
-phone: 01480 335650
-slots:
+recurring:
   fri:
   - 0915-1115
   - 1400-1600

--- a/db/seeds/prisons/LWI-lewes.yml
+++ b/db/seeds/prisons/LWI-lewes.yml
@@ -1,13 +1,14 @@
 ---
 name: Lewes
 nomis_id: LWI
-address:
-- 1 Brighton Road
-- BN7 1EA
-email: socialvisits.lewes@hmps.gsi.gov.uk
+address: |-
+  1 Brighton Road
+  BN7 1EA
+email_address: socialvisits.lewes@hmps.gsi.gov.uk
+phone_no: 01273785277
 enabled: true
-phone: 01273785277
-slots:
+weekend_processing: true
+recurring:
   mon:
   - 1410-1535
   tue:
@@ -22,4 +23,3 @@ slots:
   - 1410-1535
   sun:
   - 1410-1535
-works_weekends: true

--- a/db/seeds/prisons/LYI-leyhill.yml
+++ b/db/seeds/prisons/LYI-leyhill.yml
@@ -1,13 +1,13 @@
 ---
 name: Leyhill
 nomis_id: LYI
-address:
-- Wotton-under-edge
-- GL12 8BT
-email: socialvisits.leyhill@hmps.gsi.gov.uk
+address: |-
+  Wotton-under-edge
+  GL12 8BT
+email_address: socialvisits.leyhill@hmps.gsi.gov.uk
+phone_no: 01454 264211
 enabled: true
-phone: 01454 264211
-slots:
+recurring:
   tue:
   - 1330-1530
   thu:

--- a/db/seeds/prisons/MDI-moorland-closed.yml
+++ b/db/seeds/prisons/MDI-moorland-closed.yml
@@ -1,14 +1,14 @@
 ---
 name: Moorland Closed
 nomis_id: MDI
-address:
-- Bawtry Road
-- DN7 6BW
-email: socialvisits.moorlandclosed@hmps.gsi.gov.uk
+address: |-
+  Bawtry Road
+  DN7 6BW
+email_address: socialvisits.moorlandclosed@hmps.gsi.gov.uk
+phone_no: 01302523289
 enabled: true
 lead_days: 1
-phone: 01302523289
-slots:
+recurring:
   wed:
   - 1340-1545
   thu:

--- a/db/seeds/prisons/MSI-maidstone.yml
+++ b/db/seeds/prisons/MSI-maidstone.yml
@@ -1,13 +1,13 @@
 ---
 name: Maidstone
 nomis_id: MSI
-address:
-- 36 County Road
-- 'ME14 1UZ '
-email: socialvisits.maidstone@hmps.gsi.gov.uk
+address: |-
+  36 County Road
+  ME14 1UZ
+email_address: socialvisits.maidstone@hmps.gsi.gov.uk
+phone_no: 01622 775619
 enabled: true
-phone: 01622 775619
-slots:
+recurring:
   tue:
   - 1345-1545
   mon:

--- a/db/seeds/prisons/MTI-the-mount.yml
+++ b/db/seeds/prisons/MTI-the-mount.yml
@@ -1,13 +1,13 @@
 ---
 name: The Mount
 nomis_id: MTI
-address:
-- Molyneaux Avenue
-- HP3 0NZ
-email: socialvisits.themount@hmps.gsi.gov.uk
+address: |-
+  Molyneaux Avenue
+  HP3 0NZ
+email_address: socialvisits.themount@hmps.gsi.gov.uk
+phone_no: 01442 836352
 enabled: true
-phone: 01442 836352
-slots:
+recurring:
   wed:
   - 1400-1600
   thu:

--- a/db/seeds/prisons/NHI-new-hall.yml
+++ b/db/seeds/prisons/NHI-new-hall.yml
@@ -1,13 +1,13 @@
 ---
 name: New Hall
 nomis_id: NHI
-address:
-- Dial Wood
-- WF4 4XX
-email: socialvisits.newhall@hmps.gsi.gov.uk
+address: |-
+  Dial Wood
+  WF4 4XX
+email_address: socialvisits.newhall@hmps.gsi.gov.uk
+phone_no: 01924 803219
 enabled: true
-phone: 01924 803219
-slots:
+recurring:
   sat:
   - 1400-1600
   sun:

--- a/db/seeds/prisons/NMI-nottingham.yml
+++ b/db/seeds/prisons/NMI-nottingham.yml
@@ -1,13 +1,13 @@
 ---
 name: Nottingham
 nomis_id: NMI
-address:
-- Perry Road
-- 'NG5 3AG '
-email: socialvisits.nottingham@hmps.gsi.gov.uk
+address: |-
+  Perry Road
+  NG5 3AG
+email_address: socialvisits.nottingham@hmps.gsi.gov.uk
+phone_no: 0115 962 8980
 enabled: true
-phone: 0115 962 8980
-slots:
+recurring:
   fri:
   - 0900-1100
   - 1415-1615

--- a/db/seeds/prisons/NSI-north-sea-camp.yml
+++ b/db/seeds/prisons/NSI-north-sea-camp.yml
@@ -1,13 +1,13 @@
 ---
 name: North Sea Camp
 nomis_id: NSI
-address:
-- Freiston
-- PE22 0QX
-email: socialvisits.northseacamp@hmps.gsi.gov.uk
+address: |-
+  Freiston
+  PE22 0QX
+email_address: socialvisits.northseacamp@hmps.gsi.gov.uk
+phone_no: 01205 769 368
 enabled: true
-phone: 01205 769 368
-slots:
+recurring:
   sat:
   - 0900-1130
   - 1330-1545

--- a/db/seeds/prisons/NWI-norwich-a-b-c-e-m-only.yml
+++ b/db/seeds/prisons/NWI-norwich-a-b-c-e-m-only.yml
@@ -1,13 +1,13 @@
 ---
 name: Norwich (A, B, C, E, M only)
 nomis_id: NWI
-address:
-- Knox Road
-- 'NR1 4LU '
-email: socialvisits.norwich@hmps.gsi.gov.uk
+address: |-
+  Knox Road
+  NR1 4LU
+email_address: socialvisits.norwich@hmps.gsi.gov.uk
+phone_no: 01603 708795
 enabled: true
-phone: 01603 708795
-slots:
+recurring:
   tue:
   - 0930-1130
   wed:

--- a/db/seeds/prisons/NWI-norwich-britannia-house.yml
+++ b/db/seeds/prisons/NWI-norwich-britannia-house.yml
@@ -1,13 +1,13 @@
 ---
 name: Norwich (Britannia House)
 nomis_id: NWI
-address:
-- Knox Road
-- NR1 4LU
-email: socialvisits.norwich@hmps.gsi.gov.uk
+address: |-
+  Knox Road
+  NR1 4LU
+email_address: socialvisits.norwich@hmps.gsi.gov.uk
+phone_no: 01603 708795
 enabled: true
-phone: 01603 708795
-slots:
+recurring:
   mon:
   - 0930-1130
   - 1400-1600

--- a/db/seeds/prisons/NWI-norwich-f-g-h-l-only.yml
+++ b/db/seeds/prisons/NWI-norwich-f-g-h-l-only.yml
@@ -1,13 +1,13 @@
 ---
 name: Norwich (F, G, H, L only)
 nomis_id: NWI
-address:
-- Knox Road
-- 'NR1 4LU '
-email: socialvisits.norwich@hmps.gsi.gov.uk
+address: |-
+  Knox Road
+  NR1 4LU
+email_address: socialvisits.norwich@hmps.gsi.gov.uk
+phone_no: 01603 708795
 enabled: true
-phone: 01603 708795
-slots:
+recurring:
   tue:
   - 1415-1615
   thu:

--- a/db/seeds/prisons/ONI-onley.yml
+++ b/db/seeds/prisons/ONI-onley.yml
@@ -1,14 +1,14 @@
 ---
 name: Onley
 nomis_id: ONI
-address:
-- Willoughby
-- CV23 8AP
-adult_age: 10
-email: socialvisits.onley@hmps.gsi.gov.uk
+address: |-
+  Willoughby
+  CV23 8AP
+email_address: socialvisits.onley@hmps.gsi.gov.uk
+phone_no: 01788 523 402
 enabled: true
-phone: 01788 523 402
-slots:
+adult_age: 10
+recurring:
   mon:
   - 1345-1445
   - 1515-1615

--- a/db/seeds/prisons/PDI-portland.yml
+++ b/db/seeds/prisons/PDI-portland.yml
@@ -1,14 +1,14 @@
 ---
 name: Portland
 nomis_id: PDI
-address:
-- 104 The Grove
-- DT5 1DL
-adult_age: 11
-email: socialvisits.portland@hmps.gsi.gov.uk
+address: |-
+  104 The Grove
+  DT5 1DL
+email_address: socialvisits.portland@hmps.gsi.gov.uk
+phone_no: 01305 715775
 enabled: true
-phone: 01305 715775
-slots:
+adult_age: 11
+recurring:
   sat:
   - 1345-1600
   sun:

--- a/db/seeds/prisons/PNI-preston.yml
+++ b/db/seeds/prisons/PNI-preston.yml
@@ -1,13 +1,13 @@
 ---
 name: Preston
 nomis_id: PNI
-address:
-- 2 Ribbleton Lane
-- 'PR1 5AB '
-email: socialvisits.preston@hmps.gsi.gov.uk
+address: |-
+  2 Ribbleton Lane
+  PR1 5AB
+email_address: socialvisits.preston@hmps.gsi.gov.uk
+phone_no: 01772 444666
 enabled: true
-phone: 01772 444666
-slots:
+recurring:
   fri:
   - 1400-1600
   mon:

--- a/db/seeds/prisons/PVI-pentonville.yml
+++ b/db/seeds/prisons/PVI-pentonville.yml
@@ -1,13 +1,13 @@
 ---
 name: Pentonville
 nomis_id: PVI
-address:
-- Caledonian Road
-- N7 8TT
-email: socialvisits.pentonville@hmps.gsi.gov.uk
+address: |-
+  Caledonian Road
+  N7 8TT
+email_address: socialvisits.pentonville@hmps.gsi.gov.uk
+phone_no: 020 70237251
 enabled: true
-phone: 020 70237251
-slots:
+recurring:
   mon:
   - 0915-1115
   - 1400-1600

--- a/db/seeds/prisons/RCI-rochester.yml
+++ b/db/seeds/prisons/RCI-rochester.yml
@@ -1,15 +1,15 @@
 ---
 name: Rochester
 nomis_id: RCI
-address:
-- 1 Fort Road
-- Rochester
-- Kent
-- ME1 3QS
-email: socialvisits.rochester@hmps.gsi.gov.uk
+address: |-
+  1 Fort Road
+  Rochester
+  Kent
+  ME1 3QS
+email_address: socialvisits.rochester@hmps.gsi.gov.uk
+phone_no: 01634 803100
 enabled: true
-phone: 01634 803100
-slots:
+recurring:
   mon:
   - 1400-1600
   tue:

--- a/db/seeds/prisons/RNI-ranby.yml
+++ b/db/seeds/prisons/RNI-ranby.yml
@@ -1,13 +1,13 @@
 ---
 name: Ranby
 nomis_id: RNI
-address:
-- RETFORD
-- DN22 8EU
-email: socialvisits.ranby@hmps.gsi.gov.uk
+address: |-
+  RETFORD
+  DN22 8EU
+email_address: socialvisits.ranby@hmps.gsi.gov.uk
+phone_no: 01777 862107
 enabled: true
-phone: 01777 862107
-slots:
+recurring:
   fri:
   - 1345-1600
   mon:

--- a/db/seeds/prisons/RSI-risley.yml
+++ b/db/seeds/prisons/RSI-risley.yml
@@ -1,13 +1,13 @@
 ---
 name: Risley
 nomis_id: RSI
-address:
-- Warrington Road
-- WA3 6BP
-email: socialvisits.risley@hmps.gsi.gov.uk
+address: |-
+  Warrington Road
+  WA3 6BP
+email_address: socialvisits.risley@hmps.gsi.gov.uk
+phone_no: 01925 733284
 enabled: true
-phone: 01925 733284
-slots:
+recurring:
   sat:
   - 0900-1115
   - 1400-1600

--- a/db/seeds/prisons/SDI-send.yml
+++ b/db/seeds/prisons/SDI-send.yml
@@ -1,13 +1,13 @@
 ---
 name: Send
 nomis_id: SDI
-address:
-- Ripley Road
-- 'GU23 7LJ '
-email: socialvisits.send@hmps.gsi.gov.uk
+address: |-
+  Ripley Road
+  GU23 7LJ
+email_address: socialvisits.send@hmps.gsi.gov.uk
+phone_no: 01483 471033
 enabled: true
-phone: 01483 471033
-slots:
+recurring:
   thu:
   - 1400-1545
   sat:

--- a/db/seeds/prisons/SFI-stafford.yml
+++ b/db/seeds/prisons/SFI-stafford.yml
@@ -1,14 +1,14 @@
 ---
 name: Stafford
 nomis_id: SFI
-address:
-- 54 Gaol Road
-- Stafford
-- ST16 3AW
-email: visitsbooking.westmidlands@noms.gsi.gov.uk
+address: |-
+  54 Gaol Road
+  Stafford
+  ST16 3AW
+email_address: visitsbooking.westmidlands@noms.gsi.gov.uk
+phone_no: 0300 060 6505
 enabled: true
-phone: 0300 060 6505
-slots:
+recurring:
   wed:
   - 1400-1600
   thu:

--- a/db/seeds/prisons/SHI-stoke-heath.yml
+++ b/db/seeds/prisons/SHI-stoke-heath.yml
@@ -1,15 +1,15 @@
 ---
 name: Stoke Heath
 nomis_id: SHI
-address:
-- Market Drayton
-- Shropshire
-- TF9 2JL
-adult_age: 10
-email: visitsbooking.westmidlands@noms.gsi.gov.uk
+address: |-
+  Market Drayton
+  Shropshire
+  TF9 2JL
+email_address: visitsbooking.westmidlands@noms.gsi.gov.uk
+phone_no: 0300 060 6506
 enabled: true
-phone: 0300 060 6506
-slots:
+adult_age: 10
+recurring:
   mon:
   - 1400-1600
   tue:

--- a/db/seeds/prisons/SKI-stocken.yml
+++ b/db/seeds/prisons/SKI-stocken.yml
@@ -1,13 +1,13 @@
 ---
 name: Stocken
 nomis_id: SKI
-address:
-- Stocken Hall Road
-- LE15 7RD
-email: socialvisits.stocken@hmps.gsi.gov.uk
+address: |-
+  Stocken Hall Road
+  LE15 7RD
+email_address: socialvisits.stocken@hmps.gsi.gov.uk
+phone_no: 01780 795156
 enabled: true
-phone: 01780 795156
-slots:
+recurring:
   fri:
   - 1345-1545
   sat:

--- a/db/seeds/prisons/SLI-swaleside.yml
+++ b/db/seeds/prisons/SLI-swaleside.yml
@@ -1,13 +1,13 @@
 ---
 name: Swaleside
 nomis_id: SLI
-address:
-- Brabazon Road
-- ME12 4AX
-email: socialvisits.swaleside@hmps.gsi.gov.uk
+address: |-
+  Brabazon Road
+  ME12 4AX
+email_address: socialvisits.swaleside@hmps.gsi.gov.uk
+phone_no: 0300 060 6604
 enabled: true
-phone: 0300 060 6604
-slots:
+recurring:
   mon:
   - 1400-1600
   sat:

--- a/db/seeds/prisons/SNI-swinfen-hall.yml
+++ b/db/seeds/prisons/SNI-swinfen-hall.yml
@@ -1,16 +1,16 @@
 ---
 name: Swinfen Hall
 nomis_id: SNI
-address:
-- Swinfen Hall
-- FLichfield
-- Staffordshire
-- WS14 9QS
-adult_age: 10
-email: visitsbooking.westmidlands@noms.gsi.gov.uk
+address: |-
+  Swinfen Hall
+  FLichfield
+  Staffordshire
+  WS14 9QS
+email_address: visitsbooking.westmidlands@noms.gsi.gov.uk
+phone_no: 0300 060 6507
 enabled: true
-phone: 0300 060 6507
-slots:
+adult_age: 10
+recurring:
   tue:
   - 1400-1600
   wed:

--- a/db/seeds/prisons/SPI-spring-hill.yml
+++ b/db/seeds/prisons/SPI-spring-hill.yml
@@ -5,6 +5,7 @@ address: |-
   Grendon Underwood
   HP18 0TL
 email_address: socialvisits.springhill@hmps.gsi.gov.uk
+phone_no: 01296 445000
 enabled: true
 recurring:
   sat:

--- a/db/seeds/prisons/SPI-spring-hill.yml
+++ b/db/seeds/prisons/SPI-spring-hill.yml
@@ -1,17 +1,17 @@
 ---
 name: Spring Hill
 nomis_id: SPI
-address:
-- Grendon Underwood
-- HP18 0TL
-email: socialvisits.springhill@hmps.gsi.gov.uk
+address: |-
+  Grendon Underwood
+  HP18 0TL
+email_address: socialvisits.springhill@hmps.gsi.gov.uk
 enabled: true
-slots:
+recurring:
   sat:
   - 1345-1600
   sun:
   - 1345-1600
-slot_anomalies:
+anomalous:
   2016-01-15:
   - 1345-1600
   2016-01-22:

--- a/db/seeds/prisons/STI-styal.yml
+++ b/db/seeds/prisons/STI-styal.yml
@@ -1,13 +1,13 @@
 ---
 name: Styal
 nomis_id: STI
-address:
-- WILMSLOW
-- 'SK9 4HR '
-email: socialvisits.styal@hmps.gsi.gov.uk
+address: |-
+  Wilmslow
+  SK9 4HR
+email_address: socialvisits.styal@hmps.gsi.gov.uk
+phone_no: 01625553195
 enabled: true
-phone: 01625553195
-slots:
+recurring:
   mon:
   - 1345-1545
   sat:

--- a/db/seeds/prisons/SUI-sudbury.yml
+++ b/db/seeds/prisons/SUI-sudbury.yml
@@ -1,14 +1,14 @@
 ---
 name: Sudbury
 nomis_id: SUI
-address:
-- Ashbourne
-- Derbyshire
-- DE6 5HW
-email: socialvisitssudbury@hmps.gsi.gov.uk
+address: |-
+  Ashbourne
+  Derbyshire
+  DE6 5HW
+email_address: socialvisitssudbury@hmps.gsi.gov.uk
+phone_no: 01283 584066
 enabled: true
-phone: 01283 584066
-slots:
+recurring:
   wed:
   - 1345-1545
   thu:

--- a/db/seeds/prisons/SWI-swansea.yml
+++ b/db/seeds/prisons/SWI-swansea.yml
@@ -1,13 +1,13 @@
 ---
 name: Swansea
 nomis_id: SWI
-address:
-- 200 Oystermouth Road
-- SA1 3SR
-email: socialvisits.swansea@hmps.gsi.gov.uk
+address: |-
+  200 Oystermouth Road
+  SA1 3SR
+email_address: socialvisits.swansea@hmps.gsi.gov.uk
+phone_no: 01792 48 5322
 enabled: true
-phone: 01792 48 5322
-slots:
+recurring:
   mon:
   - 1000-1100
   - 1345-1445

--- a/db/seeds/prisons/TCI-thorn-cross.yml
+++ b/db/seeds/prisons/TCI-thorn-cross.yml
@@ -1,13 +1,13 @@
 ---
 name: Thorn Cross
 nomis_id: TCI
-address:
-- Arley Road
-- NWA4 4RL
-email: socialvisits.thorncross@hmps.gsi.gov.uk
+address: |-
+  Arley Road
+  NWA4 4RL
+email_address: socialvisits.thorncross@hmps.gsi.gov.uk
+phone_no: 01925805018
 enabled: true
-phone: 01925805018
-slots:
+recurring:
   sat:
   - 0945-1145
   - 1345-1545

--- a/db/seeds/prisons/UKI-usk.yml
+++ b/db/seeds/prisons/UKI-usk.yml
@@ -1,13 +1,13 @@
 ---
 name: Usk
 nomis_id: UKI
-address:
-- 47 Maryport Street
-- NP15 1XP
-email: socialvisits.usk@hmps.gsi.gov.uk
+address: |-
+  47 Maryport Street
+  NP15 1XP
+email_address: socialvisits.usk@hmps.gsi.gov.uk
+phone_no: 01291 671730
 enabled: true
-phone: 01291 671730
-slots:
+recurring:
   mon:
   - 1700-1900
   tue:

--- a/db/seeds/prisons/UPI-prescoed.yml
+++ b/db/seeds/prisons/UPI-prescoed.yml
@@ -2,4 +2,3 @@
 name: Prescoed
 nomis_id: UPI
 enabled: false
-reason: coming_soon

--- a/db/seeds/prisons/WCI-winchester-convicted-only.yml
+++ b/db/seeds/prisons/WCI-winchester-convicted-only.yml
@@ -1,13 +1,13 @@
 ---
 name: Winchester (Convicted only)
 nomis_id: WCI
-address:
-- Romsey Road
-- SO22 5DF
-email: socialvisits.winchester@hmps.gsi.gov.uk
+address: |-
+  Romsey Road
+  SO22 5DF
+email_address: socialvisits.winchester@hmps.gsi.gov.uk
+phone_no: 0845 223 5514
 enabled: true
-phone: 0845 223 5514
-slots:
+recurring:
   fri:
   - 1400-1600
   mon:

--- a/db/seeds/prisons/WCI-winchester-remand-only.yml
+++ b/db/seeds/prisons/WCI-winchester-remand-only.yml
@@ -1,13 +1,13 @@
 ---
 name: Winchester (Remand only)
 nomis_id: WCI
-address:
-- Romsey Road
-- SO22 5DF
-email: socialvisits.winchester@hmps.gsi.gov.uk
+address: |-
+  Romsey Road
+  SO22 5DF
+email_address: socialvisits.winchester@hmps.gsi.gov.uk
+phone_no: 0845 223 5514
 enabled: true
-phone: 0845 223 5514
-slots:
+recurring:
   fri:
   - 1400-1500
   - 1515-1615

--- a/db/seeds/prisons/WDI-wakefield.yml
+++ b/db/seeds/prisons/WDI-wakefield.yml
@@ -1,17 +1,17 @@
 ---
 name: Wakefield
 nomis_id: WDI
-address:
-- 5 Love Lane
-- Wakefield
-- West Yorkshire
-- WF2 9AG
-booking_window: 28
-email: SocialVisits.Wakefield@hmps.gsi.gov.uk
+address: |-
+  5 Love Lane
+  Wakefield
+  West Yorkshire
+  WF2 9AG
+email_address: SocialVisits.Wakefield@hmps.gsi.gov.uk
+phone_no: 01924 612274
 enabled: true
+booking_window: 28
 lead_days: 3
-phone: 01924 612274
-slots:
+recurring:
   fri:
   - 1400-1600
   sat:

--- a/db/seeds/prisons/WEI-wealstun.yml
+++ b/db/seeds/prisons/WEI-wealstun.yml
@@ -1,13 +1,13 @@
 ---
 name: Wealstun
 nomis_id: WEI
-address:
-- Church Causeway
-- LS23 7AZ
-email: socialvisits.wealstun@hmps.gsi.gov.uk
+address: |-
+  Church Causeway
+  LS23 7AZ
+email_address: socialvisits.wealstun@hmps.gsi.gov.uk
+phone_no: 01937 444599
 enabled: true
-phone: 01937 444599
-slots:
+recurring:
   mon:
   - 0930-1130
   - 1330-1530

--- a/db/seeds/prisons/WHI-woodhill.yml
+++ b/db/seeds/prisons/WHI-woodhill.yml
@@ -1,17 +1,17 @@
 ---
 name: Woodhill
 nomis_id: WHI
+address: |-
+  Tattenhoe Street
+  Milton Keynes
+  Buckinghamshire
+  MK4 4DA
+email_address: socialvisits.woodhill@hmps.gsi.gov.uk
+phone_no: 01908 722329
 enabled: true
-address:
-- Tattenhoe Street
-- Milton Keynes
-- Buckinghamshire
-- MK4 4DA
 booking_window: 28
-email: socialvisits.woodhill@hmps.gsi.gov.uk
 lead_days: 3
-phone: 01908 722329
-slots:
+recurring:
   tue:
   - 1400-1600
   wed:

--- a/db/seeds/prisons/WII-warren-hill.yml
+++ b/db/seeds/prisons/WII-warren-hill.yml
@@ -1,13 +1,13 @@
 ---
 name: Warren Hill
 nomis_id: WII
-address:
-- Hollesley
-- 'IP12 3JW '
-email: socialvisits.warrenhill@hmps.gsi.gov.uk
+address: |-
+  Hollesley
+  IP12 3JW
+email_address: socialvisits.warrenhill@hmps.gsi.gov.uk
+phone_no: 01394 633633
 enabled: true
-phone: 01394 633633
-slots:
+recurring:
   sat:
   - 1400-1600
   sun:

--- a/db/seeds/prisons/WLI-wayland.yml
+++ b/db/seeds/prisons/WLI-wayland.yml
@@ -1,13 +1,13 @@
 ---
 name: Wayland
 nomis_id: WLI
-address:
-- Griston
-- IP25 6RL
-email: socialvisits.wayland@hmps.gsi.gov.uk
+address: |-
+  Griston
+  IP25 6RL
+email_address: socialvisits.wayland@hmps.gsi.gov.uk
+phone_no: 01953 804152
 enabled: true
-phone: 01953 804152
-slots:
+recurring:
   tue:
   - 1400-1600
   wed:

--- a/db/seeds/prisons/WMI-wymott.yml
+++ b/db/seeds/prisons/WMI-wymott.yml
@@ -1,13 +1,13 @@
 ---
 name: Wymott
 nomis_id: WMI
-address:
-- Ulnes Walton Lane
-- PR26 8LW
-email: socialvisits.wymott@hmps.gsi.gov.uk
+address: |-
+  Ulnes Walton Lane
+  PR26 8LW
+email_address: socialvisits.wymott@hmps.gsi.gov.uk
+phone_no: 01772 442234
 enabled: true
-phone: 01772 442234
-slots:
+recurring:
   mon:
   - 1400-1550
   tue:

--- a/db/seeds/prisons/WNI-werrington.yml
+++ b/db/seeds/prisons/WNI-werrington.yml
@@ -1,15 +1,15 @@
 ---
 name: Werrington
 nomis_id: WNI
-address:
-- Werrington
-- Stoke-On-Trent
-- ST9 0DX
-adult_age: 10
-email: visitsbooking.westmidlands@noms.gsi.gov.uk
+address: |-
+  Werrington
+  Stoke-On-Trent
+  ST9 0DX
+email_address: visitsbooking.westmidlands@noms.gsi.gov.uk
+phone_no: 0300 060 6508
 enabled: true
-phone: 0300 060 6508
-slots:
+adult_age: 10
+recurring:
   wed:
   - 1400-1600
   fri:

--- a/db/seeds/prisons/WOI-wolds.yml
+++ b/db/seeds/prisons/WOI-wolds.yml
@@ -1,13 +1,13 @@
 ---
 name: Wolds
 nomis_id: WOI
-address:
-- Everthorpe
-- HU15 2JZ
-email: socialvisits.everthorpe@hmps.gsi.gov.uk
+address: |-
+  Everthorpe
+  HU15 2JZ
+email_address: socialvisits.everthorpe@hmps.gsi.gov.uk
+phone_no: 01430 426505
 enabled: true
-phone: 01430 426505
-slots:
+recurring:
   fri:
   - 1415-1615
   sun:

--- a/db/seeds/prisons/WRI-whitemoor.yml
+++ b/db/seeds/prisons/WRI-whitemoor.yml
@@ -1,17 +1,17 @@
 ---
 name: Whitemoor
 nomis_id: WRI
+address: |-
+  Longhill Road
+  March
+  Cambridgeshire
+  PE15 0PR
+email_address: socialvisits.whitemoor@hmps.gsi.gov.uk
+phone_no: 01354 602800
 enabled: true
-address:
-- Longhill Road
-- March
-- Cambridgeshire
-- PE15 0PR
 booking_window: 28
-email: socialvisits.whitemoor@hmps.gsi.gov.uk
 lead_days: 3
-phone: 01354 602800
-slots:
+recurring:
   thu:
   - 1400-1610
   fri:

--- a/db/seeds/prisons/WSI-wormwood-scrubs.yml
+++ b/db/seeds/prisons/WSI-wormwood-scrubs.yml
@@ -1,13 +1,13 @@
 ---
 name: Wormwood Scrubs
 nomis_id: WSI
-address:
-- Du Cane Road
-- W12 0AE
-email: visitsbooking.westmidlands@noms.gsi.gov.uk
+address: |-
+  Du Cane Road
+  W12 0AE
+email_address: visitsbooking.westmidlands@noms.gsi.gov.uk
+phone_no: 020 8588 3564
 enabled: true
-phone: 020 8588 3564
-slots:
+recurring:
   mon:
   - 1345-1545
   sat:

--- a/db/seeds/prisons/WTI-whatton.yml
+++ b/db/seeds/prisons/WTI-whatton.yml
@@ -1,13 +1,13 @@
 ---
 name: Whatton
 nomis_id: WTI
-address:
-- New Lane
-- 'NG13 9FQ '
-email: socialvisits.whatton@hmps.gsi.gov.uk
+address: |-
+  New Lane
+  NG13 9FQ
+email_address: socialvisits.whatton@hmps.gsi.gov.uk
+phone_no: 01949 803564
 enabled: true
-phone: 01949 803564
-slots:
+recurring:
   fri:
   - 1415-1615
   mon:

--- a/db/seeds/prisons/WWI-wandsworth.yml
+++ b/db/seeds/prisons/WWI-wandsworth.yml
@@ -1,14 +1,14 @@
 ---
 name: Wandsworth
 nomis_id: WWI
-address:
-- Heathfield Rd
-- PO Box 757
-- SW18 3HS
-email: socialvisits.wandsworth@hmps.gsi.gov.uk
+address: |-
+  Heathfield Rd
+  PO Box 757
+  SW18 3HS
+email_address: socialvisits.wandsworth@hmps.gsi.gov.uk
+phone_no: 020 8588 4002
 enabled: true
-phone: 020 8588 4002
-slots:
+recurring:
   mon:
   - 1000-1100
   - 1115-1215

--- a/db/seeds/prisons/WYI-wetherby.yml
+++ b/db/seeds/prisons/WYI-wetherby.yml
@@ -1,13 +1,13 @@
 ---
 name: Wetherby
 nomis_id: WYI
-address:
-- York Road
-- 'LS22 5ED '
-email: socialvisits.wetherby@hmps.gsi.gov.uk
+address: |-
+  York Road
+  LS22 5ED
+email_address: socialvisits.wetherby@hmps.gsi.gov.uk
+phone_no: 01937 544207
 enabled: true
-phone: 01937 544207
-slots:
+recurring:
   wed:
   - 1830-2000
   sat:

--- a/spec/fixtures/seeds/prisons/LNX-luna.yml
+++ b/spec/fixtures/seeds/prisons/LNX-luna.yml
@@ -1,23 +1,24 @@
+---
 name: Lunar Penal Colony
 nomis_id: LNX
-address:
-- Outer Rim
-- Eratosthenes
-- Mare Imbrium
-- Luna
-booking_window: 28
-email: luna@hmps.gsi.gov.uk
+address: |-
+  Outer Rim
+  Eratosthenes
+  Mare Imbrium
+  Luna
+email_address: luna@hmps.gsi.gov.uk
+phone_no: 0115 4960123
 enabled: true
-phone: 0115 4960123
-slot_anomalies:
-  2015-05-25:
-  - 1330-1430
-  2015-08-31:
-  - 1330-1430
-slots:
+booking_window: 28
+recurring:
   mon:
   - 1330-1430
   tue:
+  - 1330-1430
+anomalous:
+  2015-05-25:
+  - 1330-1430
+  2015-08-31:
   - 1330-1430
 unbookable:
 - 2015-11-04

--- a/spec/fixtures/seeds/prisons/MRX-mars.yml
+++ b/spec/fixtures/seeds/prisons/MRX-mars.yml
@@ -1,14 +1,14 @@
+---
 name: Martian Correctional Facility
 nomis_id: MRX
-address:
-- Tharsis Tholus
-- Tharsis
-- Mars
-email: mars@hmps.gsi.gov.uk
+address: |-
+  Tharsis Tholus
+  Tharsis
+  Mars
+email_address: mars@hmps.gsi.gov.uk
+phone_no: 0115 4960111
 enabled: true
-id: 11
-phone: 0115 4960111
-slots:
+recurring:
   thu:
   - 1400-1600
   fri:

--- a/spec/services/prison_seeder_spec.rb
+++ b/spec/services/prison_seeder_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe PrisonSeeder do
     {
       'name' => 'Lunar Penal Colony',
       'nomis_id' => 'LNX',
-      'address' => ['Outer Rim', 'Eratosthenes', 'Mare Imbrium', 'Luna'],
+      'address' => "Outer Rim\nEratosthenes\nMare Imbrium\nLuna",
       'booking_window' => 28,
-      'email' => 'luna@hmps.gsi.gov.uk',
+      'email_address' => 'luna@hmps.gsi.gov.uk',
       'enabled' => true,
-      'phone' => '0115 4960123',
-      'slot_anomalies' => {
+      'phone_no' => '0115 4960123',
+      'anomalous' => {
         Date.new(2015, 5, 25) => ['1330-1430'],
         Date.new(2015, 8, 31) => ['1330-1430']
       },
-      'slots' => {
+      'recurring' => {
         'mon' => ['1330-1430'],
         'tue' => ['1330-1430']
       },


### PR DESCRIPTION
As we have now synchronised our seed data, we can allow the old and new app data to diverge. We need them to diverge in order to support localisation of prison names and addresses, and this is a good time to:

* Make the address a string, instead of joining lines
* Make the keys match those used internally
* Require that every enabled prison has full contact details (address, phone, email)

This simplifies things and means that when we add the translations, the translated addresses can match the default addresses without having to do some custom processing.