### PR TITLE
Allow configuring the asset_host

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,10 @@ These are required in order to submit user feedback to Zendesk.
 
 `ZENDESK_URL` defaults to `https://ministryofjustice.zendesk.com/api/v2`.
 
+#### `ASSET_HOST` (optional)
+
+If specified this will configure Rails' `config.asset_host`, resulting in all asset URLs pointing to this host.
+
 ### Files to be created on deployment
 
 #### `META`

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,5 +45,9 @@ module PrisonVisits
       )
 
     config.exceptions_app = routes
+
+    if ENV['ASSET_HOST']
+      config.asset_host = ENV['ASSET_HOST']
+    end
   end
 end


### PR DESCRIPTION
This is required for dual running, and is optional. To test dual running locally, run this app with:

    ASSET_HOST=http://localhost:3000 rails server