### PR TITLE
Report processing time by percentile

### DIFF
--- a/app/metrics/percentiles.rb
+++ b/app/metrics/percentiles.rb
@@ -1,0 +1,22 @@
+require 'support/percentile_support'
+
+module Percentiles
+  class Distribution < ActiveRecord::Base
+    extend PercentileSupport
+    def self.fetch_and_format
+      hash_centiles(first.percentiles)
+    end
+  end
+
+  class DistributionByPrison < ActiveRecord::Base
+    extend PercentileSupport
+  end
+
+  class DistributionByPrisonAndCalendarWeek < ActiveRecord::Base
+    extend PercentileSupport
+  end
+
+  class DistributionByPrisonAndCalendarDate < ActiveRecord::Base
+    extend PercentileSupport
+  end
+end

--- a/app/metrics/support/counter_support.rb
+++ b/app/metrics/support/counter_support.rb
@@ -1,4 +1,8 @@
+require_relative './metrics_support'
+
 module CounterSupport
+  include MetricsSupport
+
   def fetch_and_format(aggregate = nil)
     # The block on the deep_merge ensures that the final values
     # are added.  Without it, the value is the last value passed in.
@@ -10,23 +14,5 @@ module CounterSupport
         order_and_hash_visit_values(visit)
       ) { |_key, val1, val2| val1 + val2 }
     end
-  end
-
-protected
-
-  # Takes the attributes of a visitor counter object, extracts the values,
-  # orders them from least specific to most specific and returns a hash of
-  # the results.
-  #
-  # For example, with these inputs:
-  # {isoyear: 2016, month: 1, day: 1, state: 'booked', count: 2 }
-  #
-  # The output would be:
-  #
-  # 2016 => { 1 => { 1 => { 'booked' => 2 }}}
-  def order_and_hash_visit_values(visit)
-    visit.values.reverse.inject { |result, value|
-      { value => result }
-    }
   end
 end

--- a/app/metrics/support/metrics_support.rb
+++ b/app/metrics/support/metrics_support.rb
@@ -1,0 +1,19 @@
+module MetricsSupport
+protected
+
+  # Takes the attributes of a visitor counter object, extracts the values,
+  # orders them from least specific to most specific and returns a hash of
+  # the results.
+  #
+  # For example, with these inputs:
+  # {isoyear: 2016, month: 1, day: 1, state: 'booked', count: 2 }
+  #
+  # The output would be:
+  #
+  # 2016 => { 1 => { 1 => { 'booked' => 2 }}}
+  def order_and_hash_visit_values(visit)
+    visit.values.reverse.inject { |result, value|
+      { value => result }
+    }
+  end
+end

--- a/app/metrics/support/percentile_support.rb
+++ b/app/metrics/support/percentile_support.rb
@@ -1,0 +1,29 @@
+require_relative './metrics_support'
+
+module PercentileSupport
+  include MetricsSupport
+
+  CENTILES = [99, 95, 90, 75, 50, 25]
+
+  def centiles
+    CENTILES
+  end
+
+  def fetch_and_format(aggregate = nil)
+    all.each_with_object({}) do |distrib, result|
+      metrics = distrib.attributes
+      metrics['percentiles'] = hash_centiles(metrics.delete('percentiles'))
+      prison = metrics.delete('prison_name')
+      result_key = aggregate.blank? ? prison : 'all'
+      result[result_key] = result.fetch(result_key, {}).deep_merge(
+        order_and_hash_visit_values(metrics)
+      )
+    end
+  end
+
+private
+
+  def hash_centiles(result)
+    Hash[centiles.zip(result)]
+  end
+end

--- a/db/migrate/20160119172114_add_views_for_calculating_percentiles.rb
+++ b/db/migrate/20160119172114_add_views_for_calculating_percentiles.rb
@@ -1,0 +1,57 @@
+class AddViewsForCalculatingPercentiles < ActiveRecord::Migration
+  def up
+    execute <<-SQL
+      CREATE VIEW distributions AS
+        SELECT percentile_disc(ARRAY[0.99, 0.95, 0.90, 0.75, 0.50, 0.25])
+                 WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM vsc.created_at - v.created_at)) AS percentiles
+        FROM visits AS v
+        INNER JOIN visit_state_changes AS vsc ON v.id = vsc.visit_id AND vsc.visit_state IN ('booked', 'rejected');
+
+      CREATE VIEW distribution_by_prisons AS
+        SELECT prisons.name AS prison_name,
+               PERCENTILE_DISC(ARRAY[0.99, 0.95, 0.90, 0.75, 0.50, 0.25])
+                 WITHIN GROUP (ORDER BY ROUND(EXTRACT(EPOCH FROM vsc.created_at - v.created_at))::integer) AS percentiles
+        FROM visits AS v
+        INNER JOIN visit_state_changes AS vsc ON v.id = vsc.visit_id AND vsc.visit_state IN ('booked', 'rejected')
+        INNER JOIN prisons ON prisons.id = v.prison_id
+        GROUP BY prison_name;
+
+      CREATE VIEW distribution_by_prison_and_calendar_weeks AS
+        SELECT prisons.name AS prison_name,
+               PERCENTILE_DISC(ARRAY[0.99, 0.95, 0.90, 0.75, 0.50, 0.25])
+                 WITHIN GROUP (ORDER BY ROUND(EXTRACT(EPOCH FROM vsc.created_at - v.created_at))::integer) AS percentiles,
+               extract(isoyear from v.created_at)::integer AS year,
+               extract(week from v.created_at)::integer AS week
+        FROM visits AS v
+        INNER JOIN visit_state_changes AS vsc ON v.id = vsc.visit_id AND vsc.visit_state IN ('booked', 'rejected')
+        INNER JOIN prisons ON prisons.id = v.prison_id
+        GROUP BY prison_name,
+                 week,
+                 year;
+
+      CREATE VIEW distribution_by_prison_and_calendar_dates AS
+        SELECT prisons.name AS prison_name,
+               PERCENTILE_DISC(ARRAY[0.99, 0.95, 0.90, 0.75, 0.50, 0.25])
+                 WITHIN GROUP (ORDER BY ROUND(EXTRACT(EPOCH FROM vsc.created_at - v.created_at))::integer) AS percentiles,
+               extract(year from v.created_at)::integer AS year,
+               extract(month from v.created_at)::integer AS month,
+               extract(day from v.created_at)::integer AS day
+        FROM visits AS v
+        INNER JOIN visit_state_changes AS vsc ON v.id = vsc.visit_id AND vsc.visit_state IN ('booked', 'rejected')
+        INNER JOIN prisons ON prisons.id = v.prison_id
+        GROUP BY prison_name,
+                 day,
+                 month,
+                 year;
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      DROP VIEW distributions;
+      DROP VIEW distributions_for_individual_prisons;
+      DROP VIEW distributions_for_prisons_by_calendar_weeks;
+      DROP VIEW distributions_for_prisons_by_calendar_dates;
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -175,12 +175,12 @@ CREATE TABLE visit_state_changes (
 
 CREATE VIEW distribution_by_prison_and_calendar_dates AS
  SELECT prisons.name AS prison_name,
-    percentile_disc((ARRAY[0.99, 0.95, 0.90, 0.75, 0.50, 0.25])::double precision[]) WITHIN GROUP (ORDER BY (round(date_part('epoch'::text, (vsc.created_at - v.created_at))))::integer) AS percentiles,
+    percentile_disc(ARRAY[(0.99)::double precision, (0.95)::double precision, (0.90)::double precision, (0.75)::double precision, (0.50)::double precision, (0.25)::double precision]) WITHIN GROUP (ORDER BY (round(date_part('epoch'::text, (vsc.created_at - v.created_at))))::integer) AS percentiles,
     (date_part('year'::text, v.created_at))::integer AS year,
     (date_part('month'::text, v.created_at))::integer AS month,
     (date_part('day'::text, v.created_at))::integer AS day
    FROM ((visits v
-     JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY ((ARRAY['booked'::character varying, 'rejected'::character varying])::text[])))))
+     JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY (ARRAY[('booked'::character varying)::text, ('rejected'::character varying)::text])))))
      JOIN prisons ON ((prisons.id = v.prison_id)))
   GROUP BY prisons.name, (date_part('day'::text, v.created_at))::integer, (date_part('month'::text, v.created_at))::integer, (date_part('year'::text, v.created_at))::integer;
 
@@ -191,11 +191,11 @@ CREATE VIEW distribution_by_prison_and_calendar_dates AS
 
 CREATE VIEW distribution_by_prison_and_calendar_weeks AS
  SELECT prisons.name AS prison_name,
-    percentile_disc((ARRAY[0.99, 0.95, 0.90, 0.75, 0.50, 0.25])::double precision[]) WITHIN GROUP (ORDER BY (round(date_part('epoch'::text, (vsc.created_at - v.created_at))))::integer) AS percentiles,
+    percentile_disc(ARRAY[(0.99)::double precision, (0.95)::double precision, (0.90)::double precision, (0.75)::double precision, (0.50)::double precision, (0.25)::double precision]) WITHIN GROUP (ORDER BY (round(date_part('epoch'::text, (vsc.created_at - v.created_at))))::integer) AS percentiles,
     (date_part('isoyear'::text, v.created_at))::integer AS year,
     (date_part('week'::text, v.created_at))::integer AS week
    FROM ((visits v
-     JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY ((ARRAY['booked'::character varying, 'rejected'::character varying])::text[])))))
+     JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY (ARRAY[('booked'::character varying)::text, ('rejected'::character varying)::text])))))
      JOIN prisons ON ((prisons.id = v.prison_id)))
   GROUP BY prisons.name, (date_part('week'::text, v.created_at))::integer, (date_part('isoyear'::text, v.created_at))::integer;
 
@@ -206,9 +206,9 @@ CREATE VIEW distribution_by_prison_and_calendar_weeks AS
 
 CREATE VIEW distribution_by_prisons AS
  SELECT prisons.name AS prison_name,
-    percentile_disc((ARRAY[0.99, 0.95, 0.90, 0.75, 0.50, 0.25])::double precision[]) WITHIN GROUP (ORDER BY (round(date_part('epoch'::text, (vsc.created_at - v.created_at))))::integer) AS percentiles
+    percentile_disc(ARRAY[(0.99)::double precision, (0.95)::double precision, (0.90)::double precision, (0.75)::double precision, (0.50)::double precision, (0.25)::double precision]) WITHIN GROUP (ORDER BY (round(date_part('epoch'::text, (vsc.created_at - v.created_at))))::integer) AS percentiles
    FROM ((visits v
-     JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY ((ARRAY['booked'::character varying, 'rejected'::character varying])::text[])))))
+     JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY (ARRAY[('booked'::character varying)::text, ('rejected'::character varying)::text])))))
      JOIN prisons ON ((prisons.id = v.prison_id)))
   GROUP BY prisons.name;
 
@@ -218,9 +218,9 @@ CREATE VIEW distribution_by_prisons AS
 --
 
 CREATE VIEW distributions AS
- SELECT percentile_disc((ARRAY[0.99, 0.95, 0.90, 0.75, 0.50, 0.25])::double precision[]) WITHIN GROUP (ORDER BY date_part('epoch'::text, (vsc.created_at - v.created_at))) AS percentiles
+ SELECT percentile_disc(ARRAY[(0.99)::double precision, (0.95)::double precision, (0.90)::double precision, (0.75)::double precision, (0.50)::double precision, (0.25)::double precision]) WITHIN GROUP (ORDER BY date_part('epoch'::text, (vsc.created_at - v.created_at))) AS percentiles
    FROM (visits v
-     JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY ((ARRAY['booked'::character varying, 'rejected'::character varying])::text[])))));
+     JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY (ARRAY[('booked'::character varying)::text, ('rejected'::character varying)::text])))));
 
 
 --

--- a/spec/metrics/percentiles_spec.rb
+++ b/spec/metrics/percentiles_spec.rb
@@ -1,51 +1,13 @@
 require 'rails_helper'
+require_relative 'shared_examples_for_metrics'
 
 RSpec.describe Percentiles do
-  let(:luna) { create(:prison, name: 'Lunar Penal Colony') }
-  let(:mars) { create(:prison, name: 'Martian Penal Colony') }
+  context 'that are not organised by date' do
+    include_examples 'create and process visits timed by seconds'
 
-  before do
-    [luna, mars].each do |prison|
-      travel_to Time.zone.local(2016, 3, 1, 13, 0, 0) do
-        @visits = create_list(:visit, 10, prison: prison)
-      end
-
-      @visits.each_with_index do |visit, i|
-        seconds = [1, 1, 2, 3, 5, 8, 13, 21, 34, 55].fetch(i)
-        travel_to Time.zone.local(2016, 3, 1, 13, 0, seconds) do
-          visit.accept!
-        end
-      end
-    end
-  end
-
-  describe Percentiles::CalculateDistributions do
-    it 'returns the 99% 95% 90% 75% 50% 25% times' do
-      expect(described_class.fetch_and_format).to be ==
-        {
-        99 => 55,
-        95 => 55,
-        90 => 34,
-        75 => 21,
-        50 => 5,
-        25 => 2
-      }
-    end
-  end
-
-  describe Percentiles::CalculateDistributionsForPrisons do
-    it 'returns the 99% 95% 90% 75% 50% 25% times' do
-      expect(described_class.fetch_and_format).to be ==
-        { 'Lunar Penal Colony' =>
-          {
-            99 => 55,
-            95 => 55,
-            90 => 34,
-            75 => 21,
-            50 => 5,
-            25 => 2
-          },
-          'Martian Penal Colony' =>
+    describe Percentiles::Distribution do
+      it 'returns the 99% 95% 90% 75% 50% 25% times' do
+        expect(described_class.fetch_and_format).to be ==
           {
             99 => 55,
             95 => 55,
@@ -54,7 +16,212 @@ RSpec.describe Percentiles do
             50 => 5,
             25 => 2
           }
+      end
+    end
+
+    describe Percentiles::DistributionByPrison do
+      it 'returns the 99% 95% 90% 75% 50% 25% times' do
+        expect(described_class.fetch_and_format).to be ==
+          { 'Lunar Penal Colony' =>
+            {
+              99 => 55,
+              95 => 55,
+              90 => 34,
+              75 => 21,
+              50 => 5,
+              25 => 2
+            },
+            'Martian Penal Colony' =>
+            {
+              99 => 55,
+              95 => 55,
+              90 => 34,
+              75 => 21,
+              50 => 5,
+              25 => 2
+            }
         }
+      end
+    end
+  end
+
+  context 'that are organized by date' do
+    include_examples 'create and process visits with dates'
+
+    describe Percentiles::DistributionByPrisonAndCalendarWeek do
+      before do
+        luna_visits_with_dates
+      end
+
+      it 'counts visits and groups by prison, year, calendar week and visit state' do
+        expect(described_class.fetch_and_format).to be ==
+          { 'Lunar Penal Colony' =>
+            {
+              2016 =>
+              { 5 =>
+                {
+                  95 => 777_600,
+                  99 => 777_600,
+                  90 => 777_600,
+                  75 => 777_600,
+                  50 => 432_000,
+                  25 => 259_200
+                },
+                6 =>
+                {
+                  99 => 777_600,
+                  95 => 777_600,
+                  90 => 777_600,
+                  75 => 777_600,
+                  50 => 432_000,
+                  25 => 259_200
+                },
+                7 => {
+                  99 => 777_600,
+                  95 => 777_600,
+                  90 => 777_600,
+                  50 => 432_000,
+                  75 => 777_600,
+                  25 => 259_200
+                }
+              }
+            }
+        }
+      end
+
+      context 'and aggregated across all prisons' do
+        before do
+          mars_visits_with_dates
+          luna_visits_with_dates
+        end
+
+        it 'counts visits and groups by year, calendar week and visit state' do
+          expect(described_class.fetch_and_format(:concatenate)).to be ==
+            { 'all' =>
+              {
+                2016 =>
+                { 5 =>
+                  {
+                    99 => 777_600,
+                    95 => 777_600,
+                    90 => 777_600,
+                    75 => 777_600,
+                    50 => 432_000,
+                    25 => 259_200
+                  },
+                  6 =>
+                  {
+                    99 => 777_600,
+                    95 => 777_600,
+                    90 => 777_600,
+                    75 => 777_600,
+                    50 => 432_000,
+                    25 => 259_200
+                  },
+                  7 => {
+                    99 => 777_600,
+                    95 => 777_600,
+                    90 => 777_600,
+                    75 => 777_600,
+                    50 => 432_000,
+                    25 => 259_200
+                  }
+                }
+              }
+          }
+        end
+      end
+
+      describe Percentiles::DistributionByPrisonAndCalendarDate do
+        before do
+          luna_visits_with_dates
+        end
+
+        it 'calculates distribution and groups by prison, nested calendar date and visit state' do
+          expect(described_class.fetch_and_format).to be ==
+            { 'Lunar Penal Colony' =>
+              {
+                2016 =>
+                { 2 =>
+                  {
+                    1 =>
+                    {
+                      99 => 777_600,
+                      95 => 777_600,
+                      90 => 777_600,
+                      75 => 777_600,
+                      50 => 432_000,
+                      25 => 259_200
+                    },
+                    8 =>
+                    {
+                      99 => 777_600,
+                      95 => 777_600,
+                      90 => 777_600,
+                      75 => 777_600,
+                      50 => 432_000,
+                      25 => 259_200
+                    },
+                    15 => {
+                      99 => 777_600,
+                      95 => 777_600,
+                      90 => 777_600,
+                      75 => 777_600,
+                      50 => 432_000,
+                      25 => 259_200
+                    }
+                  }
+                }
+              }
+          }
+        end
+
+        context 'and aggregated across all prisons' do
+          before do
+            mars_visits_with_dates
+            luna_visits_with_dates
+          end
+
+          it 'counts visits and groups by year, calendar week and visit state' do
+            expect(described_class.fetch_and_format(:concatenate)).to be ==
+              { 'all' =>
+                {
+                  2016 =>
+                  { 2 =>
+                    {
+                      1 =>
+                      {
+                        99 => 777_600,
+                        95 => 777_600,
+                        90 => 777_600,
+                        75 => 777_600,
+                        50 => 432_000,
+                        25 => 259_200
+                      },
+                      8 =>
+                      {
+                        99 => 777_600,
+                        95 => 777_600,
+                        90 => 777_600,
+                        75 => 777_600,
+                        50 => 432_000,
+                        25 => 259_200
+                      },
+                      15 => {
+                        99 => 777_600,
+                        95 => 777_600,
+                        90 => 777_600,
+                        75 => 777_600,
+                        50 => 432_000,
+                        25 => 259_200
+                      }
+                    }
+                  }
+                }
+            }
+          end
+        end
+      end
     end
   end
 end

--- a/spec/metrics/percentiles_spec.rb
+++ b/spec/metrics/percentiles_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe Percentiles do
+  let(:luna) { create(:prison, name: 'Lunar Penal Colony') }
+  let(:mars) { create(:prison, name: 'Martian Penal Colony') }
+
+  before do
+    [luna, mars].each do |prison|
+      travel_to Time.zone.local(2016, 3, 1, 13, 0, 0) do
+        @visits = create_list(:visit, 10, prison: prison)
+      end
+
+      @visits.each_with_index do |visit, i|
+        seconds = [1, 1, 2, 3, 5, 8, 13, 21, 34, 55].fetch(i)
+        travel_to Time.zone.local(2016, 3, 1, 13, 0, seconds) do
+          visit.accept!
+        end
+      end
+    end
+  end
+
+  describe Percentiles::CalculateDistributions do
+    it 'returns the 99% 95% 90% 75% 50% 25% times' do
+      expect(described_class.fetch_and_format).to be ==
+        {
+        99 => 55,
+        95 => 55,
+        90 => 34,
+        75 => 21,
+        50 => 5,
+        25 => 2
+      }
+    end
+  end
+
+  describe Percentiles::CalculateDistributionsForPrisons do
+    it 'returns the 99% 95% 90% 75% 50% 25% times' do
+      expect(described_class.fetch_and_format).to be ==
+        { 'Lunar Penal Colony' =>
+          {
+            99 => 55,
+            95 => 55,
+            90 => 34,
+            75 => 21,
+            50 => 5,
+            25 => 2
+          },
+          'Martian Penal Colony' =>
+          {
+            99 => 55,
+            95 => 55,
+            90 => 34,
+            75 => 21,
+            50 => 5,
+            25 => 2
+          }
+        }
+    end
+  end
+end

--- a/spec/metrics/shared_examples_for_metrics.rb
+++ b/spec/metrics/shared_examples_for_metrics.rb
@@ -45,3 +45,51 @@ RSpec.shared_examples 'create visits with dates' do
     create(:cancelled_visit, created_at: Time.zone.local(2016, 1, 1), prison: prison)
   end
 end
+
+RSpec.shared_examples 'create and process visits timed by seconds' do
+  let(:luna) { create(:prison, name: 'Lunar Penal Colony') }
+  let(:mars) { create(:prison, name: 'Martian Penal Colony') }
+
+  before do
+    [luna, mars].each do |prison|
+      visits = []
+      travel_to Time.zone.local(2016, 3, 1, 13, 0, 0) do
+        visits = create_list(:visit, 10, prison: prison)
+      end
+
+      visits.each_with_index do |visit, i|
+        seconds = [1, 1, 2, 3, 5, 8, 13, 21, 34, 55].fetch(i)
+        travel_to Time.zone.local(2016, 3, 1, 13, 0, seconds) do
+          visit.accept!
+        end
+      end
+    end
+  end
+end
+
+RSpec.shared_examples 'create and process visits with dates' do
+  let(:luna) { create(:prison, name: 'Lunar Penal Colony') }
+  let(:mars) { create(:prison, name: 'Martian Penal Colony') }
+
+  let(:luna_visits_with_dates) do
+    make_visits(luna)
+  end
+
+  let(:mars_visits_with_dates) do
+    make_visits(mars)
+  end
+
+  def make_visits(prison)
+    [1, 8, 15].each do |day|
+      visits = create_list(:visit, 3, created_at: Time.zone.local(2016, 2, day), prison: prison)
+
+      visits.each_with_index do |visit, index|
+        days = [3, 5, 9].fetch(index)
+        processed_on = visit.created_at + days.day
+        travel_to processed_on do
+          visit.accept!
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Display processing time metrics for all prisons and individual prisons and also broken down by calendar week and calendar date.