### PR TITLE
Correctly interpolate details in cancelation email

### DIFF
--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -31,13 +31,13 @@ en:
       subject: "%{status}: %{prisoner} on %{date}"
       salutation: Dear staff,
       details: >-
-        %{visitor} has cancelled the visit to %{prisoner} (%{prisoner_number) on
+        %{visitor} has cancelled the visit to %{prisoner} (%{prisoner_number}) on
         %{date}
       reference: "Reference number: %{reference_no}"
       please_delete: Please delete this visit from NOMIS.
       regards:  Kind regards,
       booking_team:  Prison visits booking team
-      visit_id: "Visit ID: %{@visit.id}"
+      visit_id: "Visit ID: %{visit_id}"
   visitor_mailer:
     booked:
       subject: >-

--- a/spec/mailers/prison_mailer/cancelled_spec.rb
+++ b/spec/mailers/prison_mailer/cancelled_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe PrisonMailer, '.cancelled' do
       expect(mail['X-Priority'].value).to eq('1 (Highest)')
       expect(mail['X-MSMail-Priority'].value).to eq('High')
     end
+
+    it 'sends an email containing the visit id and reference number' do
+      expect(mail.body.encoded).to match(prisoner.number)
+      expect(mail.body.encoded).to match(visit.id)
+    end
   end
 
   context 'withdrawn visit' do


### PR DESCRIPTION
The bug was in the yaml strings file.

I've added a regression test for these 2 fields, but it's not entirely clear how to avoid such a problem happening again. `translate()` raises an error `MissingInterpolationArgument` if an interpolation is expected but not provided, but there is nothing the other way round:

* `prisoner_number` was provided but not used because the closing brace was missing
* `%{@visit.id}` appears not to have been recognised as an interpolation because of the @.