### PR TITLE
Show validation error if dates are invalid

### DIFF
--- a/app/models/concerns/person.rb
+++ b/app/models/concerns/person.rb
@@ -33,8 +33,4 @@ module Person
   def maximum_date_of_birth
     Time.zone.today.end_of_year
   end
-
-  def date_of_birth
-    super.is_a?(Date) ? super : nil
-  end
 end

--- a/app/models/prisoner_step.rb
+++ b/app/models/prisoner_step.rb
@@ -1,10 +1,12 @@
+require 'maybe_date'
+
 class PrisonerStep
   include NonPersistedModel
   include Person
 
   attribute :first_name, String
   attribute :last_name, String
-  attribute :date_of_birth, Date
+  attribute :date_of_birth, MaybeDate
   attribute :number, String
   attribute :prison_id, Integer
 

--- a/app/models/visitors_step.rb
+++ b/app/models/visitors_step.rb
@@ -1,3 +1,5 @@
+require 'maybe_date'
+
 class VisitorsStep
   include NonPersistedModel
 
@@ -7,7 +9,7 @@ class VisitorsStep
 
     attribute :first_name, String
     attribute :last_name, String
-    attribute :date_of_birth, Date
+    attribute :date_of_birth, MaybeDate
   end
 
   attribute :prison, Prison

--- a/lib/maybe_date.rb
+++ b/lib/maybe_date.rb
@@ -1,0 +1,25 @@
+UncoercedDate = Struct.new(:year, :month, :day)
+
+# Coerces date input into either a Date (if the date is valid), or an
+# UncoercedDate struct which can be redered back to the view for correction
+class MaybeDate < Virtus::Attribute
+  # This coercion is probably not as comprehensive as
+  # Virtus::Attribute::Date, but it is understandable and sufficient for
+  # our needs
+  # rubocop:disable Metrics/MethodLength
+  def coerce(value)
+    return nil if value.nil?
+    return value if value.is_a?(Date)
+
+    if value.is_a?(String)
+      Date.parse(value)
+    elsif value.respond_to?(:values_at)
+      ymd = value.values_at(:year, :month, :day).map(&:to_i)
+      begin
+        Date.new(*ymd)
+      rescue ArgumentError # e.g. invalid date such as 2010-14-31
+        UncoercedDate.new(*ymd)
+      end
+    end
+  end
+end

--- a/spec/models/prisoner_step_spec.rb
+++ b/spec/models/prisoner_step_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe PrisonerStep do
+  subject { described_class.new(prison: prison) }
+
+  let(:params) {
+    {
+      first_name: 'Joe',
+      last_name: 'Bloggs',
+      date_of_birth: {
+        day: '31',
+        month: '12',
+        year: '1970'
+      },
+      number: 'a1234bc',
+      prison_id: 'uuid'
+    }
+  }
+
+  it 'does not fail if the date is invalid (anti-regression)' do
+    params[:date_of_birth][:month] = '13'
+    prisoner_step = described_class.new(params)
+
+    dob = prisoner_step.date_of_birth
+
+    expect(dob).to be_kind_of(UncoercedDate)
+    expect(dob.month).to eql(13)
+  end
+end


### PR DESCRIPTION
Previously, an error would be raised inside Virtus’ date coercion code.

Ideally we wouldn’t be using Virtus since it has significantly different behaviour (coersion and otherwise) to ActiveRecord – which adds significant extra complexity to the app.

See also related solution in MPS: https://github.com/ministryofjustice/moving-people-safely/blob/master/app/forms/form/date_handling.rb /ht @dan-palmer 