### PR TITLE
Fix exception pages

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -18,4 +18,8 @@ class ErrorsController < ApplicationController
 
     render template_to_render, status: status_code
   end
+
+  def test
+    fail 'This is an test exception'
+  end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -5,6 +5,10 @@ class ErrorsController < ApplicationController
     503 => :'503'
   }
 
+  # Otherwise erroring POST requests can fail the CSRF check when rendering the
+  # error page...
+  skip_before_action :verify_authenticity_token
+
   def show
     status_code = params.fetch(:status_code).to_i
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   %w[ 404 500 503 ].each do |code|
     match code, to: 'errors#show', status_code: code, via: %i[ get post ]
   end
+  match 'exception', to: 'errors#test', via: %i[ get post ]
 
   constraints format: 'json' do
     get 'ping', to: 'ping#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   get '/', to: redirect(ENV.fetch('GOVUK_START_PAGE', '/en/request'))
 
   %w[ 404 500 503 ].each do |code|
-    get code, to: 'errors#show', status_code: code
+    match code, to: 'errors#show', status_code: code, via: %i[ get post ]
   end
 
   constraints format: 'json' do

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -9,4 +9,14 @@ RSpec.describe ErrorsController do
       expect(response.status).to eq(status_code.to_i)
     end
   end
+
+  it 'raises exception on test page' do
+    expect {
+      get :test
+    }.to raise_exception('This is an test exception')
+
+    expect {
+      post :test
+    }.to raise_exception('This is an test exception')
+  end
 end


### PR DESCRIPTION
In fact, it was POST requests which were not rendering error pages correctly. This is now fixed.