### PR TITLE
Display 95th and median end to end processing times

### DIFF
--- a/app/metrics/prison_summary_metrics_presenter.rb
+++ b/app/metrics/prison_summary_metrics_presenter.rb
@@ -1,12 +1,4 @@
 class PrisonSummaryMetricsPresenter
-  PERCENTILES_INDEX = {
-    '99th' => 0,
-    '95th' => 1,
-    '90th' => 2,
-    '75th' => 3,
-    '50th' => 4,
-    '25th' => 5
-  }
   def initialize(counts: nil,
     timings: nil,
     percentiles: nil,
@@ -31,8 +23,8 @@ class PrisonSummaryMetricsPresenter
   def end_to_end_percentile(percentile)
     return 0 unless @percentiles
 
-    index = PERCENTILES_INDEX.fetch(percentile)
-    seconds = @percentiles[index]
+    key = percentile[/\d+/].to_i
+    seconds = @percentiles[key]
 
     sprintf('%2.2f', seconds.to_f / 1.day)
   end

--- a/app/views/metrics/_all_prisons.html.erb
+++ b/app/views/metrics/_all_prisons.html.erb
@@ -43,10 +43,10 @@
         <td class="narrow">
           <%= dataset.visits_in_state(prison.name, 'booked') %>
         </td>
-        <td class="left-border">
+        <td class="left-border <%= prison.finder_slug -%>-median">
           <%= dataset.end_to_end_percentile(prison.name, '50th') %>
         </td>
-        <td class="narrow">
+        <td class="narrow <%= prison.finder_slug -%>-ninety-fifth">
           <%= dataset.end_to_end_percentile(prison.name, '95th') %>
         </td>
         <td class="narrow left-border">

--- a/spec/features/metrics_spec.rb
+++ b/spec/features/metrics_spec.rb
@@ -21,4 +21,30 @@ RSpec.feature 'Metrics', js: true do
     expect(page).to have_selector('.luna-overdue', text: 2)
     expect(page).to have_selector('.mars-overdue', text: 1)
   end
+
+  context 'end to end' do
+    # Not using the shared examples as they seem to be memoizing again–the
+    # processing state does not change as it should using the methods. Will
+    # investigate later.
+    let(:luna_v) {
+      create(:visit, created_at: Time.zone.local(2016, 2, 1), prison: luna)
+    }
+
+    before do
+      travel_to Time.zone.local(2016, 2, 2) do
+        luna_v.accept!
+      end
+
+      # Shared examples are booked within the first week of February, 2106. The
+      # controller tracks one week behind the current date.
+      travel_to Time.zone.local(2016, 2, 13) do
+        visit(metrics_path(locale: 'en'))
+      end
+    end
+
+    it 'has the correct overdue values' do
+      expect(page).to have_selector('.luna-ninety-fifth', text: 1.00)
+      expect(page).to have_selector('.luna-median', text: 1.00)
+    end
+  end
 end

--- a/spec/metrics/prison_summary_metrics_presenter_spec.rb
+++ b/spec/metrics/prison_summary_metrics_presenter_spec.rb
@@ -159,42 +159,42 @@ RSpec.describe PrisonSummaryMetricsPresenter do
 
     context 'with percentiles' do
       let(:percentiles) do
-        [99.days.to_i,
-         95.days.to_i,
-         90.days.to_i,
-         75.days.to_i,
-         50.days.to_i,
-         25.days.to_i]
+        { 99 => 518_400,
+          95 => 432_000,
+          90 => 345_600,
+          75 => 259_200,
+          50 => 172_800,
+          25 => 86_400 }
       end
 
       context '99th percentile' do
         let(:percentile) { '99th' }
-        it { is_expected.to eq('99.00') }
+        it { is_expected.to eq('6.00') }
       end
 
       context '95th percentile' do
         let(:percentile) { '95th' }
-        it { is_expected.to eq('95.00') }
+        it { is_expected.to eq('5.00') }
       end
 
       context '90th percentile' do
         let(:percentile) { '90th' }
-        it { is_expected.to eq('90.00') }
+        it { is_expected.to eq('4.00') }
       end
 
       context '75th percentile' do
         let(:percentile) { '75th' }
-        it { is_expected.to eq('75.00') }
+        it { is_expected.to eq('3.00') }
       end
 
       context '50th percentile' do
         let(:percentile) { '50th' }
-        it { is_expected.to eq('50.00') }
+        it { is_expected.to eq('2.00') }
       end
 
       context '25th percentile' do
         let(:percentile) { '25th' }
-        it { is_expected.to eq('25.00') }
+        it { is_expected.to eq('1.00') }
       end
     end
   end


### PR DESCRIPTION
The method called on the view model had changed to `fetch_and_format`,
which returns a hash. However, the presenter was still expecting an
array, which was what `ordered_counters` returned.  As a result, no
values were being found.