### PR TITLE
Configure on/off sengrid email validations

### DIFF
--- a/app/services/email_checker.rb
+++ b/app/services/email_checker.rb
@@ -56,7 +56,7 @@ private
   # rubocop:enable Metrics/MethodLength
 
   def override_sendgrid?
-    @override_sendgrid
+    @override_sendgrid || !Rails.configuration.enable_sendgrid_validations
   end
 
   def domain

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,6 +14,7 @@ Rails.application.configure do
   config.assets.digest = true
   config.assets.raise_runtime_errors = true
 
+  config.enable_sendgrid_validations = true
   config.mx_checker = MxChecker::Dummy.new
 
   config.active_job.queue_adapter = :sidekiq

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,6 +32,8 @@ Rails.application.configure do
   config.lograge.logger = ActiveSupport::Logger.new \
     "#{Rails.root}/log/logstash_#{Rails.env}.json"
 
+  config.enable_sendgrid_validations =
+    ENV.key?('ENABLE_SENDGRID_VALIDATIONS')
   config.mx_checker = MxChecker.new
 
   config.active_job.queue_adapter = :sidekiq

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,6 +15,7 @@ Rails.application.configure do
   config.active_support.test_order = :random
   config.active_support.deprecation = :stderr
 
+  config.enable_sendgrid_validations = true
   config.mx_checker = MxChecker::Dummy.new
 
   config.i18n.load_path =

--- a/spec/services/email_checker_spec.rb
+++ b/spec/services/email_checker_spec.rb
@@ -98,10 +98,19 @@ RSpec.describe EmailChecker do
         it { is_expected.not_to be_reset_spam_report }
       end
 
-      context 'but override is set' do
+      context 'but override is set by a parameter' do
         let(:override) { true }
         it_behaves_like 'a valid address'
         it { is_expected.to be_reset_spam_report }
+      end
+
+      context 'but sendgrid validations are disabled' do
+        before do
+          allow(Rails.configuration).
+            to receive(:enable_sendgrid_validations).
+            and_return(false)
+        end
+        it_behaves_like 'a valid address'
       end
     end
 
@@ -115,10 +124,19 @@ RSpec.describe EmailChecker do
         it { is_expected.not_to be_reset_bounce }
       end
 
-      context 'but override is set' do
+      context 'but override is set by a paramenter' do
         let(:override) { true }
         it_behaves_like 'a valid address'
         it { is_expected.to be_reset_bounce }
+      end
+
+      context 'but sendgrid validations are disabled' do
+        before do
+          allow(Rails.configuration).
+            to receive(:enable_sendgrid_validations).
+            and_return(false)
+        end
+        it_behaves_like 'a valid address'
       end
     end
   end


### PR DESCRIPTION
Use an environment variable `ENABLE_SENDGRID_VALIDATIONS` to enable / disable Sengrid email validations.

Until the variable is set it will default to `false` behaviour so it should be safe to deploy.