### PR TITLE
Intersect returned slots with prisoner availability from Nomis

### DIFF
--- a/app/controllers/api/slots_controller.rb
+++ b/app/controllers/api/slots_controller.rb
@@ -1,8 +1,15 @@
 module Api
   class SlotsController < ApiController
     def index
-      prison = Prison.enabled.find(params[:prison_id])
-      @slots = prison.available_slots
+      prison = Prison.enabled.find(params.fetch(:prison_id))
+
+      slot_availability = SlotAvailability.new(prison: prison)
+      slot_availability.restrict_by_prisoner(
+        prisoner_number: params.fetch(:prisoner_number),
+        prisoner_dob: Date.parse(params.fetch(:prisoner_dob))
+      )
+
+      @slots = slot_availability.slots
     end
   end
 end

--- a/app/models/prisoner_validation.rb
+++ b/app/models/prisoner_validation.rb
@@ -20,6 +20,6 @@ class PrisonerValidation
     end
   rescue Excon::Errors::Error => e
     # Validation should pass if the Nomis API is misbehaving
-    Rails.logger.warn "Error calling the nomis API: #{e.inspect}"
+    Rails.logger.warn "Error calling the NOMIS API: #{e.inspect}"
   end
 end

--- a/app/models/slot_availability.rb
+++ b/app/models/slot_availability.rb
@@ -7,6 +7,7 @@ class SlotAvailability
   end
 
   # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
   def restrict_by_prisoner(prisoner_number:, prisoner_dob:)
     # Skip restriction if Nomis api is not enabled
     return unless Nomis::Api.enabled?
@@ -26,6 +27,10 @@ class SlotAvailability
     @slots = @slots.select { |slot|
       slot.to_date.in? offender_available_dates
     }
+  rescue Excon::Errors::Error => e
+    # Skip restriction if NOMIS API is misbehaving
+    Rails.logger.warn "Error calling the NOMIS API: #{e.inspect}"
   end
   # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
 end

--- a/app/models/slot_availability.rb
+++ b/app/models/slot_availability.rb
@@ -8,6 +8,9 @@ class SlotAvailability
 
   # rubocop:disable Metrics/MethodLength
   def restrict_by_prisoner(prisoner_number:, prisoner_dob:)
+    # Skip restriction if Nomis api is not enabled
+    return unless Nomis::Api.enabled?
+
     offender = Nomis::Api.instance.lookup_active_offender(
       noms_id: prisoner_number,
       date_of_birth: prisoner_dob

--- a/app/models/slot_availability.rb
+++ b/app/models/slot_availability.rb
@@ -1,0 +1,28 @@
+class SlotAvailability
+  attr_reader :slots
+
+  def initialize(prison:)
+    @prison = prison
+    @slots = prison.available_slots.to_a
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  def restrict_by_prisoner(prisoner_number:, prisoner_dob:)
+    offender = Nomis::Api.instance.lookup_active_offender(
+      noms_id: prisoner_number,
+      date_of_birth: prisoner_dob
+    )
+
+    availability = Nomis::Api.instance.offender_visiting_availability(
+      offender_id: offender.id,
+      start_date: @prison.first_bookable_date,
+      end_date: @prison.last_bookable_date
+    )
+    offender_available_dates = availability.dates
+
+    @slots = @slots.select { |slot|
+      slot.to_date.in? offender_available_dates
+    }
+  end
+  # rubocop:enable Metrics/MethodLength
+end

--- a/app/services/nomis/api.rb
+++ b/app/services/nomis/api.rb
@@ -32,5 +32,22 @@ module Nomis
       return nil unless response['found'] == true
       Offender.new(response['offender'])
     end
+
+    # rubocop:disable Metrics/MethodLength
+    def offender_visiting_availability(offender_id:, start_date:, end_date:)
+      response = @client.get(
+        "/offenders/#{offender_id}/visiting_availability",
+        offender_id: offender_id,
+        start_date: start_date,
+        end_date: end_date
+      )
+      if response.fetch('available')
+        dates = response.fetch('dates').map(&:to_date)
+        return PrisonerAvailability.new(dates: dates)
+      else
+        return PrisonerAvailability.new(dates: [])
+      end
+    end
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/app/services/nomis/prisoner_availability.rb
+++ b/app/services/nomis/prisoner_availability.rb
@@ -1,0 +1,7 @@
+module Nomis
+  class PrisonerAvailability
+    include NonPersistedModel
+
+    attribute :dates, Array
+  end
+end

--- a/spec/controllers/api/validations_controller_spec.rb
+++ b/spec/controllers/api/validations_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Api::ValidationsController do
       allow(Nomis::Api.instance).to receive(:lookup_active_offender).
         and_raise(Excon::Errors::Error, 'Something broke')
       expect(Rails.logger).to receive(:warn).with(
-        'Error calling the nomis API: #<Excon::Errors::Error: Something broke>'
+        'Error calling the NOMIS API: #<Excon::Errors::Error: Something broke>'
       )
       post :prisoner, params
       expect(parsed_body['validation']['valid']).to eq(true)

--- a/spec/fixtures/vcr_cassettes/offender_visiting_availability-noavailability.yml
+++ b/spec/fixtures/vcr_cassettes/offender_visiting_availability-noavailability.yml
@@ -1,0 +1,30 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://172.22.16.2:8080/nomisapi/offenders/1055847/visiting_availability?end_date=2016-04-21&offender_id=1055847&start_date=2016-04-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.47.0
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 30 Mar 2016 12:03:05 GMT
+    body:
+      encoding: UTF-8
+      string: '{"available":false}'
+    http_version:
+  recorded_at: Wed, 30 Mar 2016 12:03:05 GMT
+recorded_with: VCR 3.0.1

--- a/spec/fixtures/vcr_cassettes/offender_visiting_availability.yml
+++ b/spec/fixtures/vcr_cassettes/offender_visiting_availability.yml
@@ -1,0 +1,30 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://172.22.16.2:8080/nomisapi/offenders/1055827/visiting_availability?end_date=2016-04-21&offender_id=1055827&start_date=2016-04-01
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.47.0
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 30 Mar 2016 11:59:39 GMT
+    body:
+      encoding: UTF-8
+      string: '{"available":true,"dates":["2016-04-01","2016-04-02","2016-04-03","2016-04-04","2016-04-05","2016-04-06","2016-04-07","2016-04-09"]}'
+    http_version:
+  recorded_at: Wed, 30 Mar 2016 11:59:39 GMT
+recorded_with: VCR 3.0.1

--- a/spec/models/slot_availability_spec.rb
+++ b/spec/models/slot_availability_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe SlotAvailability, type: :model do
+  subject { described_class.new(prison: prison) }
+
+  let!(:prison) { create(:prison) }
+
+  let(:default_prison_slots) {
+    [
+      "2016-04-11T14:00/16:10",
+      "2016-04-12T09:00/10:00",
+      "2016-04-12T14:00/16:10",
+      "2016-04-18T14:00/16:10",
+      "2016-04-19T09:00/10:00",
+      "2016-04-19T14:00/16:10",
+      "2016-04-25T14:00/16:10",
+      "2016-04-26T09:00/10:00",
+      "2016-04-26T14:00/16:10"
+    ]
+  }
+
+  around do |example|
+    travel_to Time.zone.local(2016, 3, 31) do
+      example.run
+    end
+  end
+
+  it 'fetches slot availability from the prison' do
+    expect(subject.slots.map(&:iso8601)).to eq(default_prison_slots)
+  end
+
+  it 'can intersect available slots with prisoner availability' do
+    offender = Nomis::Offender.new(id: 123)
+    prisoner_availability = Nomis::PrisonerAvailability.new(
+      dates: [Date.parse('2016-04-12'), Date.parse('2016-04-25')]
+    )
+
+    expect(Nomis::Api.instance).to receive(:lookup_active_offender).
+      with(noms_id: 'a1234bc', date_of_birth: Date.parse('1970-01-01')).
+      and_return(offender)
+    expect(Nomis::Api.instance).to receive(:offender_visiting_availability).
+      and_return(prisoner_availability)
+
+    subject.restrict_by_prisoner(
+      prisoner_number: 'a1234bc',
+      prisoner_dob: Date.parse('1970-01-01')
+    )
+
+    expect(subject.slots.map(&:iso8601)).to eq(
+      [
+        '2016-04-12T09:00/10:00',
+        '2016-04-12T14:00/16:10',
+        '2016-04-25T14:00/16:10'
+      ]
+    )
+  end
+end

--- a/spec/models/slot_availability_spec.rb
+++ b/spec/models/slot_availability_spec.rb
@@ -5,6 +5,13 @@ RSpec.describe SlotAvailability, type: :model do
 
   let!(:prison) { create(:prison) }
 
+  let(:prisoner_params) {
+    {
+      prisoner_number: 'a1234bc',
+      prisoner_dob: Date.parse('1970-01-01')
+    }
+  }
+
   let(:default_prison_slots) {
     [
       "2016-04-11T14:00/16:10",
@@ -47,10 +54,7 @@ RSpec.describe SlotAvailability, type: :model do
     expect(Nomis::Api.instance).to receive(:offender_visiting_availability).
       and_return(prisoner_availability)
 
-    subject.restrict_by_prisoner(
-      prisoner_number: 'a1234bc',
-      prisoner_dob: Date.parse('1970-01-01')
-    )
+    subject.restrict_by_prisoner(prisoner_params)
 
     expect(subject.slots.map(&:iso8601)).to eq(
       [
@@ -66,10 +70,19 @@ RSpec.describe SlotAvailability, type: :model do
     expect(Nomis::Api.instance).not_to receive(:lookup_active_offender)
     expect(Nomis::Api.instance).not_to receive(:offender_visiting_availability)
 
-    subject.restrict_by_prisoner(
-      prisoner_number: 'a1234bc',
-      prisoner_dob: Date.parse('1970-01-01')
+    subject.restrict_by_prisoner(prisoner_params)
+
+    expect(subject.slots.map(&:iso8601)).to eq(default_prison_slots)
+  end
+
+  it 'returns only prison slots if the NOMIS API cannot be contacted' do
+    allow(Nomis::Api.instance).to receive(:lookup_active_offender).
+      and_raise(Excon::Errors::Error, 'Lookup error')
+    expect(Rails.logger).to receive(:warn).with(
+      'Error calling the NOMIS API: #<Excon::Errors::Error: Lookup error>'
     )
+
+    subject.restrict_by_prisoner(prisoner_params)
 
     expect(subject.slots.map(&:iso8601)).to eq(default_prison_slots)
   end

--- a/spec/services/nomis/api_spec.rb
+++ b/spec/services/nomis/api_spec.rb
@@ -38,4 +38,27 @@ RSpec.describe Nomis::Api do
       expect(subject).to be_nil
     end
   end
+
+  describe 'offender_visiting_availability', vcr: { cassette_name: 'offender_visiting_availability' } do
+    let(:params) {
+      {
+        offender_id: 1_055_827,
+        start_date: Date.parse('2016-04-01'),
+        end_date: Date.parse('2016-04-21')
+      }
+    }
+
+    subject { super().offender_visiting_availability(params) }
+
+    it 'returns availability info containing a list of available dates' do
+      expect(subject).to be_kind_of(Nomis::PrisonerAvailability)
+      expect(subject.dates.first).to eq(Date.parse('2016-04-01'))
+    end
+
+    it 'returns empty list of available dates if there is no availability', vcr: { cassette_name: 'offender_visiting_availability-noavailability' } do
+      params[:offender_id] = 1_055_847
+      expect(subject).to be_kind_of(Nomis::PrisonerAvailability)
+      expect(subject.dates).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
This only applies when slots are requested via the slots API, and is therefore only visible from pvb-public.