### PR TITLE
Brute-force the flip flopping sendgrid features

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rspec-rails', '~> 3.0'
+  gem 'rspec-retry'
   gem 'rubocop'
   gem 'rubocop-rspec'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,6 +221,8 @@ GEM
       rspec-expectations (~> 3.4.0)
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
+    rspec-retry (0.4.5)
+      rspec-core
     rspec-support (3.4.1)
     rubocop (0.35.1)
       astrolabe (~> 1.3)
@@ -358,6 +360,7 @@ DEPENDENCIES
   rails (~> 4.2.3)
   rake (< 11.0)
   rspec-rails (~> 3.0)
+  rspec-retry
   rubocop
   rubocop-rspec
   sass-rails (~> 5.0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ require 'capybara/rspec'
 require 'capybara/poltergeist'
 require 'ffaker'
 require 'webmock/rspec'
+require 'rspec/retry'
 
 WebMock.disable_net_connect!(allow: 'codeclimate.com', allow_localhost: true)
 
@@ -19,6 +20,12 @@ Capybara.asset_host = 'http://localhost:3000'
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  config.display_try_failure_messages = true
+
+  config.around :each, :js do |ex|
+    ex.run_with_retry retry: 3
+  end
+
   config.use_transactional_fixtures = false
   config.include FactoryGirl::Syntax::Methods
   config.include ActiveSupport::Testing::TimeHelpers


### PR DESCRIPTION
These are intermittent and impossible to reproduce. They are also wrong.
This just ensures that they get rerun when the occur.  Not intended as a
long term fix as these features will go when PVB2 becomes the API.