### PR TITLE
Fix prisoner number validation errors

### DIFF
--- a/app/models/prisoner_step.rb
+++ b/app/models/prisoner_step.rb
@@ -3,12 +3,15 @@ require 'maybe_date'
 class PrisonerStep
   include NonPersistedModel
   include Person
+  include ActiveModel::Validations::Callbacks
 
   attribute :first_name, String
   attribute :last_name, String
   attribute :date_of_birth, MaybeDate
   attribute :number, String
   attribute :prison_id, Integer
+
+  before_validation :scrub_trailing_spaces
 
   validates :number, format: {
     with: /\A[a-z]\d{4}[a-z]{2}\z/i
@@ -19,5 +22,11 @@ class PrisonerStep
 
   def prison
     Prison.find_by(id: prison_id)
+  end
+
+private
+
+  def scrub_trailing_spaces
+    number.try(:strip!)
   end
 end

--- a/spec/models/prisoner_step_spec.rb
+++ b/spec/models/prisoner_step_spec.rb
@@ -26,4 +26,12 @@ RSpec.describe PrisonerStep do
     expect(dob).to be_kind_of(UncoercedDate)
     expect(dob.month).to eql(13)
   end
+
+  it 'does not fail if the prisoner number has extra spaces' do
+    params[:number] = 'a1234bc '
+
+    prisoner_step = described_class.new(params)
+
+    expect(prisoner_step).to be_valid
+  end
 end


### PR DESCRIPTION
Users are occassionally adding trailing spaces to otherwise valid
numbers, this causes the prisoner step to fail. I've added a pre
validation hook to the model to strip leading and trailing spaces from
the prisoner number to prevent this from happening.