### PR TITLE
Prevent sidekiq daemon from going into background

### DIFF
--- a/run-sidekiq.sh
+++ b/run-sidekiq.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 export RAILS_ENV=production
-bundle exec sidekiq -d -l /var/log/sidekiq.log --environment production
+bundle exec sidekiq -l /var/log/sidekiq.log --environment production


### PR DESCRIPTION
Sidekiq has been run as a daemon in app container. When I moved it to the separate container it was still in background mode which caused container to immediately quit.