### PR TITLE
Log application output to stdout for docker container

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -11,4 +11,5 @@ migrate_and_seed)
     bundle exec rake db:migrate db:seed
     ;;
 esac
-bundle exec rails server --binding 0.0.0.0
+bundle exec rails server -d --binding 0.0.0.0
+tail -f /usr/src/app/log/logstash_production.log


### PR DESCRIPTION
At the moment we don't have application logs visible in ELK stack.
They should appear after applying this change.