### PR TITLE
Record step name as part of path for analytics

### DIFF
--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -4,6 +4,7 @@ class BookingRequestsController < ApplicationController
   def index
     processor = StepsProcessor.new(params, I18n.locale)
     @steps = processor.steps
+    @step_name = processor.step_name
     render processor.template_name
   end
 
@@ -11,6 +12,7 @@ class BookingRequestsController < ApplicationController
     processor = StepsProcessor.new(params, I18n.locale)
     @visit = processor.execute!
     @steps = processor.steps
+    @step_name = processor.step_name
     render processor.template_name
   end
 

--- a/app/services/steps_processor.rb
+++ b/app/services/steps_processor.rb
@@ -9,6 +9,8 @@ class StepsProcessor
     review_step_name || incomplete_step_name || :completed
   end
 
+  alias_method :step_name, :template_name
+
   def execute!
     return if incomplete?
     BookingRequestCreator.new.create!(

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,11 @@
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
     ga('create', '<%= config_item :ga_id %>', 'service.gov.uk');
-    ga('send', 'pageview');
+    <% if @step_name %>
+      ga('send', 'pageview', location.pathname + '#<%= @step_name %>');
+    <% else %>
+      ga('send', 'pageview');
+    <% end %>
   </script>
   <% if Rails.env == 'test' %>
     <script>


### PR DESCRIPTION
In order to track progress through a funnel, we need to be able to distinguish the steps by path in Google Analytics. This adds the step name after a `#` when recording page views.

The step names are, in order:

1. `prisoner_step`
2. `visitors_step`
3. `slots_step`
4. `confirmation_step`
5. `completed`