### PR TITLE
Remove duplicate visitor from email confirmation

### DIFF
--- a/app/views/visitor_mailer/booked.html.erb
+++ b/app/views/visitor_mailer/booked.html.erb
@@ -16,11 +16,6 @@
   <strong><%= @visit.prisoner_number %></strong>
 </p>
 
-<p>
-  <%= t('.visitor', n: 1) %>
-  <strong><%= @visit.visitor_anonymized_name %></strong>
-</p>
-
 <% @visit.visitors.each_with_index do |visitor, index| %>
   <p>
     <%= t('.visitor', n: index + 1) %>


### PR DESCRIPTION
Removes duplicate visitor from email confirmation

Fixes https://trello.com/c/SxCpqDy6/170-booking-confirmation-emails-to-staff-contain-duplicate-visitor-1

I've kept the list of all visitors, if only the first visitor should be shown I'll update the PR.

After fix:

<img width="539" alt="screen shot 2016-02-23 at 16 50 02" src="https://cloud.githubusercontent.com/assets/6356/13259163/18ffc7ba-da4e-11e5-92cd-3c086afa3ca2.png">
