### PR TITLE
Validate that a visit is processable in a booking response

### DIFF
--- a/app/models/booking_response.rb
+++ b/app/models/booking_response.rb
@@ -65,4 +65,11 @@ private
     end
   end
   validate :validate_checked_visitors
+
+  def validate_visit_is_processable
+    unless visit.processable?
+      errors.add :visit, :already_processed
+    end
+  end
+  validate :validate_visit_is_processable
 end

--- a/spec/models/booking_response_spec.rb
+++ b/spec/models/booking_response_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe BookingResponse, type: :model do
+  subject do
+    described_class.new(visit: FactoryGirl.build_stubbed(:visit))
+  end
+
   describe 'slot_selected?' do
     it 'is true if slot 0 is selected' do
       subject.selection = 'slot_0'
@@ -48,6 +52,15 @@ RSpec.describe BookingResponse, type: :model do
         expect(subject).not_to be_valid
         expect(subject.errors).to have_key(:selection)
       end
+    end
+
+    it 'is invalid if the visit is not processable' do
+      subject.visit.processing_state = 'booked'
+
+      subject.selection = 'slot_unavailable'
+
+      expect(subject).not_to be_valid
+      expect(subject.errors).to have_key(:visit)
     end
   end
 


### PR DESCRIPTION
Prevents double form submissions and other scenarios to cause a
state machine conflict.

Where an error would have happened before now the page re-renders saying that the visit was already rejected or booked