### PR TITLE
Strips whitespace from visitor and feedback emails

### DIFF
--- a/app/models/feedback_submission.rb
+++ b/app/models/feedback_submission.rb
@@ -2,7 +2,13 @@ class FeedbackSubmission < ActiveRecord::Base
   validates :body, presence: true
   validate :validate_email
 
+  before_validation :strip_email_address, on: :create
+
 private
+
+  def strip_email_address
+    self.email_address = email_address.strip
+  end
 
   def validate_email
     return unless email_address.present?

--- a/app/models/visitors_step.rb
+++ b/app/models/visitors_step.rb
@@ -27,6 +27,10 @@ class VisitorsStep
 
   attr_reader :general # Required in order to assign errors to 'general'
 
+  def email_address=(val)
+    super(val.strip)
+  end
+
   # Return at least Prison::MAX_VISITORS visitors, filling with new instances
   # as needed. The regular #visitors method will return only those visitors
   # actually supplied via filled fields (or one blank primary visitor).

--- a/spec/features/request_a_visit_spec.rb
+++ b/spec/features/request_a_visit_spec.rb
@@ -5,7 +5,9 @@ RSpec.feature 'Booking a visit', js: true do
   include FeaturesHelper
 
   let!(:prison) { create(:prison, name: 'Reading Gaol') }
-  let(:visitor_email) { 'ado@test.example.com' }
+
+  # Whitespace on email to test stripping
+  let(:visitor_email) { ' ado@test.example.com ' }
 
   scenario 'happy path' do
     visit booking_requests_path(locale: 'en')
@@ -32,7 +34,7 @@ RSpec.feature 'Booking a visit', js: true do
       to receive_email.
       with_subject(/\AVisit request for Oscar Wilde on \w+ \d+ \w+\z/).
       and_body(/Prisoner:\s*Oscar Wilde/)
-    expect(visitor_email).
+    expect(visitor_email.strip).
       to receive_email.
       with_subject(/we’ve received your visit request for \w+ \d+ \w+\z/).
       and_body(/Prisoner:\s*Oscar W/)

--- a/spec/models/feedback_submission_spec.rb
+++ b/spec/models/feedback_submission_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe FeedbackSubmission do
+  context 'before validations' do
+    context 'email_address' do
+      it 'strips whitespace' do
+        subject.email_address = ' user@example.com '
+        subject.valid?
+        expect(subject.email_address).to eq('user@example.com')
+      end
+    end
+  end
+
   context 'validations' do
     context 'email_address' do
       it 'is valid when absent' do

--- a/spec/models/visitors_step_spec.rb
+++ b/spec/models/visitors_step_spec.rb
@@ -4,6 +4,13 @@ RSpec.describe VisitorsStep do
   let(:prison) { build(:prison) }
   subject { described_class.new(prison: prison) }
 
+  describe "email_address=" do
+    it 'strips whitespace' do
+      subject.email_address = ' email@example.com '
+      expect(subject.email_address).to eq('email@example.com')
+    end
+  end
+
   describe 'backfilled_visitors' do
     it 'includes supplied visitors' do
       subject.visitors_attributes = {


### PR DESCRIPTION
Strips whitespace when the email is passed to the models. This is possibly the
fix for the bug of some valid looking emails being rejected.

This approach is different from the original app which stripped all params with
a controller concern.