### PR TITLE
Fix IP filtering code to use the correct remote_ip

### DIFF
--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -1,5 +1,6 @@
 class Prison::VisitsController < ApplicationController
   helper CalendarHelper
+  before_filter :authorize_prison_request
 
   def show
     @booking_response = BookingResponse.new(visit: visit)
@@ -31,5 +32,12 @@ private
         unlisted_visitor_ids: [], banned_visitor_ids: []
       ).
       merge(visit: visit)
+  end
+
+  def authorize_prison_request
+    unless Rails.configuration.prison_ip_matcher.include?(request.remote_ip)
+      Rails.logger.info "Unauthorized request from #{request.remote_ip}"
+      raise ActionController::RoutingError.new('Not Found')
+    end
   end
 end

--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -37,7 +37,7 @@ private
   def authorize_prison_request
     unless Rails.configuration.prison_ip_matcher.include?(request.remote_ip)
       Rails.logger.info "Unauthorized request from #{request.remote_ip}"
-      fail ActionController::RoutingError 'Not Found'
+      fail ActionController::RoutingError, 'Not Found'
     end
   end
 end

--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -1,6 +1,6 @@
 class Prison::VisitsController < ApplicationController
   helper CalendarHelper
-  before_filter :authorize_prison_request
+  before_action :authorize_prison_request
 
   def show
     @booking_response = BookingResponse.new(visit: visit)
@@ -37,7 +37,7 @@ private
   def authorize_prison_request
     unless Rails.configuration.prison_ip_matcher.include?(request.remote_ip)
       Rails.logger.info "Unauthorized request from #{request.remote_ip}"
-      raise ActionController::RoutingError.new('Not Found')
+      fail ActionController::RoutingError 'Not Found'
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,7 +29,6 @@ module PrisonVisits
     config.action_dispatch.rescue_responses.merge!(
       'StateMachines::InvalidTransition' => :unprocessable_entity
     )
-    config.prison_ip_ranges = ENV.fetch('PRISON_ESTATE_IPS', '127.0.0.1,::1')
 
     config.ga_id = ENV['GA_TRACKING_ID']
 

--- a/config/initializers/ip_filtering.rb
+++ b/config/initializers/ip_filtering.rb
@@ -1,0 +1,2 @@
+prison_estate_ips = ENV.fetch('PRISON_ESTATE_IPS', '127.0.0.1,::1')
+Rails.configuration.prison_ip_matcher = IpAddressMatcher.new(prison_estate_ips)

--- a/config/initializers/ip_filtering.rb
+++ b/config/initializers/ip_filtering.rb
@@ -1,2 +1,2 @@
-prison_estate_ips = ENV.fetch('PRISON_ESTATE_IPS', '127.0.0.1,::1')
+prison_estate_ips = ENV.fetch('PRISON_ESTATE_IPS', '0.0.0.0,127.0.0.1,::1')
 Rails.configuration.prison_ip_matcher = IpAddressMatcher.new(prison_estate_ips)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,4 @@
 Rails.application.routes.draw do
-  prison_ip_matcher =
-    IpAddressMatcher.new(Rails.configuration.prison_ip_ranges)
-
   get '/', to: redirect(ENV.fetch('GOVUK_START_PAGE', '/en/request'))
 
   %w[ 404 500 503 ].each do |code|
@@ -17,10 +14,8 @@ Rails.application.routes.draw do
   scope '/:locale', locale: /[a-z]{2}/ do
     get '/', to: redirect('/%{locale}/request')
 
-    constraints ip: prison_ip_matcher do
-      namespace :prison do
-        resources :visits, only: %i[ show update ]
-      end
+    namespace :prison do
+      resources :visits, only: %i[ show update ]
     end
 
     resources :booking_requests, path: 'request', only: %i[ index create ]

--- a/spec/controllers/prison/visits_controller_spec.rb
+++ b/spec/controllers/prison/visits_controller_spec.rb
@@ -10,4 +10,18 @@ RSpec.describe Prison::VisitsController, type: :controller do
       id: visit.id, booking_response: { selection: 'slot_0' }, locale: 'en'
     expect(response).to render_template('show')
   end
+
+  context "whent the ip is not allowed" do
+    before do
+      allow_any_instance_of(ActionDispatch::Request).
+        to receive(:remote_ip).
+        and_return('192.168.1.0')
+    end
+
+    it 'raises a not found error' do
+      expect {
+        put :update, id: visit.id, locale: 'en'
+      }.to raise_error(ActionController::RoutingError)
+    end
+  end
 end


### PR DESCRIPTION
The Rails routing ip constraint calls, for unfathomable reasons, the Rack::Request#ip method rather than using ActionDispatch::Request#remote_ip. This is unfortunate given that Rails comes with it’s own middleware for determining the remote IP.

Reimplemented using a simple before filter on the controller.