### PR TITLE
Don't allow to re-cancel a visit

### DIFF
--- a/app/controllers/cancellations_controller.rb
+++ b/app/controllers/cancellations_controller.rb
@@ -1,9 +1,8 @@
 class CancellationsController < ApplicationController
   def create
     visit = Visit.find(params[:id])
-    if cancellation_confirmed?
+    if cancellation_confirmed? && visit.can_cancel?
       visit.cancel!
-      PrisonMailer.cancelled(visit).deliver_later
     end
     redirect_to visit_path(visit)
   end

--- a/spec/controllers/cancellations_controller_spec.rb
+++ b/spec/controllers/cancellations_controller_spec.rb
@@ -73,6 +73,11 @@ RSpec.describe CancellationsController, type: :controller do
           post :create, params
           expect(response).to redirect_to(visit_path(visit, locale: 'en'))
         end
+
+        it 'does not try to re-cancel the visit' do
+          expect_any_instance_of(Visit).not_to receive(:cancel!)
+          post :create, params
+        end
       end
     end
 

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe Visit, type: :model do
   subject { build(:visit) }
 
+  let(:mailing) {
+    double(Mail::Message, deliver_later: nil)
+  }
+
   describe '.delivery_error_type' do
     specify do
       is_expected.
@@ -38,6 +42,13 @@ RSpec.describe Visit, type: :model do
       subject.accept!
       subject.cancel!
       expect(subject).to be_cancelled
+    end
+
+    it "sends an email when cancelling" do
+      subject.accept!
+
+      expect(PrisonMailer).to receive(:cancelled).with(subject).and_return(mailing)
+      subject.cancel!
     end
 
     it 'is not processable after booking' do


### PR DESCRIPTION
Updated the state machine to not allow transitions from cancelled to cancelled and moved the sending of the email inside the state machine.

I'd like to move the rest of the emails inside the state machine if you like this approach to have them consistent.

Fixes https://trello.com/c/Ql4Ip0dP/174-it-s-possible-to-resubmit-the-cancel-form-multiple-times-and-thereby-send-multiple-emails-to-a-prison