### PR TITLE
Implement basic prisons API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,8 @@ gem 'rails', '~> 4.2.3'
 
 gem 'govuk_frontend_toolkit', '2.0.1'
 gem 'high_voltage'
+gem 'http_accept_language'
+gem 'jbuilder'
 gem 'kramdown'
 gem 'logstasher'
 gem 'moj_template', '0.21.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,12 +107,16 @@ GEM
     high_voltage (2.4.0)
     highline (1.7.8)
     htmlentities (4.3.4)
+    http_accept_language (2.0.5)
     httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
     ice_nine (0.11.1)
     inflection (1.0.0)
+    jbuilder (2.4.0)
+      activesupport (>= 3.0.0, < 5.1)
+      multi_json (~> 1.2)
     json (1.8.3)
     kramdown (1.9.0)
     launchy (2.4.3)
@@ -332,6 +336,8 @@ DEPENDENCIES
   fuubar
   govuk_frontend_toolkit (= 2.0.1)
   high_voltage
+  http_accept_language
+  jbuilder
   kramdown
   launchy
   logstasher

--- a/app/controllers/api/prisons_controller.rb
+++ b/app/controllers/api/prisons_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  class PrisonsController < ApiController
+    def index
+      @prisons = scope.all
+    end
+
+    def show
+      @prison = scope.find(params[:id])
+    end
+
+  private
+
+    def scope
+      Prison.enabled
+    end
+  end
+end

--- a/app/controllers/api/root_controller.rb
+++ b/app/controllers/api/root_controller.rb
@@ -1,0 +1,6 @@
+module Api
+  class RootController < ApiController
+    def index
+    end
+  end
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,11 @@
+class ApiController < ActionController::Base
+  skip_before_action :verify_authenticity_token
+  before_action :set_locale
+
+private
+
+  def set_locale
+    I18n.locale =
+      http_accept_language.compatible_language_from(I18n.available_locales)
+  end
+end

--- a/app/views/api/prisons/index.json.jbuilder
+++ b/app/views/api/prisons/index.json.jbuilder
@@ -1,0 +1,17 @@
+json.prisons do
+  json.array! @prisons do |prison|
+    json.id prison.id
+    json.name prison.name
+    json._links do
+      json.self do
+        json.href api_prison_url(prison, format: :json)
+      end
+    end
+  end
+end
+
+json._links do
+  json.self do
+    json.href api_prisons_url(format: :json)
+  end
+end

--- a/app/views/api/prisons/show.json.jbuilder
+++ b/app/views/api/prisons/show.json.jbuilder
@@ -1,0 +1,13 @@
+json.prison do
+  json.id @prison.id
+  json.name @prison.name
+  json.address @prison.address
+  json.postcode @prison.postcode
+  json.email_address @prison.email_address
+  json.phone_no @prison.phone_no
+  json._links do
+    json.self do
+      json.href api_prison_url(@prison, format: :json)
+    end
+  end
+end

--- a/app/views/api/prisons/show.json.jbuilder
+++ b/app/views/api/prisons/show.json.jbuilder
@@ -5,6 +5,7 @@ json.prison do
   json.postcode @prison.postcode
   json.email_address @prison.email_address
   json.phone_no @prison.phone_no
+  json.prison_finder_url link_directory.prison_finder(@prison)
   json._links do
     json.self do
       json.href api_prison_url(@prison, format: :json)

--- a/app/views/api/root/index.json.jbuilder
+++ b/app/views/api/root/index.json.jbuilder
@@ -1,0 +1,5 @@
+json._links do
+  json.prisons do
+    json.href api_prisons_url(format: :json)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,4 +33,9 @@ Rails.application.routes.draw do
       get 'unsubscribe', action: :show, id: 'unsubscribe'
     end
   end
+
+  namespace :api, constraints: { format: 'json' } do
+    get '/', to: 'root#index'
+    resources :prisons, only: %i[ index show ]
+  end
 end

--- a/spec/controllers/api/prisons_controller_spec.rb
+++ b/spec/controllers/api/prisons_controller_spec.rb
@@ -8,12 +8,15 @@ RSpec.describe Api::PrisonsController do
   let!(:prison) {
     create(
       :prison,
+      estate: estate,
       id: 'e3148a7b-a667-449d-b11a-bc72835f5a26',
       name: 'Luna',
       postcode: 'XL1 1AA',
       translations: { 'xx' => { 'name' => 'Lüna' } }
     )
   }
+
+  let(:estate) { create(:estate, nomis_id: 'LNX', name: 'Moon') }
 
   render_views
 
@@ -70,7 +73,9 @@ RSpec.describe Api::PrisonsController do
         'prison' => include(
           'id' => prison.id,
           'name' => 'Luna',
-          'postcode' => 'XL1 1AA'
+          'postcode' => 'XL1 1AA',
+          'prison_finder_url' =>
+            'http://www.justice.gov.uk/contacts/prison-finder/moon'
         )
       )
     end

--- a/spec/controllers/api/prisons_controller_spec.rb
+++ b/spec/controllers/api/prisons_controller_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe Api::PrisonsController do
+  let(:parsed_body) {
+    JSON.parse(response.body)
+  }
+
+  let!(:prison) {
+    create(
+      :prison,
+      id: 'e3148a7b-a667-449d-b11a-bc72835f5a26',
+      name: 'Luna',
+      postcode: 'XL1 1AA',
+      translations: { 'xx' => { 'name' => 'Lüna' } }
+    )
+  }
+
+  render_views
+
+  describe 'index' do
+    let(:params) { { format: :json } }
+
+    it 'returns 200 OK' do
+      get :index, params
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns the id and name of each enabled prison' do
+      get :index, params
+      expect(parsed_body).to include(
+        'prisons' => [include('id' => prison.id, 'name' => 'Luna')]
+      )
+    end
+
+    it 'includes an API link for each prison' do
+      get :index, params
+      expect(parsed_body).to include(
+        'prisons' => [
+          include(
+            '_links' => {
+              'self' => {
+                'href' => "http://test.host/api/prisons/#{prison.id}.json"
+              }
+            }
+          )
+        ]
+      )
+    end
+
+    it 'localises prison details on Accept-Language header' do
+      request.env['HTTP_ACCEPT_LANGUAGE'] = 'xx'
+      get :index, params
+      expect(parsed_body).to include(
+        'prisons' => [include('name' => 'Lüna')]
+      )
+    end
+  end
+
+  describe 'show' do
+    let(:params) { { id: prison.id, format: :json } }
+
+    it 'returns 200 OK' do
+      get :show, params
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns prison details' do
+      get :show, params
+      expect(parsed_body).to include(
+        'prison' => include(
+          'id' => prison.id,
+          'name' => 'Luna',
+          'postcode' => 'XL1 1AA'
+        )
+      )
+    end
+
+    it 'localises prison details on Accept-Language header' do
+      request.env['HTTP_ACCEPT_LANGUAGE'] = 'xx'
+      get :show, params
+      expect(parsed_body).to include(
+        'prison' => include('name' => 'Lüna')
+      )
+    end
+  end
+end

--- a/spec/controllers/api/root_controller_spec.rb
+++ b/spec/controllers/api/root_controller_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Api::RootController do
+  let(:parsed_body) {
+    JSON.parse(response.body)
+  }
+
+  render_views
+
+  describe 'index' do
+    it 'returns 200 OK' do
+      get :index, format: :json
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns a link to the prisons endpoint' do
+      get :index, format: :json
+      expect(parsed_body).to include(
+        '_links' => {
+          'prisons' => {
+            'href' => 'http://test.host/api/prisons.json'
+          }
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
This API lists all enabled prisons, and returns details about an individual prison.

I've added links in an attempt to make it conform to HATEOAS. That's harmless, but I'm not entirely convinced that it's useful.

A [Swagger](http://swagger.io/) definition is included. The code generated by Swagger's client codegen is messy and buggy, so it's probably useful only for documentation.

Locale is determined by the `Accept-Language` header.

There is now working code using this API in https://github.com/ministryofjustice/prison-visits-public/pull/3, so it seems to be fit for purpose.