### PR TITLE
Strong parameters in booking requests controller

### DIFF
--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -2,7 +2,7 @@ class BookingRequestsController < ApplicationController
   helper FormElementsHelper
 
   def index
-    processor = StepsProcessor.new(params, I18n.locale)
+    processor = StepsProcessor.new(steps_params, I18n.locale)
     @steps = processor.steps
     @step_name = processor.step_name
     append_to_log booking_step_rendered: processor.step_name
@@ -10,7 +10,7 @@ class BookingRequestsController < ApplicationController
   end
 
   def create
-    processor = StepsProcessor.new(params, I18n.locale)
+    processor = StepsProcessor.new(steps_params, I18n.locale)
     @visit = processor.execute!
     @steps = processor.steps
     @step_name = processor.step_name
@@ -20,6 +20,62 @@ class BookingRequestsController < ApplicationController
   end
 
 private
+
+  # It is not straight forward to whitelist parameters because the
+  # 'date_of_birth' values can be a String or a Hash depending on the step.
+  def steps_params
+    permitted_fields = permit_prisoner_step +
+                       permit_visitors_step +
+                       permit_slots_step +
+                       permit_review_step +
+                       permit_confirmation_step
+
+    params.permit(permitted_fields)
+  end
+
+  def permit_prisoner_step
+    prisoner_step_attrs = params.fetch(:prisoner_step, {})
+
+    person_attrs = permitted_person_attrs(prisoner_step_attrs)
+    [prisoner_step:  person_attrs + [:number, :prison_id]]
+  end
+
+  def permit_visitors_step
+    visitors_step = params.fetch(:visitors_step, {})
+    # Any visitor would do here as all the visitors use the same type for their
+    # date of birth.
+    first_visitor = visitors_step.fetch(:visitors_attributes, {}).fetch('0', {})
+    [visitors_step: [
+      :email_address,
+      :phone_no,
+      :additional_visitor_count,
+      :override_delivery_error,
+      :delivery_error_type,
+      visitors_attributes: permitted_person_attrs(first_visitor)]
+    ]
+  end
+
+  def permit_slots_step
+    [slots_step: [:option_0, :option_1, :option_2]]
+  end
+
+  def permit_review_step
+    [:review_step]
+  end
+
+  def permit_confirmation_step
+    [confirmation_step: [:confirmed]]
+  end
+
+  def permitted_person_attrs(hash = {})
+    person_attrs = [:first_name, :last_name]
+
+    if hash[:date_of_birth].is_a?(String)
+      person_attrs + [:date_of_birth]
+    else
+      person_attrs + [date_of_birth: [:year, :month, :day]]
+    end
+  end
 
   def prison
     @steps.fetch(:prisoner_step).prison

--- a/spec/controllers/booking_requests_controller_spec.rb
+++ b/spec/controllers/booking_requests_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe BookingRequestsController do
       email_address: 'ada@test.example.com',
       phone_no: '01154960222',
       visitors_attributes: {
-        0 => {
+        '0' => {
           first_name: 'Ada',
           last_name: 'Lovelace',
           date_of_birth: {
@@ -73,6 +73,22 @@ RSpec.describe BookingRequestsController do
     it 'renders the prisoner template' do
       expect(response).to render_template('prisoner_step')
     end
+  end
+
+  context 'passing a hash as the prison_id' do
+    before do
+      allow(Prison).to receive(:find_by).and_call_original
+    end
+
+    subject do
+      lambda {
+        post :create,
+          prisoner_step: { prison_id: { admin: true } },
+          locale: 'en'
+      }
+    end
+
+    it { is_expected.to_not raise_error }
   end
 
   context 'after submitting prisoner details' do


### PR DESCRIPTION
To prevent the use of hashes in params values where a string is expected.
This is to prevent params modifying DB queries because of how find_by works
when used with hashes.