### PR TITLE
Break down timely and overdue visits by prisions

### DIFF
--- a/app/metrics/timings.rb
+++ b/app/metrics/timings.rb
@@ -1,0 +1,10 @@
+require 'support/counter_support'
+
+module Timings
+  class TimelyAndOverdue < ActiveRecord::Base
+    extend CounterSupport
+    def self.ordered_counters
+      pluck(:prison_name, :status, :visit_state, :count)
+    end
+  end
+end

--- a/db/migrate/20160315143957_create_timely_and_overdues.rb
+++ b/db/migrate/20160315143957_create_timely_and_overdues.rb
@@ -1,0 +1,5 @@
+class CreateTimelyAndOverdues < ActiveRecord::Migration
+  def change
+    create_view :timely_and_overdues
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160314160900) do
+ActiveRecord::Schema.define(version: 20160315143957) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -452,6 +452,28 @@ ActiveRecord::Schema.define(version: 20160314160900) do
             GROUP BY prisons.name, visits.prison_id) booked
     WHERE ((rejected.prison_name)::text = (booked.prison_name)::text)
     GROUP BY rejected.prison_name, rejected.reason, round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2), (date_part('year'::text, rejected.created_at))::integer, (date_part('month'::text, rejected.created_at))::integer, (date_part('day'::text, rejected.created_at))::integer;
+  SQL
+
+  create_view :timely_and_overdues,  sql_definition: <<-SQL
+      SELECT count(*) AS count,
+      'overdue'::text AS status,
+      vsc.visit_state,
+      prisons.name AS prison_name
+     FROM ((visits v
+       JOIN prisons ON ((prisons.id = v.prison_id)))
+       JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY ((ARRAY['booked'::character varying, 'rejected'::character varying])::text[])))))
+    WHERE (date_part('epoch'::text, (vsc.created_at - v.created_at)) > (259200)::double precision)
+    GROUP BY prisons.name, vsc.visit_state
+  UNION
+   SELECT count(*) AS count,
+      'timely'::text AS status,
+      vsc.visit_state,
+      prisons.name AS prison_name
+     FROM ((visits v
+       JOIN prisons ON ((prisons.id = v.prison_id)))
+       JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY ((ARRAY['booked'::character varying, 'rejected'::character varying])::text[])))))
+    WHERE (date_part('epoch'::text, (vsc.created_at - v.created_at)) < (259200)::double precision)
+    GROUP BY prisons.name, vsc.visit_state;
   SQL
 
 end

--- a/db/views/timely_and_overdues_v01.sql
+++ b/db/views/timely_and_overdues_v01.sql
@@ -1,0 +1,21 @@
+SELECT COUNT(*),
+        'overdue' AS status,
+         vsc.visit_state AS visit_state,
+         prisons.name AS prison_name
+  FROM visits AS v
+  INNER JOIN prisons ON prisons.id = v.prison_id
+  INNER JOIN visit_state_changes AS vsc ON v.id = vsc.visit_id AND vsc.visit_state IN ('booked', 'rejected')
+  WHERE EXTRACT(EPOCH FROM vsc.created_at - v.created_at) > 259200
+  GROUP BY prison_name,
+           visit_state
+UNION
+SELECT COUNT(*),
+        'timely' AS status,
+         vsc.visit_state AS visit_state,
+         prisons.name AS prison_name
+  FROM visits AS v
+  INNER JOIN prisons ON prisons.id = v.prison_id
+  INNER JOIN visit_state_changes AS vsc ON v.id = vsc.visit_id AND vsc.visit_state IN ('booked', 'rejected')
+  WHERE EXTRACT(EPOCH FROM vsc.created_at - v.created_at) < 259200
+  GROUP BY prison_name,
+           visit_state

--- a/spec/metrics/timings_spec.rb
+++ b/spec/metrics/timings_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+require_relative 'shared_examples_for_metrics'
+
+RSpec.describe Timings do
+  include_examples 'create visits with dates'
+
+  before do
+    book_a_luna_visit_late
+    book_a_luna_visit_on_time
+    reject_a_luna_visit_late
+    reject_a_luna_visit_on_time
+    book_a_mars_visit_late
+    book_a_mars_visit_on_time
+    reject_a_mars_visit_late
+    reject_a_mars_visit_on_time
+  end
+
+  describe Timings::TimelyAndOverdue do
+    it 'counts all timely and overdue visits and group by prison' do
+      expect(described_class.fetch_and_format).to be ==
+        { 'Lunar Penal Colony' =>
+          {
+            'timely' => {
+              'booked' => 1,
+              'rejected' => 1
+            },
+            'overdue' => {
+              'booked' => 1,
+              'rejected' => 1
+            }
+          },
+          'Martian Penal Colony' =>
+          {
+            'timely' => {
+              'booked' => 1,
+              'rejected' => 1
+            },
+            'overdue' => {
+              'booked' => 1,
+              'rejected' => 1
+            }
+          }
+      }
+    end
+  end
+end


### PR DESCRIPTION
Only for booked and rejected visits.  Use the overdue metric if you'd
like to see all status that are overdue.