### PR TITLE
Disable autocomplete when requesting visit

### DIFF
--- a/app/views/booking_requests/prisoner_step.html.erb
+++ b/app/views/booking_requests/prisoner_step.html.erb
@@ -6,7 +6,7 @@
 
     <%= form_for(@steps.fetch(:prisoner_step),
                  url: booking_requests_path,
-                 html: { class: 'js-SubmitOnce' }) do |f| %>
+                 html: { class: 'js-SubmitOnce', autocomplete: 'off' }) do |f| %>
       <% if reviewing? %>
         <%= render(partial: 'hidden_visitors_step') %>
         <%= render(partial: 'hidden_slots_step') %>

--- a/app/views/booking_requests/slots_step.html.erb
+++ b/app/views/booking_requests/slots_step.html.erb
@@ -3,7 +3,7 @@
 
 <%= form_for(@steps.fetch(:slots_step),
              url: booking_requests_path,
-             html: { class: 'js-SubmitOnce' }) do |f| %>
+             html: { class: 'js-SubmitOnce', autocomplete: 'off' }) do |f| %>
       <%= render(partial: 'hidden_prisoner_step') %>
       <%= render(partial: 'hidden_visitors_step') %>
 

--- a/app/views/booking_requests/visitors_step.html.erb
+++ b/app/views/booking_requests/visitors_step.html.erb
@@ -4,7 +4,7 @@
   <div class="Grid-2-3">
     <%= form_for(@steps.fetch(:visitors_step),
                  url: booking_requests_path,
-                 html: { class: 'js-SubmitOnce' }) do |f| %>
+                 html: { class: 'js-SubmitOnce', autocomplete: 'off' }) do |f| %>
       <%= render(partial: 'hidden_prisoner_step') %>
       <% if reviewing? %>
         <%= render(partial: 'hidden_slots_step') %>

--- a/app/views/feedback_submissions/new.html.erb
+++ b/app/views/feedback_submissions/new.html.erb
@@ -26,9 +26,17 @@
   <%= t('.not_able_to_help') %>
 </p>
 
-<%= form_for(@feedback,
-             url: feedback_submissions_path,
-             html: { novalidate: 'novalidate', class: 'js-SubmitOnce' }) do |f| %>
+<%= 
+  form_for(
+    @feedback,
+    url: feedback_submissions_path,
+    html: {
+      novalidate: 'novalidate',
+      class: 'js-SubmitOnce',
+      autocomplete: 'off'
+    }
+  ) do |f|
+%>
 
   <%= render(partial: 'shared/validation', object: f.object) %>
 


### PR DESCRIPTION
In order that people using shared computers can't see the details of others, we do not want the browser to remember or suggest previous values.