### PR TITLE
Move admin pages under /en/

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,18 +4,18 @@ Rails.application.routes.draw do
 
   get '/', to: redirect(ENV.fetch('GOVUK_START_PAGE', '/en/request'))
 
-  constraints ip: prison_ip_matcher do
-    namespace :prison do
-      resources :visits, only: %i[ show update ]
-    end
-  end
-
   constraints format: 'json' do
     get 'ping', to: 'ping#index'
     get 'healthcheck', to: 'healthcheck#index'
   end
 
   scope '/:locale', locale: /[a-z]{2}/ do
+    constraints ip: prison_ip_matcher do
+      namespace :prison do
+        resources :visits, only: %i[ show update ]
+      end
+    end
+
     resources :booking_requests, path: 'request', only: %i[ index create ]
     resources :visits, only: %i[ show ]
     resources :cancellations, path: 'cancel', only: %i[ create ]

--- a/spec/controllers/prison/visits_controller_spec.rb
+++ b/spec/controllers/prison/visits_controller_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Prison::VisitsController, type: :controller do
   }
 
   it 'renders the show template when the submission is invalid' do
-    put :update, id: visit.id, booking_response: { selection: 'slot_0' }
+    put :update,
+      id: visit.id, booking_response: { selection: 'slot_0' }, locale: 'en'
     expect(response).to render_template('show')
   end
 end

--- a/spec/features/process_a_request_spec.rb
+++ b/spec/features/process_a_request_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature 'Processing a request', js: true do
   }
 
   before do
-    visit prison_visit_path(vst)
+    visit prison_visit_path(vst, locale: 'en')
   end
 
   context 'with a withdrawn visit' do


### PR DESCRIPTION
This means that we can say that all pages on the new app (with the exception of `/ping.json` and `/healthcheck.json` and the `/pages/*id` route used only internally to generate static pages) are under a locale prefix of either `/en/` or `/cy/`, which simplifies routing to the old and new apps during the parallel running period.