### PR TITLE
Cast to float for metrics image helper

### DIFF
--- a/app/views/metrics/summary.html.erb
+++ b/app/views/metrics/summary.html.erb
@@ -32,7 +32,7 @@
       <%= @summary.processed_overdue %>
     </td>
     <td>
-      <%= image_for_performance_score(@summary.end_to_end_percentile('95th')) %>
+      <%= image_for_performance_score(@summary.end_to_end_percentile('95th').to_f) %>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
This was supposed to have gone in the previous metrics PR however it got lost in
during rebase