### PR TITLE
Catch Excon errors subclasses

### DIFF
--- a/app/services/sendgrid_api.rb
+++ b/app/services/sendgrid_api.rb
@@ -112,14 +112,15 @@ private
     yield response
   rescue => e
     Rails.logger.error("#{e.class.name}: #{e.message}")
-    unless RESCUABLE_ERRORS.any? { |error_klass| e.is_a?(error_klass) }
-      Raven.capture_exception(e)
-    end
+    Raven.capture_exception(e) unless ignore_error?(e)
     false
   end
 
+  def ignore_error?(error)
+    RESCUABLE_ERRORS.any? { |error_klass| error.is_a?(error_klass) }
+  end
+
   def enabled?
-    Rails.logger.error('Sendgrid is disabled') unless @enabled
     @enabled
   end
 end

--- a/app/services/sendgrid_api.rb
+++ b/app/services/sendgrid_api.rb
@@ -105,21 +105,21 @@ private
   end
 
   def call_api(method, action, data)
-    unless enabled?
-      Rails.logger.error('Sendgrid is disabled')
-      return false
-    end
+    return false unless enabled?
 
     response = @pool.with { |client| client.request(method, action, data) }
 
     yield response
   rescue => e
     Rails.logger.error("#{e.class.name}: #{e.message}")
-    Raven.capture_exception(e) unless RESCUABLE_ERRORS.include?(e.class)
+    unless RESCUABLE_ERRORS.any? { |error_klass| e.is_a?(error_klass) }
+      Raven.capture_exception(e)
+    end
     false
   end
 
   def enabled?
+    Rails.logger.error('Sendgrid is disabled') unless @enabled
     @enabled
   end
 end

--- a/config/initializers/sendgrid_api.rb
+++ b/config/initializers/sendgrid_api.rb
@@ -1,3 +1,4 @@
 if Rails.configuration.disable_sendgrid_validations
+  Rails.logger.warn('App starting with Sendgrid disabled')
   SendgridApi.instance.disable
 end

--- a/spec/services/sendgrid_api/shared_examples.rb
+++ b/spec/services/sendgrid_api/shared_examples.rb
@@ -18,8 +18,8 @@ RSpec.shared_examples 'error handling' do
       end
     end
 
-    context 'when times outs' do
-      include_context 'sendgrid times out'
+    context 'when Sendgrid times outs' do
+      include_context 'sendgrid timeout'
 
       it 'rescues, logs the error and returns false' do
         check_error_log_message_contains(/Timeout/)
@@ -54,7 +54,6 @@ RSpec.shared_examples 'error handling for missing credentials' do
     include_context 'sendgrid credentials are not set'
 
     it 'rescues, logs the error and returns false' do
-      check_error_log_message_contains(/Sendgrid is disabled/)
       expect(subject).to be_falsey
     end
   end

--- a/spec/services/sendgrid_api/shared_examples.rb
+++ b/spec/services/sendgrid_api/shared_examples.rb
@@ -18,6 +18,17 @@ RSpec.shared_examples 'error handling' do
       end
     end
 
+    context 'when times outs' do
+      include_context 'sendgrid times out'
+
+      it 'rescues, logs the error and returns false' do
+        check_error_log_message_contains(/Timeout/)
+        expect(Raven).to_not receive(:capture_exception)
+
+        expect(subject).to be_falsey
+      end
+    end
+
     context 'when the API reports an error' do
       let(:body) { '{"error":"LOL"}' }
 

--- a/spec/services/sendgrid_api_shared_context.rb
+++ b/spec/services/sendgrid_api_shared_context.rb
@@ -57,3 +57,10 @@ RSpec.shared_context 'sendgrid api raises an exception' do
       to_raise(StandardError)
   end
 end
+
+RSpec.shared_context 'sendgrid times out' do
+  before do
+    stub_request(:any, %r{.*api\.sendgrid\.com/api/.+\.json}).
+      to_raise(Excon::Errors::Timeout)
+  end
+end

--- a/spec/services/sendgrid_api_shared_context.rb
+++ b/spec/services/sendgrid_api_shared_context.rb
@@ -58,7 +58,7 @@ RSpec.shared_context 'sendgrid api raises an exception' do
   end
 end
 
-RSpec.shared_context 'sendgrid times out' do
+RSpec.shared_context 'sendgrid timeout' do
   before do
     stub_request(:any, %r{.*api\.sendgrid\.com/api/.+\.json}).
       to_raise(Excon::Errors::Timeout)


### PR DESCRIPTION
Excon raises its own timeout class which means that it is getting reported to
Sentry