### PR TITLE
Show table of booking info on staff confirm email

### DIFF
--- a/app/views/prison_mailer/booked.html.erb
+++ b/app/views/prison_mailer/booked.html.erb
@@ -1,4 +1,39 @@
 <p class="copy-notice">
+  <strong>Confirmed booking information</strong>
+</p>
+
+<table cellspacing="10">
+  <tr>
+    <th valign="top" align="left">Slot granted</th>
+    <td><%= format_slot_for_public(@visit.slot_granted) %></td>
+  </tr>
+  <tr>
+    <th valign="top" align="left">Prisoner name</th>
+    <td><%= @visit.prisoner_full_name %></td>
+  </tr>
+  <tr>
+    <th valign="top" align="left">Prisoner number</th>
+    <td><%= @visit.prisoner_number %></td>
+  </tr>
+  <tr>
+    <th valign="top" align="left">Approved visitors</th>
+    <td>
+      <% @visit.visitors.allowed.each do |visitor| %>
+      <div><%= visitor.full_name %></div>
+      <% end %>
+    </td>
+  </tr>
+  <tr>
+    <th valign="top" align="left">Reference number</th>
+    <td><%= @visit.reference_no %></td>
+  </tr>
+  <tr>
+    <th valign="top" align="left">Visit ID</th>
+    <td><%= @visit.id %></td>
+  </tr>
+</table>
+
+<p class="copy-notice">
   <strong><%= t('.copy_of_booking') %></strong>
 </p>
 

--- a/spec/features/process_a_request_spec.rb
+++ b/spec/features/process_a_request_spec.rb
@@ -85,7 +85,9 @@ RSpec.feature 'Processing a request', js: true do
       expect(prison_email_address).
         to receive_email.
         with_subject(/COPY of booking confirmation for Oscar Wilde/).
-        and_body(/This is a copy of the booking confirmation email sent to the visitor/)
+        with_body(/This is a copy of the booking confirmation email sent to the visitor/).
+        with_body(/#{vst.visitors.first.full_name}/).
+        with_body(/#{vst.prisoner.full_name}/)
     end
 
     context 'disallowed visitors' do


### PR DESCRIPTION
The table includes full visitor and prisoner names.

The copy of the visitor email shows shortened names, and should be removed as soon as we know it's not used.