### PR TITLE
Re enable problematic views

### DIFF
--- a/app/metrics/overdue.rb
+++ b/app/metrics/overdue.rb
@@ -1,0 +1,31 @@
+require 'support/counter_support'
+
+module Overdue
+  class CountOverdueVisits < ActiveRecord::Base
+    extend CounterSupport
+    def self.fetch_and_format
+      pluck(:visit_state, :count).to_h
+    end
+  end
+
+  class CountOverdueVisitsByPrison < ActiveRecord::Base
+    extend CounterSupport
+    def self.ordered_counters
+      pluck(:prison_name, :visit_state, :count)
+    end
+  end
+
+  class CountOverdueVisitsByPrisonAndCalendarWeek < ActiveRecord::Base
+    extend CounterSupport
+    def self.ordered_counters
+      pluck(:prison_name, :year, :week, :visit_state, :count)
+    end
+  end
+
+  class CountOverdueVisitsByPrisonAndCalendarDate < ActiveRecord::Base
+    extend CounterSupport
+    def self.ordered_counters
+      pluck(:prison_name, :year, :month, :day, :visit_state, :count)
+    end
+  end
+end

--- a/app/metrics/percentiles.rb
+++ b/app/metrics/percentiles.rb
@@ -1,0 +1,31 @@
+require 'support/percentile_support'
+
+module Percentiles
+  class Distribution < ActiveRecord::Base
+    extend PercentileSupport
+    def self.fetch_and_format
+      hash_centiles(first.percentiles)
+    end
+  end
+
+  class DistributionByPrison < ActiveRecord::Base
+    extend PercentileSupport
+    def self.ordered_counters
+      pluck(:prison_name, :percentiles)
+    end
+  end
+
+  class DistributionByPrisonAndCalendarWeek < ActiveRecord::Base
+    extend PercentileSupport
+    def self.ordered_counters
+      pluck(:prison_name, :year, :week, :percentiles)
+    end
+  end
+
+  class DistributionByPrisonAndCalendarDate < ActiveRecord::Base
+    extend PercentileSupport
+    def self.ordered_counters
+      pluck(:prison_name, :year, :month, :day, :percentiles)
+    end
+  end
+end

--- a/app/metrics/support/percentile_support.rb
+++ b/app/metrics/support/percentile_support.rb
@@ -1,0 +1,28 @@
+require_relative './metrics_support'
+
+module PercentileSupport
+  include MetricsSupport
+
+  CENTILES = [99, 95, 90, 75, 50, 25]
+
+  def centiles
+    CENTILES
+  end
+
+  def fetch_and_format(aggregate = nil)
+    ordered_counters.each_with_object({}) do |values, result|
+      prison = values.shift
+      values << hash_centiles(values.pop)
+      result_key = aggregate.blank? ? prison : 'all'
+      result[result_key] = result.fetch(result_key, {}).deep_merge(
+        order_and_hash_visit_values(values)
+      )
+    end
+  end
+
+private
+
+  def hash_centiles(result)
+    Hash[centiles.zip(result)]
+  end
+end

--- a/db/migrate/20160308165239_create_distributions.rb
+++ b/db/migrate/20160308165239_create_distributions.rb
@@ -1,0 +1,6 @@
+class CreateDistributions < ActiveRecord::Migration
+  def change
+    execute 'DROP VIEW IF EXISTS distributions;'
+    create_view :distributions
+  end
+end

--- a/db/migrate/20160308165532_create_distribution_by_prisons.rb
+++ b/db/migrate/20160308165532_create_distribution_by_prisons.rb
@@ -1,0 +1,6 @@
+class CreateDistributionByPrisons < ActiveRecord::Migration
+  def change
+    execute 'DROP VIEW IF EXISTS distribution_by_prisons;'
+    create_view :distribution_by_prisons
+  end
+end

--- a/db/migrate/20160308165546_create_distribution_by_prison_and_calendar_weeks.rb
+++ b/db/migrate/20160308165546_create_distribution_by_prison_and_calendar_weeks.rb
@@ -1,0 +1,6 @@
+class CreateDistributionByPrisonAndCalendarWeeks < ActiveRecord::Migration
+  def change
+    execute 'DROP VIEW IF EXISTS distribution_by_prison_and_calendar_weeks;'
+    create_view :distribution_by_prison_and_calendar_weeks
+  end
+end

--- a/db/migrate/20160308165607_create_distribution_by_prison_and_calendar_dates.rb
+++ b/db/migrate/20160308165607_create_distribution_by_prison_and_calendar_dates.rb
@@ -1,0 +1,6 @@
+class CreateDistributionByPrisonAndCalendarDates < ActiveRecord::Migration
+  def change
+    execute 'DROP VIEW IF EXISTS distribution_by_prison_and_calendar_dates;'
+    create_view :distribution_by_prison_and_calendar_dates
+  end
+end

--- a/db/migrate/20160308170656_create_count_overdue_visits.rb
+++ b/db/migrate/20160308170656_create_count_overdue_visits.rb
@@ -1,0 +1,6 @@
+class CreateCountOverdueVisits < ActiveRecord::Migration
+  def change
+    execute 'DROP VIEW IF EXISTS count_overdue_visits;'
+    create_view :count_overdue_visits
+  end
+end

--- a/db/migrate/20160308170712_create_count_overdue_visits_by_prisons.rb
+++ b/db/migrate/20160308170712_create_count_overdue_visits_by_prisons.rb
@@ -1,0 +1,6 @@
+class CreateCountOverdueVisitsByPrisons < ActiveRecord::Migration
+  def change
+    execute 'DROP VIEW IF EXISTS count_overdue_visits_by_prisons;'
+    create_view :count_overdue_visits_by_prisons
+  end
+end

--- a/db/migrate/20160308170726_create_count_overdue_visits_by_prison_and_calendar_weeks.rb
+++ b/db/migrate/20160308170726_create_count_overdue_visits_by_prison_and_calendar_weeks.rb
@@ -1,0 +1,6 @@
+class CreateCountOverdueVisitsByPrisonAndCalendarWeeks < ActiveRecord::Migration
+  def change
+    execute 'DROP VIEW IF EXISTS count_overdue_visits_by_prison_and_calendar_weeks;'
+    create_view :count_overdue_visits_by_prison_and_calendar_weeks
+  end
+end

--- a/db/migrate/20160308170742_create_count_overdue_visits_by_prison_and_calendar_dates.rb
+++ b/db/migrate/20160308170742_create_count_overdue_visits_by_prison_and_calendar_dates.rb
@@ -1,0 +1,6 @@
+class CreateCountOverdueVisitsByPrisonAndCalendarDates < ActiveRecord::Migration
+  def change
+    execute 'DROP VIEW IF EXISTS count_overdue_visits_by_prison_and_calendar_dates;'
+    create_view :count_overdue_visits_by_prison_and_calendar_dates
+  end
+end

--- a/spec/metrics/overdue_spec.rb
+++ b/spec/metrics/overdue_spec.rb
@@ -1,0 +1,154 @@
+require 'rails_helper'
+require_relative 'shared_examples_for_metrics'
+
+RSpec.describe Overdue do
+  include_examples 'create visits with dates'
+
+  before do
+    book_a_luna_visit_late
+    book_a_luna_visit_on_time
+    reject_a_luna_visit_late
+    reject_a_luna_visit_on_time
+    book_a_mars_visit_late
+    book_a_mars_visit_on_time
+    reject_a_mars_visit_late
+    reject_a_mars_visit_on_time
+    request_a_visit_that_remains_overdue
+  end
+
+  context 'that are not organised by date' do
+    describe Overdue::CountOverdueVisits do
+      it 'counts all overdue visits' do
+        expect(described_class.fetch_and_format).to eq('booked' => 2,
+                                                       'rejected' => 2,
+                                                       'requested' => 1)
+      end
+    end
+
+    describe Overdue::CountOverdueVisitsByPrison do
+      it 'counts all overdue visits and group by prison' do
+        expect(described_class.fetch_and_format).to be ==
+          { 'Lunar Penal Colony' =>
+            { 'booked' => 1,
+              'rejected' => 1,
+              'requested' => 1
+            },
+            'Martian Penal Colony' =>
+            { 'booked' => 1,
+              'rejected' => 1
+            }
+        }
+      end
+    end
+  end
+
+  context 'that are organized by date' do
+    describe Overdue::CountOverdueVisitsByPrisonAndCalendarWeek do
+      it 'counts visits and groups by prison, year, calendar week and visit state' do
+        expect(described_class.fetch_and_format).to be ==
+          { 'Lunar Penal Colony' =>
+            {
+              2015 => {
+                53 => {
+                  'requested' => 1
+                }
+              },
+              2016 => {
+                5 => {
+                  'rejected' => 1,
+                  'booked' => 1
+                }
+              }
+            },
+            'Martian Penal Colony' =>
+            {
+              2016 => {
+                5 => {
+                  'rejected' => 1,
+                  'booked' => 1
+                }
+              }
+            }
+        }
+      end
+
+      context 'and aggregated across all prisons' do
+        it 'counts visits and groups by year, calendar week and visit state' do
+          expect(described_class.fetch_and_format(:concatenate)).to be ==
+            { 'all' =>
+              {
+                2015 => {
+                  53 => {
+                    'requested' => 1
+                  }
+                },
+                2016 => {
+                  5 => {
+                    'rejected' => 2,
+                    'booked' => 2
+                  }
+                }
+              }
+          }
+        end
+      end
+    end
+
+    describe Overdue::CountOverdueVisitsByPrisonAndCalendarDate do
+      it 'counts visits and groups by prison, year, calendar week and visit state' do
+        expect(described_class.fetch_and_format).to be ==
+          { 'Lunar Penal Colony' =>
+            {
+              2016 => {
+                1 => {
+                  1 => {
+                    'requested' => 1
+                  }
+                },
+                2 => {
+                  1 => {
+                    'rejected' => 1,
+                    'booked' => 1
+                  }
+                }
+              }
+            },
+            'Martian Penal Colony' =>
+            {
+              2016 => {
+                2 => {
+                  1 => {
+                    'rejected' => 1,
+                    'booked' => 1
+                  }
+                }
+              }
+            }
+        }
+      end
+
+      context 'and aggregated across all prisons' do
+        it 'counts visits and groups by year, calendar week and visit state' do
+          expect(described_class.fetch_and_format(:concatenate)).to be ==
+            { 'all' =>
+              {
+                2016 => {
+                  1 => {
+                    1 => {
+                      'requested' => 1
+                    }
+                  },
+                  2 => {
+                    1 => {
+                      'rejected' => 2,
+                      'booked' => 2
+                    }
+                  }
+                }
+              }
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/metrics/percentiles_spec.rb
+++ b/spec/metrics/percentiles_spec.rb
@@ -1,0 +1,227 @@
+require 'rails_helper'
+require_relative 'shared_examples_for_metrics'
+
+RSpec.describe Percentiles do
+  context 'that are not organised by date' do
+    include_examples 'create and process visits timed by seconds'
+
+    describe Percentiles::Distribution do
+      it 'returns the 99% 95% 90% 75% 50% 25% times' do
+        expect(described_class.fetch_and_format).to be ==
+          {
+            99 => 55,
+            95 => 55,
+            90 => 34,
+            75 => 21,
+            50 => 5,
+            25 => 2
+          }
+      end
+    end
+
+    describe Percentiles::DistributionByPrison do
+      it 'returns the 99% 95% 90% 75% 50% 25% times' do
+        expect(described_class.fetch_and_format).to be ==
+          { 'Lunar Penal Colony' =>
+            {
+              99 => 55,
+              95 => 55,
+              90 => 34,
+              75 => 21,
+              50 => 5,
+              25 => 2
+            },
+            'Martian Penal Colony' =>
+            {
+              99 => 55,
+              95 => 55,
+              90 => 34,
+              75 => 21,
+              50 => 5,
+              25 => 2
+            }
+        }
+      end
+    end
+  end
+
+  context 'that are organized by date' do
+    include_examples 'create and process visits with dates'
+
+    describe Percentiles::DistributionByPrisonAndCalendarWeek do
+      before do
+        luna_visits_with_dates
+      end
+
+      it 'counts visits and groups by prison, year, calendar week and visit state' do
+        expect(described_class.fetch_and_format).to be ==
+          { 'Lunar Penal Colony' =>
+            {
+              2016 =>
+              { 5 =>
+                {
+                  95 => 777_600,
+                  99 => 777_600,
+                  90 => 777_600,
+                  75 => 777_600,
+                  50 => 432_000,
+                  25 => 259_200
+                },
+                6 =>
+                {
+                  99 => 777_600,
+                  95 => 777_600,
+                  90 => 777_600,
+                  75 => 777_600,
+                  50 => 432_000,
+                  25 => 259_200
+                },
+                7 => {
+                  99 => 777_600,
+                  95 => 777_600,
+                  90 => 777_600,
+                  50 => 432_000,
+                  75 => 777_600,
+                  25 => 259_200
+                }
+              }
+            }
+        }
+      end
+
+      context 'and aggregated across all prisons' do
+        before do
+          mars_visits_with_dates
+          luna_visits_with_dates
+        end
+
+        it 'counts visits and groups by year, calendar week and visit state' do
+          expect(described_class.fetch_and_format(:concatenate)).to be ==
+            { 'all' =>
+              {
+                2016 =>
+                { 5 =>
+                  {
+                    99 => 777_600,
+                    95 => 777_600,
+                    90 => 777_600,
+                    75 => 777_600,
+                    50 => 432_000,
+                    25 => 259_200
+                  },
+                  6 =>
+                  {
+                    99 => 777_600,
+                    95 => 777_600,
+                    90 => 777_600,
+                    75 => 777_600,
+                    50 => 432_000,
+                    25 => 259_200
+                  },
+                  7 => {
+                    99 => 777_600,
+                    95 => 777_600,
+                    90 => 777_600,
+                    75 => 777_600,
+                    50 => 432_000,
+                    25 => 259_200
+                  }
+                }
+              }
+          }
+        end
+      end
+
+      describe Percentiles::DistributionByPrisonAndCalendarDate do
+        before do
+          luna_visits_with_dates
+        end
+
+        it 'calculates distribution and groups by prison, nested calendar date and visit state' do
+          expect(described_class.fetch_and_format).to be ==
+            { 'Lunar Penal Colony' =>
+              {
+                2016 =>
+                { 2 =>
+                  {
+                    1 =>
+                    {
+                      99 => 777_600,
+                      95 => 777_600,
+                      90 => 777_600,
+                      75 => 777_600,
+                      50 => 432_000,
+                      25 => 259_200
+                    },
+                    8 =>
+                    {
+                      99 => 777_600,
+                      95 => 777_600,
+                      90 => 777_600,
+                      75 => 777_600,
+                      50 => 432_000,
+                      25 => 259_200
+                    },
+                    15 => {
+                      99 => 777_600,
+                      95 => 777_600,
+                      90 => 777_600,
+                      75 => 777_600,
+                      50 => 432_000,
+                      25 => 259_200
+                    }
+                  }
+                }
+              }
+          }
+        end
+
+        context 'and aggregated across all prisons' do
+          before do
+            mars_visits_with_dates
+            luna_visits_with_dates
+          end
+
+          it 'counts visits and groups by year, calendar week and visit state' do
+            expect(described_class.fetch_and_format(:concatenate)).to be ==
+              { 'all' =>
+                {
+                  2016 =>
+                  { 2 =>
+                    {
+                      1 =>
+                      {
+                        99 => 777_600,
+                        95 => 777_600,
+                        90 => 777_600,
+                        75 => 777_600,
+                        50 => 432_000,
+                        25 => 259_200
+                      },
+                      8 =>
+                      {
+                        99 => 777_600,
+                        95 => 777_600,
+                        90 => 777_600,
+                        75 => 777_600,
+                        50 => 432_000,
+                        25 => 259_200
+                      },
+                      15 => {
+                        99 => 777_600,
+                        95 => 777_600,
+                        90 => 777_600,
+                        75 => 777_600,
+                        50 => 432_000,
+                        25 => 259_200
+                      }
+                    }
+                  }
+                }
+            }
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
These were broken because we were running Postgres 9.3 on our staging
and production RDS instances. We have requested that platforms upgrade
these to 9.4.  According to the AWS documentation, this is a trivial operation.