### PR TITLE
Fix email expectation in smoke test

### DIFF
--- a/smoke_test/steps/prison_booking_cancelled.rb
+++ b/smoke_test/steps/prison_booking_cancelled.rb
@@ -14,7 +14,7 @@ module SmokeTest
     private
 
       def expected_email_subject
-        'CANCELLED: %s on %s' % [
+        'CANCELLED: Visit for %s on %s' % [
           state.prisoner.full_name,
           state.first_slot_date_prison_format
         ]


### PR DESCRIPTION
Test was expecting subject with format 'CANCELLED: %s on %s' but email subject
is 'CANCELLED: Visit for %s on %s'