### PR TITLE
Prisoner validation api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,5 +60,6 @@ group :test do
   gem 'poltergeist'
   gem 'simplecov'
   gem 'simplecov-rcov'
+  gem 'vcr'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -299,6 +299,7 @@ GEM
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     uri_template (0.6.0)
+    vcr (3.0.1)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -369,6 +370,7 @@ DEPENDENCIES
   string_scrubber
   uglifier (>= 1.3.0)
   uri_template
+  vcr
   virtus
   webmock
   zendesk_api

--- a/app/controllers/api.rb
+++ b/app/controllers/api.rb
@@ -1,0 +1,1 @@
+module Api; end

--- a/app/controllers/api/validations_controller.rb
+++ b/app/controllers/api/validations_controller.rb
@@ -4,14 +4,16 @@ module Api
       valid = true
       errors = []
 
-      offender = Nomis::Api.instance.lookup_active_offender(
-        noms_id: params.fetch(:number),
-        date_of_birth: Date.parse(params.fetch(:date_of_birth))
-      )
+      if Nomis::Api.enabled?
+        offender = Nomis::Api.instance.lookup_active_offender(
+          noms_id: params.fetch(:number),
+          date_of_birth: Date.parse(params.fetch(:date_of_birth))
+        )
 
-      unless offender
-        valid = false
-        errors << 'prisoner_does_not_exist'
+        unless offender
+          valid = false
+          errors << 'prisoner_does_not_exist'
+        end
       end
 
       validation = { valid: valid }

--- a/app/controllers/api/validations_controller.rb
+++ b/app/controllers/api/validations_controller.rb
@@ -5,14 +5,18 @@ module Api
       errors = []
 
       if Nomis::Api.enabled?
-        offender = Nomis::Api.instance.lookup_active_offender(
-          noms_id: params.fetch(:number),
-          date_of_birth: Date.parse(params.fetch(:date_of_birth))
-        )
+        begin
+          offender = Nomis::Api.instance.lookup_active_offender(
+            noms_id: params.fetch(:number),
+            date_of_birth: Date.parse(params.fetch(:date_of_birth))
+          )
 
-        unless offender
-          valid = false
-          errors << 'prisoner_does_not_exist'
+          unless offender
+            valid = false
+            errors << 'prisoner_does_not_exist'
+          end
+        rescue Excon::Errors::Error => e
+          Rails.logger.warn "Error calling the nomis API: #{e.inspect}"
         end
       end
 

--- a/app/controllers/api/validations_controller.rb
+++ b/app/controllers/api/validations_controller.rb
@@ -1,0 +1,23 @@
+module Api
+  class ValidationsController < ApiController
+    def prisoner
+      valid = true
+      errors = []
+
+      offender = Nomis::Api.instance.lookup_active_offender(
+        noms_id: params.fetch(:number),
+        date_of_birth: Date.parse(params.fetch(:date_of_birth))
+      )
+
+      unless offender
+        valid = false
+        errors << 'prisoner_does_not_exist'
+      end
+
+      validation = { valid: valid }
+      validation[:errors] = errors if errors.any?
+
+      render status: 200, json: { validation: validation }
+    end
+  end
+end

--- a/app/models/prisoner_validation.rb
+++ b/app/models/prisoner_validation.rb
@@ -1,0 +1,25 @@
+class PrisonerValidation
+  include NonPersistedModel
+
+  attribute :noms_id, String
+  attribute :date_of_birth, Date
+
+  validate :active_offender_exists
+
+  def active_offender_exists
+    # Validation should pass if the Nomis API has been disabled
+    return unless Nomis::Api.enabled?
+
+    offender = Nomis::Api.instance.lookup_active_offender(
+      noms_id: noms_id,
+      date_of_birth: date_of_birth
+    )
+
+    unless offender
+      errors.add :general, 'prisoner_does_not_exist'
+    end
+  rescue Excon::Errors::Error => e
+    # Validation should pass if the Nomis API is misbehaving
+    Rails.logger.warn "Error calling the nomis API: #{e.inspect}"
+  end
+end

--- a/app/services/nomis/api.rb
+++ b/app/services/nomis/api.rb
@@ -29,8 +29,8 @@ module Nomis
         noms_id: noms_id,
         date_of_birth: date_of_birth
       )
-      return nil unless response['found'] == 'true'
-      Offender.new(id: response['offender_id'])
+      return nil unless response['found'] == true
+      Offender.new(response['offender'])
     end
   end
 end

--- a/app/services/nomis/api.rb
+++ b/app/services/nomis/api.rb
@@ -1,7 +1,17 @@
 module Nomis
+  DisabledError = Class.new(StandardError)
+
   class Api
     class << self
+      def enabled?
+        Rails.configuration.nomis_api_host != nil
+      end
+
       def instance
+        unless enabled?
+          fail DisabledError, 'Nomis API is disabled'
+        end
+
         @instance ||= begin
           client = Nomis::Client.new(Rails.configuration.nomis_api_host)
           new(client)

--- a/app/services/nomis/api.rb
+++ b/app/services/nomis/api.rb
@@ -1,0 +1,26 @@
+module Nomis
+  class Api
+    class << self
+      def instance
+        @instance ||= begin
+          client = Nomis::Client.new(Rails.configuration.nomis_api_host)
+          new(client)
+        end
+      end
+    end
+
+    def initialize(client)
+      @client = client
+    end
+
+    def lookup_active_offender(noms_id:, date_of_birth:)
+      response = @client.get(
+        '/lookup/active_offender',
+        noms_id: noms_id,
+        date_of_birth: date_of_birth
+      )
+      return nil unless response['found'] == 'true'
+      Offender.new(id: response['offender_id'])
+    end
+  end
+end

--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -11,9 +11,9 @@ module Nomis
       request(:get, route, params)
     end
 
-    def post(route, params)
-      request(:post, route, params)
-    end
+  # def post(route, params)
+  #   request(:post, route, params)
+  # end
 
   private
 
@@ -48,11 +48,11 @@ module Nomis
 
       if method == :get || method == :delete
         { query: params }
-      else
-        {
-          body: params.to_json,
-          headers: { 'Content-Type' => 'application/json' }
-        }
+        # else
+        #   {
+        #     body: params.to_json,
+        #     headers: { 'Content-Type' => 'application/json' }
+        #   }
       end
     end
   end

--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -1,0 +1,59 @@
+require 'excon'
+
+module Nomis
+  class Client
+    def initialize(host)
+      @host = host
+      @connection = Excon.new(host, persistent: true)
+    end
+
+    def get(route, params = {})
+      request(:get, route, params)
+    end
+
+    def post(route, params)
+      request(:post, route, params)
+    end
+
+  private
+
+    # rubocop:disable Metrics/MethodLength
+    def request(method, route, params)
+      # For cleanliness, strip initial / if supplied
+      route = route.sub(%r{^\/}, '')
+      path = "/nomisapi/#{route}"
+
+      options = {
+        method: method,
+        path: path,
+        expects: [200],
+        headers: {
+          'Accept' => 'application/json'
+        }
+      }.deep_merge(params_options(method, params))
+
+      Rails.logger.info do
+        "Calling NOMIS API: #{method.to_s.upcase} #{path}"
+      end
+
+      response = @connection.request(options)
+
+      JSON.parse(response.body)
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    # Returns excon options which put params in either the query string or body.
+    def params_options(method, params)
+      return {} if params.empty?
+
+      if method == :get || method == :delete
+        { query: params }
+      else
+        {
+          body: params.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        }
+      end
+    end
+  end
+end

--- a/app/services/nomis/offender.rb
+++ b/app/services/nomis/offender.rb
@@ -1,0 +1,7 @@
+module Nomis
+  class Offender
+    include NonPersistedModel
+
+    attribute :id
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -70,5 +70,7 @@ module PrisonVisits
       !ENV.key?('ENABLE_SENDGRID_VALIDATIONS') &&
       !ENV.key?('SMTP_USERNAME') &&
       !ENV.key?('SMTP_PASSWORD')
+
+    config.nomis_api_host = ENV.fetch('NOMIS_API_HOST')
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -71,6 +71,6 @@ module PrisonVisits
       !ENV.key?('SMTP_USERNAME') &&
       !ENV.key?('SMTP_PASSWORD')
 
-    config.nomis_api_host = ENV.fetch('NOMIS_API_HOST')
+    config.nomis_api_host = ENV.fetch('NOMIS_API_HOST', nil)
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,4 +20,7 @@ Rails.application.configure do
 
   config.i18n.load_path =
     Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
+
+  config.nomis_api_host = ENV.fetch('NOMIS_API_HOST',
+    'http://172.22.16.2:8080/')
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -19,4 +19,7 @@ Rails.application.configure do
 
   config.i18n.load_path =
     Dir[Rails.root.join('config', 'locales', '**', '*.yml').to_s]
+
+  config.nomis_api_host = ENV.fetch('NOMIS_API_HOST',
+    'http://172.22.16.2:8080/')
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,5 +49,6 @@ Rails.application.routes.draw do
     resources :prisons, only: %i[ index show ]
     resources :slots, only: %i[ index ]
     resources :visits, only: %i[ create show destroy ]
+    post '/validations/prisoner', to: 'validations#prisoner'
   end
 end

--- a/spec/controllers/api/validations_controller_spec.rb
+++ b/spec/controllers/api/validations_controller_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe Api::ValidationsController do
     JSON.parse(response.body)
   }
 
+  before do
+    allow(Nomis::Api).to receive(:enabled?).and_return(true)
+    allow(Nomis::Api).to receive(:instance).and_return(instance_double(Nomis::Api))
+  end
+
   describe 'prisoner' do
     let(:params) {
       {
@@ -42,6 +47,13 @@ RSpec.describe Api::ValidationsController do
         'valid' => false,
         'errors' => ['prisoner_does_not_exist']
       )
+    end
+
+    it 'returns valid if the NOMIS API is disabled' do
+      expect(Nomis::Api).to receive(:enabled?).and_return(false)
+      expect(Nomis::Api.instance).not_to receive(:lookup_active_offender)
+      post :prisoner, params
+      expect(parsed_body['validation']['valid']).to eq(true)
     end
   end
 end

--- a/spec/controllers/api/validations_controller_spec.rb
+++ b/spec/controllers/api/validations_controller_spec.rb
@@ -55,5 +55,15 @@ RSpec.describe Api::ValidationsController do
       post :prisoner, params
       expect(parsed_body['validation']['valid']).to eq(true)
     end
+
+    it 'returns valid if the NOMIS API cannot be contacted' do
+      allow(Nomis::Api.instance).to receive(:lookup_active_offender).
+        and_raise(Excon::Errors::Error, 'Something broke')
+      expect(Rails.logger).to receive(:warn).with(
+        'Error calling the nomis API: #<Excon::Errors::Error: Something broke>'
+      )
+      post :prisoner, params
+      expect(parsed_body['validation']['valid']).to eq(true)
+    end
   end
 end

--- a/spec/controllers/api/validations_controller_spec.rb
+++ b/spec/controllers/api/validations_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe Api::ValidationsController do
+  render_views
+
+  let(:parsed_body) {
+    JSON.parse(response.body)
+  }
+
+  describe 'prisoner' do
+    let(:params) {
+      {
+        format: :json,
+        first_name: 'Joe',
+        last_name: 'Bloggs',
+        date_of_birth: '1980-01-01',
+        number: 'A1234BC'
+      }
+    }
+
+    let(:offender) {
+      instance_double(Nomis::Offender, id: 123)
+    }
+
+    before do
+      allow(Nomis::Api.instance).to receive(:lookup_active_offender).
+        and_return(offender)
+    end
+
+    it 'returns valid if the prisoner exists and can be visisted' do
+      expect(Nomis::Api.instance).to receive(:lookup_active_offender).
+        and_return(offender)
+      post :prisoner, params
+      expect(parsed_body['validation']).to eq('valid' => true)
+    end
+
+    it 'returns a validation error if the prisoner does not exist' do
+      expect(Nomis::Api.instance).to receive(:lookup_active_offender).
+        and_return(nil)
+      post :prisoner, params
+      expect(parsed_body['validation']).to eq(
+        'valid' => false,
+        'errors' => ['prisoner_does_not_exist']
+      )
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/lookup_active_offender-nomatch.yml
+++ b/spec/fixtures/vcr_cassettes/lookup_active_offender-nomatch.yml
@@ -1,0 +1,30 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://172.22.16.2:8080/nomisapi/lookup/active_offender?date_of_birth=1976-06-12&noms_id=Z9999ZZ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.47.0
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 29 Mar 2016 14:49:29 GMT
+    body:
+      encoding: UTF-8
+      string: '{"found":false}'
+    http_version:
+  recorded_at: Tue, 29 Mar 2016 14:49:54 GMT
+recorded_with: VCR 3.0.1

--- a/spec/fixtures/vcr_cassettes/lookup_active_offender.yml
+++ b/spec/fixtures/vcr_cassettes/lookup_active_offender.yml
@@ -1,0 +1,30 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://172.22.16.2:8080/nomisapi/lookup/active_offender?date_of_birth=1976-06-12&noms_id=A1459AE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.47.0
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 29 Mar 2016 14:40:19 GMT
+    body:
+      encoding: UTF-8
+      string: '{"found":true,"offender":{"id":1055827}}'
+    http_version:
+  recorded_at: Tue, 29 Mar 2016 14:40:45 GMT
+recorded_with: VCR 3.0.1

--- a/spec/services/nomis/api_spec.rb
+++ b/spec/services/nomis/api_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Nomis::Api do
+  subject { described_class.instance }
+
+  describe 'lookup_active_offender', vcr: { cassette_name: 'lookup_active_offender' } do
+    let(:params) {
+      {
+        noms_id: 'A1459AE',
+        date_of_birth: Date.parse('1976-06-12')
+      }
+    }
+
+    subject { super().lookup_active_offender(params) }
+
+    it 'returns and offender if the data matches' do
+      expect(subject).to be_kind_of(Nomis::Offender)
+      expect(subject.id).to eq(1_055_827)
+    end
+
+    it 'returns nil if the data does not match', vcr: { cassette_name: 'lookup_active_offender-nomatch' } do
+      params[:noms_id] = 'Z9999ZZ'
+      expect(subject).to be_nil
+    end
+  end
+end

--- a/spec/services/nomis/api_spec.rb
+++ b/spec/services/nomis/api_spec.rb
@@ -3,6 +3,21 @@ require 'rails_helper'
 RSpec.describe Nomis::Api do
   subject { described_class.instance }
 
+  it 'is implicitly enabled if the api host is configured' do
+    expect(Rails.configuration).to receive(:nomis_api_host).and_return(nil)
+    expect(described_class.enabled?).to be false
+
+    expect(Rails.configuration).to receive(:nomis_api_host).and_return('http://example.com/')
+    expect(described_class.enabled?).to be true
+  end
+
+  it 'fails if code attempts to use the client when disabled' do
+    expect(described_class).to receive(:enabled?).and_return(false)
+    expect {
+      described_class.instance
+    }.to raise_error(Nomis::DisabledError, 'Nomis API is disabled')
+  end
+
   describe 'lookup_active_offender', vcr: { cassette_name: 'lookup_active_offender' } do
     let(:params) {
       {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,3 +55,16 @@ RSpec.configure do |config|
   config.order = :random
   Kernel.srand config.seed
 end
+
+require 'vcr'
+
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
+  config.hook_into :webmock
+  config.configure_rspec_metadata!
+
+  config.ignore_request do |request|
+    # Ignore capybara requests within feature tests
+    request.uri =~ /__identify__/
+  end
+end


### PR DESCRIPTION
This is used by prison-visits-public when validating the prisoner step.

Note: It is intended that this validation is not used by this app's public facing pages, which are destined for removal.