### PR TITLE
Fix bad validations when no slot is selected

### DIFF
--- a/app/models/booking_response.rb
+++ b/app/models/booking_response.rb
@@ -1,12 +1,14 @@
 class BookingResponse
   include NonPersistedModel
 
-  SLOTS = %w[ slot_0 slot_1 slot_2 none ]
+  SLOTS = %w[ slot_0 slot_1 slot_2 ]
 
   attribute :visit
 
   attribute :selection, String, default: 'none'
-  validates :selection, inclusion: { in: SLOTS + Rejection::REASONS }
+  validates :selection,
+    inclusion: { in: SLOTS + Rejection::REASONS },
+    if: :at_least_one_valid_visitor?
 
   attribute :reference_no, String
   validates :reference_no, presence: true, if: :bookable?


### PR DESCRIPTION
After changing the flags to allow for banning or noting unlisted
visitors separately, the application would throw a 500 error when banned
or not_on_list were selected, but a slot was not selected. This was
because `_inquiry` does not gracefully handle blank values.

In order to prevent this, I set the default for `selection` to none.
Stupidly, I then added that to the global used to check that a slot had
been selected.  This meant that every record was coming back valid to
begin with, even if a time slot had not been selected.  It also meant
that the model was always requiring a reference number, even if there
was not actually a slot.

This change fixes the problem and *should* resolve the issue being seen
on some requests whereby they *appear* to reload the page without
showing any errors (they are expecting a reference number, even though
the selection is 'none').