### PR TITLE
Make sidekiq listen on all available interfaces within a container

### DIFF
--- a/run-sidekiq.sh
+++ b/run-sidekiq.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 export RAILS_ENV=production
-bundle exec rackup sidekiq-admin.ru -p 3000 -E production &
+bundle exec rackup sidekiq-admin.ru -p 3000 -E production -o 0.0.0.0 &
 bundle exec sidekiq -l /var/log/sidekiq.log --environment production


### PR DESCRIPTION
By default sidekiq admin listens only on localhost which makes it return empty
response as the upstream server when queried from the docker host