### PR TITLE
Reset booking request after 20 minutes

### DIFF
--- a/app/views/booking_requests/completed.html.erb
+++ b/app/views/booking_requests/completed.html.erb
@@ -1,5 +1,7 @@
 <% content_for :header, t('.title') %>
 
+<%= render(partial: 'shared/timeout_prompt') %>
+
 <div class="Grid">
   <div class="Grid-2-3">
     <p>

--- a/app/views/booking_requests/confirmation_step.html.erb
+++ b/app/views/booking_requests/confirmation_step.html.erb
@@ -1,5 +1,7 @@
 <% content_for :header, t('.title') %>
 
+<%= render(partial: 'shared/timeout_prompt') %>
+
 <%
   prisoner_step = @steps.fetch(:prisoner_step)
   visitors_step = @steps.fetch(:visitors_step)

--- a/app/views/booking_requests/prisoner_step.html.erb
+++ b/app/views/booking_requests/prisoner_step.html.erb
@@ -1,5 +1,7 @@
 <% content_for :header, t('.title') %>
 
+<%= render(partial: 'shared/timeout_prompt') %>
+
 <div class="Grid">
   <div class="Grid-2-3">
     <%= t('.information_html') %>

--- a/app/views/booking_requests/slots_step.html.erb
+++ b/app/views/booking_requests/slots_step.html.erb
@@ -1,4 +1,7 @@
 <% content_for :header, t('.title') %>
+
+<%= render(partial: 'shared/timeout_prompt') %>
+
 <%= render('shared/slotpicker_templates') %>
 
 <%= form_for(@steps.fetch(:slots_step),

--- a/app/views/booking_requests/visitors_step.html.erb
+++ b/app/views/booking_requests/visitors_step.html.erb
@@ -1,5 +1,7 @@
 <% content_for :header, t('.title') %>
 
+<%= render(partial: 'shared/timeout_prompt') %>
+
 <div class="Grid">
   <div class="Grid-2-3">
     <%= form_for(@steps.fetch(:visitors_step),

--- a/app/views/shared/_timeout_prompt.html.erb
+++ b/app/views/shared/_timeout_prompt.html.erb
@@ -1,0 +1,26 @@
+<div
+  class="TimeoutPrompt"
+  data-exit-path="<%= booking_requests_path %>"
+  data-timeout-minutes="15"
+  data-respond-minutes="5"
+>
+  <script class="TimeoutPrompt-template" type="text/html">
+    <div
+      class="TimeoutPrompt-alert validation-summary alert-dialog"
+      role="alertdialog"
+      aria-labelledby="timeoutTitle"
+      aria-describedby="timeoutDesc"
+      tabindex="0"
+    >
+      <h2 id="timeoutTitle">
+        <%= t('.title', minutes_left: '{{ respondTime }}') %>
+      </h2>
+      <p id="timeoutDesc">
+        <%= t('.continue_question') %>
+      </p>
+      <button class="TimeoutPrompt-extend button button-primary">
+        <%= t('.yes_continue') %>
+      </button>
+    </div>
+  </script>
+</div>

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -425,6 +425,10 @@ en:
         Please don’t bring anything restricted or illegal to the prison. The
         <a href="%{url}">%{prison} prison page</a> has more information about
         what you can bring.
+    timeout_prompt:
+      title: Your session will expire in %{minutes_left} minutes
+      continue_question: Would you like to continue?
+      yes_continue: "Yes"
   visits:
     show:
       title: Visit status


### PR DESCRIPTION
If someone abandons a booking request, the browser will return to the start of the booking process after 20 minutes in order to try to keep their data private.

After 15 minutes, a prompt is displayed, giving them 5 minutes to reset the counter.