### PR TITLE
'/status/:id' to catch pvb1 email url

### DIFF
--- a/app/controllers/pvb1_paths_controller.rb
+++ b/app/controllers/pvb1_paths_controller.rb
@@ -1,0 +1,8 @@
+class Pvb1PathsController < ApplicationController
+  # This path was followed by pvb1 users from their emails and it showed
+  # information about a visit.
+  # Can be removed when we stop getting traffic
+  def status
+    render :status, status: :not_found
+  end
+end

--- a/app/views/pvb1_paths/status.html.erb
+++ b/app/views/pvb1_paths/status.html.erb
@@ -1,0 +1,11 @@
+<% content_for :header, t('.title') %>
+
+<div class='Grid'>
+  <div class='Grid-2-3'>
+    <article>
+      <%= markdown t('.body_md', {
+            new_booking_url: booking_requests_path,
+            prison_finder_url: link_directory.prison_finder}) %>
+    </article>
+  </div>
+</div>

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -1,4 +1,14 @@
 en:
+  pvb1_paths:
+    status:
+      title: Visit expired
+      body_md: |
+        This visit has expired and its information has been removed.
+
+        You can
+        [start a new prison visit request](%{new_booking_url})
+        or book your visit by phone instead. See the
+        [prison finder](%{prison_finder_url}) for contact details.
   errors:
     "404":
       title: This page cannot be found

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
     get 'healthcheck', to: 'healthcheck#index'
   end
 
+  # Old pvb1 link that users got in an email
+  get 'status/:id', controller: :pvb1_paths, action: :status, as: :pvb1_status
+
   scope '/:locale', locale: /[a-z]{2}/ do
     get '/', to: redirect('/%{locale}/request')
 

--- a/spec/controllers/pvb1_paths_controller_spec.rb
+++ b/spec/controllers/pvb1_paths_controller_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Pvb1PathsController, type: :controller do
+  describe "#status" do
+    subject { get :status, id: 'old-id' }
+
+    it { is_expected.to be_not_found }
+  end
+end

--- a/spec/features/pvb1_spec.rb
+++ b/spec/features/pvb1_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.feature 'PVB1 old links', js: true do
+  it 'renders an appropiate message' do
+    visit(pvb1_status_path(id: 'old-id'))
+
+    expect(page).to have_text('Visit expired')
+  end
+end


### PR DESCRIPTION
Implements the pvb1 path that it is still being used. Users got a link on their
email in pvb1 that took them to a page with information about a visit.

It renders a page similar to the not found page but with a message that is more
helpful than just page not found.

Ommited the Welsh translation since it shoud always default to the english
locale.