### PR TITLE
Don't blow away the database on deploy

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,15 +4,11 @@ cd /usr/src/app
 case ${DOCKER_STATE} in
 create)
     echo "running create"
-    bundle exec rake db:create db:schema:load db:seed
+    bundle exec rake db:setup db:seed
     ;;
-seed)
-    echo "running seed"
-    bundle exec rake db:schema:load db:seed
-    ;;
-migrate)
-    echo "running migrate"
-    bundle exec rake db:schema:load
+migrate_and_seed)
+    echo "running migrate and seed"
+    bundle exec rake db:migrate db:seed
     ;;
 esac
 REDIS_URL="redis://redis:6379" bundle exec sidekiq -d -l /var/log/sidekiq.log --environment production


### PR DESCRIPTION
As we are using the SQL schema format, `rake db:schema:load` will no longer work. In its place, `db:setup` will work regardless of the schema format.

On deploy, we should migrate the database, not blow it away. Furthermore, as seeding is idempotent, there is no need to migrate without seeding. We want to seed on every deployment in order to ensure
that the prisons are up to date and reflect the data on disk.