### PR TITLE
Redirect mails to maildrop based on ENV variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,14 @@ These configure email delivery in the production environment. `SMTP_DOMAIN` is
 also used when generating the `no-reply@` address and the `feedback@` stand-in
 address used when submitting feedback without an email address to Zendesk.
 
+#### `SMTP_HOSTNAME` and staging
+
+If you set `SMTP_HOSTNAME` to `maildrop.dsd.io` and seed prisons, it
+will create or update all prisons with emails in the format
+`pvb2.(parameterized prison name)@maildrop.dsd.io`.  This will ensure
+that staging and other test emails do not accidentally get sent to real
+prisons.
+
 #### `ZENDESK_USERNAME`, `ZENDESK_TOKEN`, `ZENDESK_URL`
 
 These are required in order to submit user feedback to Zendesk.

--- a/README.md
+++ b/README.md
@@ -255,13 +255,16 @@ These configure email delivery in the production environment. `SMTP_DOMAIN` is
 also used when generating the `no-reply@` address and the `feedback@` stand-in
 address used when submitting feedback without an email address to Zendesk.
 
-#### `SMTP_HOSTNAME` and staging
+#### `OVERRIDE_PRISON_EMAIL_DOMAIN`
 
-If you set `SMTP_HOSTNAME` to `maildrop.dsd.io` and seed prisons, it
-will create or update all prisons with emails in the format
-`pvb2.(parameterized prison name)@maildrop.dsd.io`.  This will ensure
-that staging and other test emails do not accidentally get sent to real
-prisons.
+In order to avoid sending confusing and irrelevant messages to real prisons and
+to facilitate testing, it is possible to send all prison emails to a different
+domain.
+
+If you set `OVERRIDE_PRISON_EMAIL_DOMAIN` to `maildrop.dsd.io` and seed
+prisons, it will create or update all prisons with emails in the format
+`pvb2.(parameterized prison name)@maildrop.dsd.io`. This will ensure that
+staging and other test emails do not accidentally get sent to real prisons.
 
 #### `ZENDESK_USERNAME`, `ZENDESK_TOKEN`, `ZENDESK_URL`
 

--- a/app/services/prison_seeder/seed_entry.rb
+++ b/app/services/prison_seeder/seed_entry.rb
@@ -1,4 +1,5 @@
 class PrisonSeeder::SeedEntry
+  OVERRIDE_KEY = 'OVERRIDE_PRISON_EMAIL_DOMAIN'
   DEFAULT_BOOKING_WINDOW = 28
   DEFAULT_LEAD_DAYS = 3
   DEFAULT_ADULT_AGE = 18
@@ -33,8 +34,8 @@ private
   end
 
   def email_address
-    if ENV['SMTP_HOSTNAME'] == 'maildrop.dsd.io'
-      "pvb2.#{name.parameterize}@maildrop.dsd.io"
+    if ENV.key?(OVERRIDE_KEY)
+      'pvb2.%s@%s' % [name.parameterize, ENV.fetch(OVERRIDE_KEY)]
     else
       hash.fetch('email_address', nil)
     end

--- a/app/services/prison_seeder/seed_entry.rb
+++ b/app/services/prison_seeder/seed_entry.rb
@@ -33,7 +33,11 @@ private
   end
 
   def email_address
-    hash.fetch('email_address', nil)
+    if ENV['SMTP_HOSTNAME'] == 'maildrop.dsd.io'
+      "pvb2.#{name.parameterize}@maildrop.dsd.io"
+    else
+      hash.fetch('email_address', nil)
+    end
   end
 
   def enabled

--- a/spec/services/prison_seeder_spec.rb
+++ b/spec/services/prison_seeder_spec.rb
@@ -120,26 +120,27 @@ RSpec.describe PrisonSeeder do
       )
     end
 
-    context 'changes email address to maildrop when needed' do
-      before do
-        allow(ENV).to receive(:[]).
-          with('SMTP_HOSTNAME').
-          and_return('maildrop.dsd.io')
-      end
-
-      it 'creates a new prison record with a maildrop address' do
+    context 'when no override is specified' do
+      it 'uses the supplied email address' do
         subject.import filename, hash
-        expect(Prison.first.email_address).
-          to eq('pvb2.lunar-penal-colony@maildrop.dsd.io')
+        expect(Prison.find(uuid)).
+          to have_attributes(email_address: 'luna@hmps.gsi.gov.uk')
+      end
+    end
+
+    context 'when an override is specified' do
+      around do |example|
+        ENV['OVERRIDE_PRISON_EMAIL_DOMAIN'] = 'override.example.com'
+        example.run
+        ENV.delete 'OVERRIDE_PRISON_EMAIL_DOMAIN'
       end
 
-      it 'updates an existing prison record with a maildrop address' do
-        create :prison, id: uuid
-        expect {
-          subject.import filename, hash
-        }.not_to change(Prison, :count)
-        expect(Prison.find(uuid).email_address).
-          to eq('pvb2.lunar-penal-colony@maildrop.dsd.io')
+      it 'generates a NOMIS ID-based email address' do
+        subject.import filename, hash
+        expect(Prison.find(uuid)).
+          to have_attributes(
+            email_address: 'pvb2.lunar-penal-colony@override.example.com'
+          )
       end
     end
   end

--- a/spec/services/prison_seeder_spec.rb
+++ b/spec/services/prison_seeder_spec.rb
@@ -119,5 +119,28 @@ RSpec.describe PrisonSeeder do
         }
       )
     end
+
+    context 'changes email address to maildrop when needed' do
+      before do
+        allow(ENV).to receive(:[]).
+          with('SMTP_HOSTNAME').
+          and_return('maildrop.dsd.io')
+      end
+
+      it 'creates a new prison record with a maildrop address' do
+        subject.import filename, hash
+        expect(Prison.first.email_address).
+          to eq('pvb2.lunar-penal-colony@maildrop.dsd.io')
+      end
+
+      it 'updates an existing prison record with a maildrop address' do
+        create :prison, id: uuid
+        expect {
+          subject.import filename, hash
+        }.not_to change(Prison, :count)
+        expect(Prison.find(uuid).email_address).
+          to eq('pvb2.lunar-penal-colony@maildrop.dsd.io')
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently, staging sends real emails.  This changes the seeder such that
it writes a `maildrop.dsd.io` address for each prison if the
`SMTP_HOSTNAME` environment variable is set to `maildrop.dsd.io`.  I
decided to do it this way as it prevents us from having to change the
smoketests to account for different environments. This would have been
the case with any of the other mail interceptor gems.