### PR TITLE
Add API for available slots

### DIFF
--- a/app/controllers/api/slots_controller.rb
+++ b/app/controllers/api/slots_controller.rb
@@ -1,0 +1,8 @@
+module Api
+  class SlotsController < ApiController
+    def index
+      prison = Prison.enabled.find(params[:prison_id])
+      @slots = prison.available_slots
+    end
+  end
+end

--- a/app/views/api/slots/index.json.jbuilder
+++ b/app/views/api/slots/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.slots @slots.map(&:iso8601)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,5 +37,6 @@ Rails.application.routes.draw do
   namespace :api, constraints: { format: 'json' } do
     get '/', to: 'root#index'
     resources :prisons, only: %i[ index show ]
+    resources :slots, only: %i[ index ]
   end
 end

--- a/spec/controllers/api/slots_controller_spec.rb
+++ b/spec/controllers/api/slots_controller_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe Api::SlotsController do
+  let(:parsed_body) {
+    JSON.parse(response.body)
+  }
+
+  let!(:prison) {
+    create(
+      :prison,
+      slot_details: { 'recurring' => { 'mon' => ['1330-1430'] } }
+    )
+  }
+
+  around do |example|
+    travel_to Time.zone.local(2016, 2, 3, 14, 0) do
+      example.run
+    end
+  end
+
+  render_views
+
+  describe 'index' do
+    let(:params) {
+      {
+        format: :json,
+        prison_id: prison.id,
+        prisoner_no: 'a1234bc',
+        first_name: 'Winston',
+        last_name: 'Smith',
+        date_of_birth: '1950-01-01'
+      }
+    }
+
+    it 'returns 200 OK' do
+      get :index, params
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'lists available slots' do
+      get :index, params
+      expect(parsed_body).to include(
+        'slots' => [
+          '2016-02-15T13:30/14:30',
+          '2016-02-22T13:30/14:30',
+          '2016-02-29T13:30/14:30'
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
Although we don't use the prisoner details yet, we reserve them in order that we can seamlessly integrate with NOMIS in future.