### PR TITLE
Fix feedback page default email

### DIFF
--- a/app/jobs/zendesk_tickets_job.rb
+++ b/app/jobs/zendesk_tickets_job.rb
@@ -6,7 +6,12 @@ class ZendeskTicketsJob < ActiveJob::Base
   SERVICE_FIELD = '23757677'
   BROWSER_FIELD = '23791776'
 
+  # rubocop:disable Metrics/MethodLength
   def perform(feedback)
+    unless Rails.configuration.zendesk_client
+      fail 'Cannot create Zendesk ticket since Zendesk not configured'
+    end
+
     ZendeskAPI::Ticket.create!(
       Rails.configuration.zendesk_client,
       description: feedback.body,

--- a/app/jobs/zendesk_tickets_job.rb
+++ b/app/jobs/zendesk_tickets_job.rb
@@ -16,7 +16,7 @@ class ZendeskTicketsJob < ActiveJob::Base
       Rails.configuration.zendesk_client,
       description: feedback.body,
       requester: {
-        email: feedback.email_address,
+        email: email_address_to_submit(feedback),
         name: 'Unknown'
       },
       custom_fields: custom_fields(feedback)
@@ -29,5 +29,17 @@ class ZendeskTicketsJob < ActiveJob::Base
       { id: SERVICE_FIELD, value: 'prison_visits' },
       { id: BROWSER_FIELD, value: feedback.user_agent }
     ]
+  end
+
+private
+
+  # Zendesk requires tickets to have an email, but we do not enforce
+  # providing an email. Therefore, a default email is used.
+  def email_address_to_submit(feedback)
+    if feedback.email_address.present?
+      feedback.email_address
+    else
+      Rails.configuration.address_book.feedback
+    end
   end
 end

--- a/app/models/feedback_submission.rb
+++ b/app/models/feedback_submission.rb
@@ -2,10 +2,6 @@ class FeedbackSubmission < ActiveRecord::Base
   validates :body, presence: true
   validate :validate_email
 
-  def email_address
-    super.present? ? super : Rails.configuration.address_book.feedback
-  end
-
 private
 
   def validate_email

--- a/config/initializers/zendesk.rb
+++ b/config/initializers/zendesk.rb
@@ -1,7 +1,16 @@
-Rails.configuration.zendesk_client = ZendeskAPI::Client.new do |config|
-  config.url =
-    ENV.fetch('ZENDESK_URL', 'https://ministryofjustice.zendesk.com/api/v2')
-  config.username = ENV['ZENDESK_USERNAME']
-  config.token = ENV['ZENDESK_TOKEN']
-  config.retry = true
+url = ENV.fetch('ZENDESK_URL', 'https://ministryofjustice.zendesk.com/api/v2')
+username = ENV['ZENDESK_USERNAME']
+token = ENV['ZENDESK_TOKEN']
+
+if url && username && token
+  Rails.configuration.zendesk_client = ZendeskAPI::Client.new do |config|
+    config.url = url
+    config.username = username
+    config.token = token
+    config.retry = true
+  end
+else
+  # rubocop:disable Rails/Output
+  # (Rails logger is not initialized yet)
+  puts '[WARN] Zendesk is not configured'
 end

--- a/spec/jobs/zendesk_tickets_job_spec.rb
+++ b/spec/jobs/zendesk_tickets_job_spec.rb
@@ -49,4 +49,30 @@ RSpec.describe ZendeskTicketsJob, type: :job do
     expect(ticket).to receive(:save!).once
     subject.perform_now(feedback)
   end
+
+  describe 'when email not provided' do
+    let(:feedback) {
+      FeedbackSubmission.new(
+        body: 'text',
+        referrer: 'ref',
+        user_agent: 'Mozilla'
+      )
+    }
+
+    it 'creates a ticket with default email address' do
+      expect(ZendeskAPI::Ticket).
+        to receive(:new).
+        with(
+          client,
+          description: 'text',
+          requester: { email: 'feedback@email.test.host', name: 'Unknown' },
+          custom_fields: [
+            { id: '23730083', value: 'ref' },
+            { id: '23757677', value: 'prison_visits' },
+            { id: '23791776', value: 'Mozilla' }
+          ]
+        ).and_return(ticket)
+      subject.perform_now(feedback)
+    end
+  end
 end

--- a/spec/jobs/zendesk_tickets_job_spec.rb
+++ b/spec/jobs/zendesk_tickets_job_spec.rb
@@ -11,8 +11,20 @@ RSpec.describe ZendeskTicketsJob, type: :job do
       user_agent: 'Mozilla'
     )
   }
-  let(:client) { Rails.configuration.zendesk_client }
+  let(:client) { double(ZendeskAPI::Client) }
   let(:ticket) { double(ZendeskAPI::Ticket, save!: nil) }
+
+  before :each do
+    Rails.configuration.zendesk_client = client
+  end
+
+  it 'raises an error if Zendesk is not configured' do
+    Rails.configuration.zendesk_client = nil
+
+    expect {
+      subject.perform_now(feedback)
+    }.to raise_error('Cannot create Zendesk ticket since Zendesk not configured')
+  end
 
   it 'creates a ticket with feedback and custom fields' do
     expect(ZendeskAPI::Ticket).

--- a/spec/models/feedback_submission_spec.rb
+++ b/spec/models/feedback_submission_spec.rb
@@ -22,21 +22,4 @@ RSpec.describe FeedbackSubmission do
       end
     end
   end
-
-  describe 'email_address' do
-    it 'returns default when not set' do
-      expect(subject.email_address).to eq('feedback@email.test.host')
-    end
-
-    it 'returns default when blank' do
-      subject.email_address = ''
-      expect(subject.email_address).to eq('feedback@email.test.host')
-    end
-
-    it 'returns explicitly assigned value' do
-      subject.email_address = 'user@test.example.com'
-      expect(subject.email_address).
-        to eq('user@test.example.com')
-    end
-  end
 end


### PR DESCRIPTION
This fixes a bug where a default Zendesk feedback email was shown on the feedback page.