### PR TITLE
Removed sidekiq startup from application container

### DIFF
--- a/run-sidekiq.sh
+++ b/run-sidekiq.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export RAILS_ENV=production
+bundle exec sidekiq -d -l /var/log/sidekiq.log --environment production

--- a/run.sh
+++ b/run.sh
@@ -11,5 +11,4 @@ migrate_and_seed)
     bundle exec rake db:migrate db:seed
     ;;
 esac
-REDIS_URL="redis://redis:6379" bundle exec sidekiq -d -l /var/log/sidekiq.log --environment production
 bundle exec rails server --binding 0.0.0.0


### PR DESCRIPTION
Sidekiq now runs in separate container linked to redis one as requested
during last retrospective meeting.