### PR TITLE
Timeout after 2s when using the Sendgrid API

### DIFF
--- a/app/services/sendgrid_api.rb
+++ b/app/services/sendgrid_api.rb
@@ -1,6 +1,8 @@
 class SendgridApi
   extend SingleForwardable
 
+  DEFAULT_TIMEOUT = 2 # seconds
+
   def_single_delegators :new, :spam_reported?, :bounced?,
     :remove_from_bounce_list, :remove_from_spam_list
 
@@ -23,7 +25,12 @@ class SendgridApi
 private
 
   def api(&_action)
-    yield
+    Timeout.timeout(DEFAULT_TIMEOUT) do
+      yield
+    end
+  rescue Timeout::Error => e
+    Rails.logger.error("SendgripApi timeout: #{e.class} #{e}")
+    false
   rescue => e
     Rails.logger.error("SendgridApi error: #{e.class} #{e}")
     false

--- a/spec/services/email_checker_spec.rb
+++ b/spec/services/email_checker_spec.rb
@@ -139,5 +139,11 @@ RSpec.describe EmailChecker do
         it_behaves_like 'a valid address'
       end
     end
+
+    context 'when sendgrid api client times out' do
+      include_context 'sendgrid timeouts'
+
+      it { is_expected.to be_valid }
+    end
   end
 end

--- a/spec/services/sendgrid_api/bounced_spec.rb
+++ b/spec/services/sendgrid_api/bounced_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe SendgridApi, '.bounced?' do
 
   context 'sendgrid credentials are set' do
     include_examples 'error handling'
+    include_examples 'timeout handling'
 
     context 'when there is no bounce' do
       it_should_behave_like 'there is nothing to report'

--- a/spec/services/sendgrid_api/remove_from_bounce_list_spec.rb
+++ b/spec/services/sendgrid_api/remove_from_bounce_list_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe SendgridApi, '.remove_from_bounce_list' do
 
   context 'sendgrid credentials are set' do
     include_examples 'error handling'
+    include_examples 'timeout handling'
 
     context 'when there is no bounce' do
       include_examples 'API reports email does not exist'

--- a/spec/services/sendgrid_api/remove_from_spam_list_spec.rb
+++ b/spec/services/sendgrid_api/remove_from_spam_list_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe SendgridApi, '.remove_from_spam_list' do
 
   context 'sendgrid credentials are set' do
     include_examples 'error handling'
+    include_examples 'timeout handling'
 
     context 'when email does not exist' do
       include_examples 'API reports email does not exist'

--- a/spec/services/sendgrid_api/shared_examples.rb
+++ b/spec/services/sendgrid_api/shared_examples.rb
@@ -78,3 +78,14 @@ RSpec.shared_examples 'there is something to report' do
     expect(subject).to be_truthy
   end
 end
+
+RSpec.shared_examples 'timeout handling' do
+  specify do
+    expect(Timeout).
+      to receive(:timeout).
+      with(described_class::DEFAULT_TIMEOUT).
+      and_raise(Timeout::Error)
+
+    expect(subject).to be_falsey
+  end
+end

--- a/spec/services/sendgrid_api/spam_reported_spec.rb
+++ b/spec/services/sendgrid_api/spam_reported_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe SendgridApi, '.spam_reported?' do
 
   context 'sendgrid credentials are set' do
     include_examples 'error handling'
+    include_examples 'timeout handling'
 
     context 'when there is no spam report' do
       it_should_behave_like 'there is nothing to report'

--- a/spec/shared_sendgrid_context.rb
+++ b/spec/shared_sendgrid_context.rb
@@ -9,3 +9,9 @@ RSpec.shared_context 'sendgrid reports spam' do
     allow(SendgridApi).to receive(:spam_reported?).at_least(:once).and_return(true)
   end
 end
+
+RSpec.shared_context 'sendgrid timeouts' do
+  before do
+    allow(Timeout).to receive(:timeout).and_raise(Timeout::Error)
+  end
+end


### PR DESCRIPTION
Use `Timeout.timeout` around the Sendgrid client.

Currently SendgridToolkit uses HTTP Party without a timeout so if the Sendgrid
API becomes unresponsive booking a visit becomes unresponsive.

Ideally the timeout would be set on the HTTP client, however it is not possible
to set it by design. We should revisit this issue as the fix is not a good term
solution.