### PR TITLE
Improvements to staff email

### DIFF
--- a/app/assets/stylesheets/email.css
+++ b/app/assets/stylesheets/email.css
@@ -46,6 +46,10 @@ p, li {
   font: 16px Helvetica, Arial, sans-serif
 }
 
+p small {
+  font: 14px Helvetica, Arial, sans-serif;
+}
+
 h1, h2 {
   font: bold 24px Helvetica, Arial, sans-serif;
 }

--- a/app/views/prison_mailer/request_received.html.erb
+++ b/app/views/prison_mailer/request_received.html.erb
@@ -33,6 +33,8 @@
     <strong><%= format_date_of_birth(visitor.date_of_birth) %></strong>
 
     <% if index.zero? %>
+      <br/>
+
       <%= t('.email_address') %>
       <strong><%= @visit.contact_email_address %></strong>
       <br/>
@@ -52,9 +54,9 @@
   <%= t('.copy_paste_explanation') %>
 </p>
 
-<div>
+<p>
   <%= prison_visit_url(@visit, locale: I18n.locale) %>
-</div>
+</p>
 
 <p>
   <small><%= t('.visit_id') %> <%= @visit.id %></small>

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -7,8 +7,8 @@ en:
       prisoner: "Prisoner:"
       number: "Number:"
       date_of_birth: "Date of birth:"
-      choice: "Choice %{n}"
-      visitor: "Visitor %{n}"
+      choice: "Choice %{n}:"
+      visitor: "Visitor %{n}:"
       age: "Age:"
       email_address: "Email:"
       phone_no: "Phone:"
@@ -149,7 +149,7 @@ en:
       cancel_html: >-
         If you no longer want to visit on this date,
         <a href="%{url}">you can cancel this visit</a>.
-      choice: "Choice %{n}"
+      choice: "Choice %{n}:"
       details: "Visit request details"
       feedback_html: >-
         Need help or want to make a complaint? If you have a question or need


### PR DESCRIPTION
Fixes https://trello.com/c/D9frS202/162-missing-s-in-the-staff-email

* Add missing `:`
* Introduce line break for email
* CSS tweaks to use the same font

<img width="643" alt="screen shot 2016-02-24 at 10 54 14" src="https://cloud.githubusercontent.com/assets/6356/13283389/899f2424-dae5-11e5-85da-2d36bd431f20.png">
