### PR TITLE
Show the booked slot if visit has been approved

### DIFF
--- a/app/mailers/prison_mailer.rb
+++ b/app/mailers/prison_mailer.rb
@@ -50,7 +50,19 @@ class PrisonMailer < ActionMailer::Base
       to: visit.prison_email_address,
       subject: default_i18n_subject(
         prisoner: visit.prisoner_full_name,
-        date: format_date_without_year(visit.slots.first.begin_at),
+        date: format_date_without_year(visit.slot_granted),
+        status: visit.processing_state.upcase
+      )
+    )
+  end
+
+  def withdrawn(visit)
+    @visit = visit
+
+    mail(
+      to: visit.prison_email_address,
+      subject: default_i18n_subject(
+        prisoner: visit.prisoner_full_name,
         status: visit.processing_state.upcase
       )
     )

--- a/app/views/prison_mailer/cancelled.html.erb
+++ b/app/views/prison_mailer/cancelled.html.erb
@@ -5,7 +5,9 @@
           visitor: @visit.visitor_full_name,
           prisoner: @visit.prisoner_full_name,
           prisoner_number: @visit.prisoner_number,
-          date: format_slot_for_staff(@visit.slots.first)
+          date: format_slot_for_staff(
+            @visit.slot_granted || @visit.slots.first
+          )
        )
   %>
 </p>

--- a/app/views/prison_mailer/withdrawn.html.erb
+++ b/app/views/prison_mailer/withdrawn.html.erb
@@ -4,8 +4,7 @@
   <%= t('.details',
           visitor: @visit.visitor_full_name,
           prisoner: @visit.prisoner_full_name,
-          prisoner_number: @visit.prisoner_number,
-          date: format_slot_for_staff(@visit.slot_granted)
+          prisoner_number: @visit.prisoner_number
        )
   %>
 </p>
@@ -15,8 +14,6 @@
     <%= t('.reference', reference_no: @visit.reference_no) %>
   </p>
 <% end %>
-
-<p><%= t('.please_delete') %></p>
 
 <p>
   <%= t('.regards') %>

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -28,13 +28,22 @@ en:
       copy_of_rejection: >-
         This is a copy of the booking rejection email sent to the visitor
     cancelled:
-      subject: "%{status}: %{prisoner} on %{date}"
+      subject: "CANCELLED: Visit for %{prisoner} on %{date}"
       salutation: Dear staff,
       details: >-
         %{visitor} has cancelled the visit to %{prisoner} (%{prisoner_number}) on
         %{date}
       reference: "Reference number: %{reference_no}"
       please_delete: Please delete this visit from NOMIS.
+      regards:  Kind regards,
+      booking_team:  Prison visits booking team
+      visit_id: "Visit ID: %{visit_id}"
+    withdrawn:
+      subject: "WITHDRAWN: Visit request for %{prisoner}"
+      salutation: Dear staff,
+      details: >-
+        %{visitor} has withdrawn their request to visit %{prisoner} (%{prisoner_number})
+      reference: "Reference number: %{reference_no}"
       regards:  Kind regards,
       booking_team:  Prison visits booking team
       visit_id: "Visit ID: %{visit_id}"

--- a/spec/mailers/prison_mailer/cancelled_spec.rb
+++ b/spec/mailers/prison_mailer/cancelled_spec.rb
@@ -3,11 +3,7 @@ require 'mailers/shared_mailer_examples'
 
 RSpec.describe PrisonMailer, '.cancelled' do
   let(:prisoner) {
-    create(
-      :prisoner,
-      first_name: 'Arthur',
-      last_name: 'Raffles'
-    )
+    create(:prisoner, first_name: 'Arthur', last_name: 'Raffles')
   }
 
   let(:mail) { described_class.cancelled(visit) }
@@ -20,11 +16,11 @@ RSpec.describe PrisonMailer, '.cancelled' do
   end
 
   context 'cancelled visit' do
-    let(:visit) { create(:cancelled_visit, prisoner: prisoner) }
+    let(:visit) { create(:cancelled_visit, prisoner: prisoner, slot_granted: '2015-11-06T16:00/17:00') }
     include_examples 'template checks'
 
     it 'sends an email notifyting the prison of the cancellation' do
-      expect(mail.subject).to eq('CANCELLED: Arthur Raffles on Monday 8 June')
+      expect(mail.subject).to eq('CANCELLED: Visit for Arthur Raffles on Friday 6 November')
       expect(mail['X-Priority'].value).to eq('1 (Highest)')
       expect(mail['X-MSMail-Priority'].value).to eq('High')
     end
@@ -32,17 +28,6 @@ RSpec.describe PrisonMailer, '.cancelled' do
     it 'sends an email containing the visit id and reference number' do
       expect(mail.body.encoded).to match(prisoner.number)
       expect(mail.body.encoded).to match(visit.id)
-    end
-  end
-
-  context 'withdrawn visit' do
-    let(:visit) { create(:withdrawn_visit, prisoner: prisoner) }
-    include_examples 'template checks'
-
-    it 'sends an email notifyting the prison of the withdrawal' do
-      expect(mail.subject).to eq('WITHDRAWN: Arthur Raffles on Monday 8 June')
-      expect(mail['X-Priority'].value).to eq('1 (Highest)')
-      expect(mail['X-MSMail-Priority'].value).to eq('High')
     end
   end
 end

--- a/spec/mailers/prison_mailer/withdrawn_spec.rb
+++ b/spec/mailers/prison_mailer/withdrawn_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+require 'mailers/shared_mailer_examples'
+
+RSpec.describe PrisonMailer, '.withdrawn' do
+  let(:prisoner) {
+    create(:prisoner, first_name: 'Arthur', last_name: 'Raffles')
+  }
+
+  let(:mail) { described_class.withdrawn(visit) }
+
+  around do |example|
+    ActionMailer::Base.deliveries.clear
+    travel_to(Date.new(2015, 6, 1)) do
+      example.run
+    end
+  end
+
+  context 'withdrawn visit' do
+    let(:visit) { create(:withdrawn_visit, prisoner: prisoner) }
+    include_examples 'template checks'
+
+    it 'sends an email notifyting the prison of the withdrawal' do
+      expect(mail.subject).to eq('WITHDRAWN: Visit request for Arthur Raffles')
+    end
+  end
+end


### PR DESCRIPTION
This was defaulting to the first slot requested even after the visit had
been accepted.  This logic show the booked slot if the visit is
accepted, and the first requested slot if it is not.