### PR TITLE
Configure Transifex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 
 /spec/examples.txt
 /coverage/*
+
+.transifexrc

--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,44 @@
+[main]
+host = https://www.transifex.com
+
+[prison-visit-booking.defaults]
+file_filter = config/locales/<lang>/defaults.yml
+source_file = config/locales/en/defaults.yml
+source_lang = en
+type = YAML
+
+[prison-visit-booking.email_checker]
+file_filter = config/locales/<lang>/email_checker.yml
+source_file = config/locales/en/email_checker.yml
+source_lang = en
+type = YAML
+
+[prison-visit-booking.errors]
+file_filter = config/locales/<lang>/errors.yml
+source_file = config/locales/en/errors.yml
+source_lang = en
+type = YAML
+
+[prison-visit-booking.mailers]
+file_filter = config/locales/<lang>/mailers.yml
+source_file = config/locales/en/mailers.yml
+source_lang = en
+type = YAML
+
+[prison-visit-booking.models]
+file_filter = config/locales/<lang>/models.yml
+source_file = config/locales/en/models.yml
+source_lang = en
+type = YAML
+
+[prison-visit-booking.pages]
+file_filter = config/locales/<lang>/pages.yml
+source_file = config/locales/en/pages.yml
+source_lang = en
+type = YAML
+
+[prison-visit-booking.views]
+file_filter = config/locales/<lang>/views.yml
+source_file = config/locales/en/views.yml
+source_lang = en
+type = YAML

--- a/README.md
+++ b/README.md
@@ -559,3 +559,35 @@ check that the emails have been delivered.
 This is the url of the particular version of the application that the
 smoke test will run against.
 
+## Welsh translation
+
+NOMS Wales manages translations via Transifex. This means that we:
+
+* Write English translations in the YAML files as usual.
+* Push the English up to Transifex.
+* Pull down Welsh from Transifex.
+
+In order to use Transifex, you need the client and an account.
+
+The Transifex client is written in Python and can be installed via
+
+```sh
+$ pip install transifex-client
+```
+
+You will also need to [configure the user account for the
+client](http://docs.transifex.com/client/config/#transifexrc).
+
+To push the English translations to Transifex, use
+
+```sh
+tx push -s
+```
+
+To pull Welsh, use
+
+```sh
+tx pull -l cy
+```
+
+Then commit as usual.


### PR DESCRIPTION
Transifex is the online translation tool used by NOMS Wales.

Install the Transifex client (configuring Python and/or virtualenv is out of scope here):

    $ pip install transifex-client

Configure .transifexrc with your account details: see http://docs.transifex.com/client/config/#transifexrc

Push translations:

    $ tx push -s

Pull translations:

    $ tx pull -l cy