### PR TITLE
Attempt to fix failing docker build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ ruby '2.3.0'
 
 gem 'rails', '~> 4.2.3'
 
-gem 'connection_pool'
+gem 'connection_pool', require: false
 gem 'excon'
 gem 'govuk_frontend_toolkit', '2.0.1'
 gem 'high_voltage'

--- a/app/services/sendgrid_api.rb
+++ b/app/services/sendgrid_api.rb
@@ -1,3 +1,5 @@
+require 'connection_pool'
+
 class SendgridApi
   RESCUABLE_ERRORS = [JSON::ParserError,
                       Excon::Errors::Error,


### PR DESCRIPTION
`assets:precompile` is trying to make a database connection.  Lukasz
suspects the `connection_pool` gem. This is my attempt to constrain its
scope and see if that fixes the problem.