### PR TITLE
Change enabled to a scope and eager load estate

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -10,6 +10,7 @@ class MetricsController < ApplicationController
       metrics_counts = weekly_counts(@start_date)
     end
 
+    @prisons = Prison.enabled.includes(:estate)
     @dataset = MetricsPresenter.new(metrics_counts)
   end
 

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -18,9 +18,9 @@ class Prison < ActiveRecord::Base
     to: :parsed_slot_details
   delegate :finder_slug, to: :estate
 
-  def self.enabled
+  scope :enabled, lambda {
     where(enabled: true).order(name: :asc)
-  end
+  }
 
   def available_slots(today = Time.zone.today)
     AvailableSlotEnumerator.new(

--- a/app/views/metrics/_all_prisons.html.erb
+++ b/app/views/metrics/_all_prisons.html.erb
@@ -23,7 +23,7 @@
       <td>Visitor banned</td>
       <td>Prisoner details incorrect</td>
     </tr>
-    <% Prison.enabled.each do |prison| %>
+    <% @prisons.each do |prison| %>
       <tr class="<%= cycle('odd', 'even') %>">
         <td class="prison-name">
           <%= link_to(prison.name, prison_metrics_summary_path(prison)) %>


### PR DESCRIPTION
I noticed an n+1 query in the metrics when Prison was loading Estate.
The class method `enabled` seemed better expressed as a scope and I
added eager loading of Estate.