### PR TITLE
Fix incorrect calculations in the weekly specs.

### DIFF
--- a/app/metrics/rejections.rb
+++ b/app/metrics/rejections.rb
@@ -20,11 +20,4 @@ module Rejections
       pluck(:prison_name, :year, :week, :reason, :percentage)
     end
   end
-
-  class RejectionPercentageByPrisonAndCalendarDate < ActiveRecord::Base
-    extend CounterSupport
-    def self.ordered_counters
-      pluck(:prison_name, :year, :month, :day, :reason, :percentage)
-    end
-  end
 end

--- a/app/views/metrics/_all_prisons.html.erb
+++ b/app/views/metrics/_all_prisons.html.erb
@@ -49,25 +49,25 @@
         <td class="narrow <%= prison.finder_slug -%>-ninety-fifth">
           <%= dataset.end_to_end_percentile(prison.name, '95th') %>
         </td>
-        <td class="narrow left-border">
+        <td class="narrow left-border <%= prison.finder_slug -%>-total-rejected">
           <%= dataset.percent_rejected(prison.name, 'total') %>
         </td>
-        <td class="narrow">
+        <td class="narrow <%= prison.finder_slug -%>-slot-unavailable">
           <%= dataset.percent_rejected(prison.name, 'slot_unavailable') %>
         </td>
-        <td class="narrow">
+        <td class="narrow <%= prison.finder_slug -%>-visitor-not-on-list">
           <%= dataset.percent_rejected(prison.name, 'visitor_not_on_list') %>
         </td>
-        <td class="narrow">
+        <td class="narrow <%= prison.finder_slug -%>-no-allowance">
           <%= dataset.percent_rejected(prison.name, 'no_allowance') %>
         </td>
-        <td class="narrow">
+        <td class="narrow <%= prison.finder_slug -%>-prisoner-moved">
           <%= dataset.percent_rejected(prison.name, 'prisoner_moved') %>
         </td>
-        <td class="narrow">
+        <td class="narrow <%= prison.finder_slug -%>-visitor-banned">
           <%= dataset.percent_rejected(prison.name, 'visitor_banned') %>
         </td>
-        <td class="narrow">
+        <td class="narrow <%= prison.finder_slug -%>-prisoner-details-incorrect">
           <%= dataset.percent_rejected(prison.name, 'prisoner_details_incorrect') %>
         </td>
       </tr>

--- a/db/migrate/20160324150553_update_rejection_percentage_by_prison_and_calendar_weeks_to_version_2.rb
+++ b/db/migrate/20160324150553_update_rejection_percentage_by_prison_and_calendar_weeks_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdateRejectionPercentageByPrisonAndCalendarWeeksToVersion2 < ActiveRecord::Migration
+  def change
+    update_view :rejection_percentage_by_prison_and_calendar_weeks, version: 2, revert_to_version: 1
+  end
+end

--- a/db/views/rejection_percentage_by_prison_and_calendar_weeks_v02.sql
+++ b/db/views/rejection_percentage_by_prison_and_calendar_weeks_v02.sql
@@ -1,0 +1,64 @@
+SELECT rejected.prison_name,
+       'total' AS reason,
+       rejected.year AS year,
+       rejected.week AS week,
+       ROUND((rejected_count::numeric / booked_count * 100),2) AS percentage
+FROM (SELECT prisons.name AS prison_name,
+             count(*) AS rejected_count,
+             extract(isoyear from visits.created_at)::integer AS year,
+             extract(week from visits.created_at)::integer AS week
+      FROM visits
+      INNER JOIN prisons ON prisons.id = visits.prison_id
+      WHERE visits.processing_state = 'rejected'
+      GROUP BY prison_name,
+             prison_id,
+               year,
+               week
+      ) rejected,
+     (SELECT prisons.name AS prison_name,
+             count(*) AS booked_count
+      FROM visits
+      INNER JOIN prisons ON prisons.id = visits.prison_id
+      GROUP BY prison_name,
+               prison_id
+      ) booked
+WHERE rejected.prison_name = booked.prison_name
+GROUP BY rejected.prison_name,
+         reason,
+         percentage,
+         year,
+         week
+UNION
+SELECT rejected.prison_name,
+       reason,
+       rejected.year AS year,
+       rejected.week AS week,
+       ROUND((rejected_count::numeric / booked_count * 100),2) AS percentage
+FROM (SELECT reason,
+             prisons.name AS prison_name,
+             count(*) AS rejected_count,
+             extract(isoyear from visits.created_at)::integer AS year,
+             extract(week from visits.created_at)::integer AS week
+      FROM visits
+      INNER JOIN prisons ON prisons.id = visits.prison_id
+      INNER JOIN rejections ON rejections.visit_id = visits.id
+      WHERE visits.processing_state = 'rejected'
+      GROUP BY prison_name,
+             prison_id,
+               reason,
+               year,
+               week
+      ) rejected,
+     (SELECT prisons.name AS prison_name,
+             count(*) AS booked_count
+      FROM visits
+      INNER JOIN prisons ON prisons.id = visits.prison_id
+      GROUP BY prison_name,
+               prison_id
+      ) booked
+WHERE rejected.prison_name = booked.prison_name
+GROUP BY rejected.prison_name,
+         reason,
+         percentage,
+         year,
+         week

--- a/spec/features/metrics_spec.rb
+++ b/spec/features/metrics_spec.rb
@@ -3,26 +3,81 @@ require_relative '../metrics/shared_examples_for_metrics'
 
 RSpec.feature 'Metrics', js: true do
   include ActiveJobHelper
-  include_examples 'create visits with dates'
 
-  before do
-    luna_visit
-    luna_visit
-    mars_visit
+  context 'overdue' do
+    include_examples 'create visits with dates'
 
-    # Shared examples are booked within the first week of February, 2106. The
-    # controller tracks one week behind the current date.
-    travel_to Time.zone.local(2016, 2, 13) do
-      visit(metrics_path(locale: 'en'))
+    before do
+      luna_visit
+      luna_visit
+      mars_visit
+
+      # Shared examples are booked within the first week of February, 2106. The
+      # controller tracks one week behind the current date.
+      travel_to Time.zone.local(2016, 2, 13) do
+        visit(metrics_path(locale: 'en'))
+      end
+    end
+
+    it 'has the correct overdue values' do
+      expect(page).to have_selector('.luna-overdue', text: 2)
+      expect(page).to have_selector('.mars-overdue', text: 1)
     end
   end
 
-  it 'has the correct overdue values' do
-    expect(page).to have_selector('.luna-overdue', text: 2)
-    expect(page).to have_selector('.mars-overdue', text: 1)
+  context 'rejections' do
+    include_examples 'create rejections with dates'
+
+    before do
+      luna_visits_with_dates
+
+      # Shared examples are booked within the first week of February, 2106. The
+      # controller tracks one week behind the current date.
+      travel_to Time.zone.local(2016, 2, 8) do
+        visit(metrics_path(locale: 'en'))
+      end
+    end
+
+    it 'has the correct rejection percentages' do
+      # These will track the spec in spec/metrics/rejections_spec.rb
+      expect(page).to have_selector('.luna-total-rejected', text: 36.36)
+      expect(page).to have_selector('.luna-no-allowance', text: 18.18)
+      expect(page).to have_selector('.luna-visitor-banned', text: 9.09)
+      expect(page).to have_selector('.luna-slot-unavailable', text: 9.09)
+    end
   end
 
   context 'end to end' do
+    include_examples 'create visits with dates'
+
+    # Not using the shared examples as they seem to be memoizing again–the
+    # processing state does not change as it should using the methods. Will
+    # investigate later.
+    let(:luna_v) {
+      create(:visit, created_at: Time.zone.local(2016, 2, 1), prison: luna)
+    }
+
+    before do
+      travel_to Time.zone.local(2016, 2, 2) do
+        luna_v.accept!
+      end
+
+      # Shared examples are booked within the first week of February, 2106. The
+      # controller tracks one week behind the current date.
+      travel_to Time.zone.local(2016, 2, 13) do
+        visit(metrics_path(locale: 'en'))
+      end
+    end
+
+    it 'has the correct overdue values' do
+      expect(page).to have_selector('.luna-ninety-fifth', text: 1.00)
+      expect(page).to have_selector('.luna-median', text: 1.00)
+    end
+  end
+
+  context 'end to end' do
+    include_examples 'create visits with dates'
+
     # Not using the shared examples as they seem to be memoizing again–the
     # processing state does not change as it should using the methods. Will
     # investigate later.

--- a/spec/metrics/rejections_spec.rb
+++ b/spec/metrics/rejections_spec.rb
@@ -51,35 +51,10 @@ RSpec.describe Rejections do
               2016 =>
               { 5 =>
                 {
-                  'no_allowance' => 25.0,
-                  'slot_unavailable' => 8.33,
-                  'visitor_banned' => 8.33,
-                  'total' => 41.67
-                }
-              }
-            }
-        }
-      end
-    end
-
-    describe Rejections::RejectionPercentageByPrisonAndCalendarDate do
-      before do
-        luna_visits_with_dates
-      end
-
-      it 'counts visits and groups by prison, year, calendar week and visit state' do
-        expect(described_class.fetch_and_format).to be ==
-          { 'Lunar Penal Colony' =>
-            {
-              2016 =>
-              { 2 =>
-                { 1 =>
-                  {
-                    'no_allowance' => 25.0,
-                    'slot_unavailable' => 8.33,
-                    'visitor_banned' => 8.33,
-                    'total' => 41.67
-                  }
+                  'no_allowance' => 18.18,
+                  'slot_unavailable' => 9.09,
+                  'visitor_banned' => 9.09,
+                  'total' => 36.36
                 }
               }
             }

--- a/spec/metrics/rejections_spec.rb
+++ b/spec/metrics/rejections_spec.rb
@@ -51,10 +51,34 @@ RSpec.describe Rejections do
               2016 =>
               { 5 =>
                 {
-                  'no_allowance' => 18.18,
-                  'slot_unavailable' => 9.09,
-                  'visitor_banned' => 9.09,
-                  'total' => 36.36
+                  'no_allowance' => 25.0,
+                  'slot_unavailable' => 8.33,
+                  'visitor_banned' => 8.33,
+                  'total' => 41.67
+                }
+              }
+            }
+        }
+      end
+    end
+
+    describe Rejections::RejectionPercentageByPrisonAndCalendarDate do
+      before do
+        luna_visits_with_dates
+      end
+
+      it 'counts visits and groups by prison, year, calendar week and visit state' do
+        expect(described_class.fetch_and_format).to be ==
+          { 'Lunar Penal Colony' =>
+            {
+              2016 =>
+              { 2 =>
+                { 1 =>
+                  {
+                    'no_allowance' => 25.0,
+                    'slot_unavailable' => 8.33,
+                    'visitor_banned' => 8.33,
+                    'total' => 41.67
                 }
               }
             }

--- a/spec/metrics/rejections_spec.rb
+++ b/spec/metrics/rejections_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe Rejections do
               2016 =>
               { 5 =>
                 {
-                  'no_allowance' => 10.0,
-                  'slot_unavailable' => 10.0,
-                  'visitor_banned' => 10.0,
-                  'total' => 30.0
+                  'no_allowance' => 25.0,
+                  'slot_unavailable' => 8.33,
+                  'visitor_banned' => 8.33,
+                  'total' => 41.67
                 }
               }
             }
@@ -75,10 +75,10 @@ RSpec.describe Rejections do
               { 2 =>
                 { 1 =>
                   {
-                    'no_allowance' => 10.0,
-                    'slot_unavailable' => 10.0,
-                    'visitor_banned' => 10.0,
-                    'total' => 30.0
+                    'no_allowance' => 25.0,
+                    'slot_unavailable' => 8.33,
+                    'visitor_banned' => 8.33,
+                    'total' => 41.67
                   }
                 }
               }

--- a/spec/metrics/rejections_spec.rb
+++ b/spec/metrics/rejections_spec.rb
@@ -51,34 +51,10 @@ RSpec.describe Rejections do
               2016 =>
               { 5 =>
                 {
-                  'no_allowance' => 25.0,
-                  'slot_unavailable' => 8.33,
-                  'visitor_banned' => 8.33,
-                  'total' => 41.67
-                }
-              }
-            }
-        }
-      end
-    end
-
-    describe Rejections::RejectionPercentageByPrisonAndCalendarDate do
-      before do
-        luna_visits_with_dates
-      end
-
-      it 'counts visits and groups by prison, year, calendar week and visit state' do
-        expect(described_class.fetch_and_format).to be ==
-          { 'Lunar Penal Colony' =>
-            {
-              2016 =>
-              { 2 =>
-                { 1 =>
-                  {
-                    'no_allowance' => 25.0,
-                    'slot_unavailable' => 8.33,
-                    'visitor_banned' => 8.33,
-                    'total' => 41.67
+                  'no_allowance' => 18.18,
+                  'slot_unavailable' => 9.09,
+                  'visitor_banned' => 9.09,
+                  'total' => 36.36
                 }
               }
             }

--- a/spec/metrics/shared_examples_for_metrics.rb
+++ b/spec/metrics/shared_examples_for_metrics.rb
@@ -36,10 +36,12 @@ RSpec.shared_examples 'create rejections with dates' do
   def make_visits(prison)
     create_list(:visit, 7, created_at: Time.zone.local(2016, 2, 1), prison: luna)
 
-    na = create(:rejected_visit, prison: prison, created_at: Time.zone.local(2016, 2, 1))
+    na = create_list(:rejected_visit, 3, prison: prison, created_at: Time.zone.local(2016, 2, 1))
     su = create(:rejected_visit, prison: prison, created_at: Time.zone.local(2016, 2, 1))
     vb = create(:rejected_visit, prison: prison, created_at: Time.zone.local(2016, 2, 1))
-    create(:rejection, visit: na, reason: 'no_allowance', created_at: Time.zone.local(2016, 2, 1))
+    na.each do |visit|
+      create(:rejection, visit: visit, reason: 'no_allowance', created_at: Time.zone.local(2016, 2, 1))
+    end
     create(:rejection, visit: su, reason: 'slot_unavailable', created_at: Time.zone.local(2016, 2, 1))
     create(:rejection, visit: vb, reason: 'visitor_banned', created_at: Time.zone.local(2016, 2, 1))
   end

--- a/spec/metrics/shared_examples_for_metrics.rb
+++ b/spec/metrics/shared_examples_for_metrics.rb
@@ -22,28 +22,30 @@ RSpec.shared_examples 'create rejections without dates' do
 end
 
 RSpec.shared_examples 'create rejections with dates' do
-  let(:luna) { create(:prison, name: 'Lunar Penal Colony') }
-  let(:mars) { create(:prison, name: 'Martian Penal Colony') }
+  let(:luna_estate) { create(:estate, finder_slug: 'luna') }
+  let(:mars_estate) { create(:estate, finder_slug: 'mars') }
+  let(:luna) { create(:prison, name: 'Lunar Penal Colony', estate: luna_estate) }
+  let(:mars) { create(:prison, name: 'Martian Penal Colony', estate: mars_estate) }
 
-  let(:luna_visits_with_dates) do
+  def luna_visits_with_dates
     make_visits(luna)
   end
 
-  let(:mars_visits_with_dates) do
+  def mars_visits_with_dates
     make_visits(mars)
   end
 
   def make_visits(prison)
-    create_list(:visit, 7, created_at: Time.zone.local(2016, 2, 1), prison: luna)
+    create_list(:booked_visit, 7, created_at: Time.zone.local(2016, 2, 1), prison: luna)
 
-    na = create_list(:rejected_visit, 3, prison: prison, created_at: Time.zone.local(2016, 2, 1))
-    su = create(:rejected_visit, prison: prison, created_at: Time.zone.local(2016, 2, 1))
-    vb = create(:rejected_visit, prison: prison, created_at: Time.zone.local(2016, 2, 1))
-    na.each do |visit|
-      create(:rejection, visit: visit, reason: 'no_allowance', created_at: Time.zone.local(2016, 2, 1))
-    end
-    create(:rejection, visit: su, reason: 'slot_unavailable', created_at: Time.zone.local(2016, 2, 1))
-    create(:rejection, visit: vb, reason: 'visitor_banned', created_at: Time.zone.local(2016, 2, 1))
+    nc = create(:rejected_visit, prison: prison, created_at: Time.zone.local(2016, 2, 1))
+    na = create(:rejected_visit, prison: prison, created_at: Time.zone.local(2016, 2, 2))
+    su = create(:rejected_visit, prison: prison, created_at: Time.zone.local(2016, 2, 3))
+    vb = create(:rejected_visit, prison: prison, created_at: Time.zone.local(2016, 2, 4))
+    create(:rejection, visit: nc, created_at: Time.zone.local(2016, 2, 1))
+    create(:rejection, visit: na, created_at: Time.zone.local(2016, 2, 2))
+    create(:rejection, visit: su, reason: 'slot_unavailable', created_at: Time.zone.local(2016, 2, 3))
+    create(:rejection, visit: vb, reason: 'visitor_banned', created_at: Time.zone.local(2016, 2, 4))
   end
 end
 


### PR DESCRIPTION
Ensure weekly rejection percentages are correct

Previously, the SQL used for the calculations would report the same
percentage for every type of rejection including the total. This was
because the date selection logic was in the wrong place.

This also removes the class and the specs for rejections done by
calendar date.  This was not being used anywhere and required additional
tuning to avoid the same problems.  If it is required, we can revisit
the SQL and migrations at a later date.