### PR TITLE
Stop re-rejecting a visit

### DIFF
--- a/app/services/booking_responder.rb
+++ b/app/services/booking_responder.rb
@@ -28,15 +28,19 @@ private
   end
 
   def reject!
+    return if visit.rejected?
+
     visit.reject!
     rejection = Rejection.new(visit: visit, reason: booking_response.selection)
-    copy_no_allowance_parameters rejection if booking_response.no_allowance?
-    mark_disallowed_visitors
+    copy_no_allowance_parameters(rejection)
     rejection.save!
+    mark_disallowed_visitors
     notify_rejected visit
   end
 
   def copy_no_allowance_parameters(rejection)
+    return unless booking_response.no_allowance?
+
     if booking_response.allowance_will_renew?
       rejection.allowance_renews_on = booking_response.allowance_renews_on
     end

--- a/spec/services/booking_responder_spec.rb
+++ b/spec/services/booking_responder_spec.rb
@@ -100,6 +100,18 @@ RSpec.describe BookingResponder do
       booking_response.selection = 'slot_unavailable'
     end
 
+    context 'an already rejected visit' do
+      before do
+        subject.respond!
+      end
+
+      it 'does not try to re-reject the visit' do
+        expect(VisitorMailer).to_not receive(:rejected)
+        expect(PrisonMailer).to_not receive(:rejected)
+        expect { subject.respond! }.to_not change { Rejection.count }
+      end
+    end
+
     it 'emails the visitor' do
       expect(VisitorMailer).to receive(:rejected).with(visit).
         and_return(mailing)


### PR DESCRIPTION
Resolves most of the events seen in https://sentry.service.dsd.io/mojds/pvb2-prod/group/620 as described in https://trello.com/b/lbxS986X/prison-visit-booking-v2

Ideally the validation used in the controller would check for state machine incompatibilities as it would catch other incompatible transitions, from what I see doing that could end up being a big refactor.

Worth noting that it is still possible to hit the error due to race conditions, I _think_ that is a design issue with the state machine gem. The race condition would happen if 2 staff members submitted a rejection at the same time.
