### PR TITLE
Log to stdout in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,3 +48,7 @@ group :test do
   gem 'simplecov-rcov'
   gem 'webmock'
 end
+
+group :production do
+  gem 'rails_stdout_logging'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,6 +189,7 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.2)
       loofah (~> 2.0)
+    rails_stdout_logging (0.0.4)
     railties (4.2.5)
       actionpack (= 4.2.5)
       activesupport (= 4.2.5)
@@ -345,6 +346,7 @@ DEPENDENCIES
   pry-rails
   puma
   rails (~> 4.2.3)
+  rails_stdout_logging
   rspec-rails (~> 3.0)
   rubocop
   rubocop-rspec


### PR DESCRIPTION
This makes it easier to deliver logs to the Elasticsearch/Logstash/Kibana stack. It does not affect environments other than production.