### PR TITLE
Don't explode if visitor cancels rejected request

### DIFF
--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -48,6 +48,7 @@ class Visit < ActiveRecord::Base
       transition withdrawn: :withdrawn
       transition booked: :cancelled
       transition cancelled: :cancelled
+      transition rejected: :rejected
     end
   end
 

--- a/spec/controllers/cancellations_controller_spec.rb
+++ b/spec/controllers/cancellations_controller_spec.rb
@@ -50,9 +50,14 @@ RSpec.describe CancellationsController, type: :controller do
       context 'when the request has been rejected' do
         let(:visit) { create(:rejected_visit) }
 
-        it 'raises StateMachines::InvalidTransition' do
-          expect { post :create, params }.
-            to raise_exception(StateMachines::InvalidTransition)
+        it 'does not change the visit' do
+          post :create, params
+          expect(visit.reload).to be_rejected
+        end
+
+        it 'redirects to the visit page' do
+          post :create, params
+          expect(response).to redirect_to(visit_path(visit, locale: 'en'))
         end
       end
 


### PR DESCRIPTION
If, between a visitor opening the visit page on a requested visit and them clicking the cancel button, a prison had rejected the visit, they would see an error page.

Instead, we'll now just do nothing and take them to a page showing them that the visit was rejected.