### PR TITLE
Proxy staff info pages from S3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'netaddr'
 gem 'pg'
 gem 'premailer-rails'
 gem 'puma'
+gem 'redcarpet'
 gem 'sass-rails', '~> 5.0'
 gem 'scenic', '>= 1.2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,6 +197,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.0.0)
     rake (10.5.0)
+    redcarpet (3.3.4)
     redis (3.2.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
@@ -355,6 +356,7 @@ DEPENDENCIES
   puma
   rails (~> 4.2.3)
   rake (< 11.0)
+  redcarpet
   rspec-rails (~> 3.0)
   rubocop
   rubocop-rspec

--- a/README.md
+++ b/README.md
@@ -259,6 +259,10 @@ These configure email delivery in the production environment. `SMTP_DOMAIN` is
 also used when generating the `no-reply@` address and the `feedback@` stand-in
 address used when submitting feedback without an email address to Zendesk.
 
+#### `STAFF_INFO_ENDPOINT`
+
+This is used to proxy the staff information pages static site.
+
 #### `OVERRIDE_PRISON_EMAIL_DOMAIN`
 
 In order to avoid sending confusing and irrelevant messages to real prisons and

--- a/app/controllers/staff_info_controller.rb
+++ b/app/controllers/staff_info_controller.rb
@@ -1,0 +1,87 @@
+class StaffInfoController < ApplicationController
+  rescue_from Excon::Errors::Error, with: :handle_excon_error
+  # Raised when Excon tries to parse the URI.  Will be raised if there is
+  # an error or ENV['STAFF_INFO_ENDPOINT'] is not set.
+  rescue_from URI::InvalidURIError, with: :not_available
+
+  TIMEOUT = 2
+
+  before_action :authorize_prison_request
+
+  def index
+    @content = fetch('/').body
+  end
+
+  # rubocop:disable Metrics/AbcSize
+  def show
+    page_path = params.values_at(:page, :format).compact.join('.')
+    resp = fetch(page_path)
+
+    if pdf?(resp)
+      send_data(resp.body, filename: page_path, type: 'application/pdf')
+    else
+      @nav = markdown(fetch('nav.md').body)
+      @content = markdown?(resp) ? markdown(resp.body) : resp.body
+    end
+  end
+# rubocop:enable Metrics/AbcSize
+
+private
+
+  def handle_excon_error(exception)
+    Rails.logger.
+      warn "Staff info pages cannot be served because of #{exception}."
+
+    if exception.class == Excon::Errors::NotFound
+      not_found
+    else
+      not_available
+    end
+  end
+
+  def not_found
+    fail ActionController::RoutingError, 'Not Found'
+  end
+
+  def not_available
+    render :not_available
+  end
+
+  def markdown?(resp)
+    resp.headers['Content-Type'] == 'text/markdown'
+  end
+
+  def pdf?(resp)
+    resp.headers['Content-Type'] == 'application/pdf'
+  end
+
+  def fetch(page_path)
+    options = {
+      expects: [200],
+      method: :get,
+      path: page_path,
+      read_timeout: TIMEOUT
+    }
+    connection.request(options)
+  end
+
+  def connection
+    @connection ||= Excon.new(
+      Rails.configuration.staff_info_endpoint,
+      persistent: true,
+      connect_timeout: TIMEOUT)
+  end
+
+  def markdown(content)
+    # Several of the existing pages have bad ASCII encoding. While we
+    # will fix these, it is highly likely others will appear in time as
+    # less experienced staff edit them using obsolete versions of Word.
+    unless content.encoding == Encoding::UTF_8
+      content.force_encoding('UTF-8')
+    end
+    content.scrub! unless content.valid_encoding?
+
+    Redcarpet::Markdown.new(Redcarpet::Render::HTML).
+      render(content)
+  end
+end

--- a/app/views/staff_info/index.html.erb
+++ b/app/views/staff_info/index.html.erb
@@ -1,0 +1,1 @@
+<%= raw(@content) %>

--- a/app/views/staff_info/not_available.html.erb
+++ b/app/views/staff_info/not_available.html.erb
@@ -1,0 +1,1 @@
+<h1><%= t('.staff_info_service_unavailable') %></h1>

--- a/app/views/staff_info/show.html.erb
+++ b/app/views/staff_info/show.html.erb
@@ -1,0 +1,8 @@
+<section class = "Grid">
+  <div class="Grid-2-3">
+    <%= raw(@content) %>
+  </div>
+  <div class="Grid-1-3">
+    <%= raw(@nav) %>
+  </div>
+</section>

--- a/config/application.rb
+++ b/config/application.rb
@@ -72,5 +72,6 @@ module PrisonVisits
       !ENV.key?('SMTP_PASSWORD')
 
     config.nomis_api_host = ENV.fetch('NOMIS_API_HOST', nil)
+    config.staff_info_endpoint = ENV.fetch('STAFF_INFO_ENDPOINT', nil)
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,6 +3,43 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
+      "fingerprint": "02ab7b803c65898228495f502abdf9c6f3e623f025bafec655c1a547ef03dcf3",
+      "message": "Render path contains parameter value",
+      "file": "app/controllers/errors_controller.rb",
+      "line": 19,
+      "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => { 404 => :\"404\", 500 => :\"500\", 503 => :\"503\" }.fetch(params.fetch(:status_code).to_i), { :status => params.fetch(:status_code).to_i })",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ErrorsController",
+        "method": "show"
+      },
+      "user_input": "params.fetch(:status_code)",
+      "confidence": "Weak",
+      "note": "The controller has a lookup table of acceptable render templates"
+    },
+    {
+      "warning_type": "Cross Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "000ec2b11dfa993c085c2bd6603794de8567c67c0c41f3b5dbc4cb95d5186163",
+      "message": "Unescaped parameter value",
+      "file": "app/views/staff_info/show.html.erb",
+      "line": 3,
+      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "markdown(fetch(params.values_at(:page, :format).compact.join(\".\")).body)",
+      "render_path": [{"type":"controller","class":"StaffInfoController","method":"show","line":20,"file":"app/controllers/staff_info_controller.rb"}],
+      "location": {
+        "type": "template",
+        "template": "staff_info/show"
+      },
+      "user_input": "params.values_at(:page, :format).compact.join(\".\")",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
       "fingerprint": "c598eec54ac508f70f6b8ec3509e6d2d65910784da867ef6ceb57c171b86841c",
       "message": "Render path contains parameter value",
       "file": "app/controllers/booking_requests_controller.rb",
@@ -37,25 +74,6 @@
       "user_input": "params",
       "confidence": "Weak",
       "note": ""
-    },
-    {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "02ab7b803c65898228495f502abdf9c6f3e623f025bafec655c1a547ef03dcf3",
-      "message": "Render path contains parameter value",
-      "file": "app/controllers/errors_controller.rb",
-      "line": 15,
-      "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => { 404 => :\"404\", 500 => :\"500\", 503 => :\"503\" }.fetch(params.fetch(:status_code).to_i), { :status => params.fetch(:status_code).to_i })",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ErrorsController",
-        "method": "show"
-      },
-      "user_input": "params.fetch(:status_code)",
-      "confidence": "Weak",
-      "note": "The controller has a lookup table of acceptable render templates"
     },
     {
       "warning_type": "Dynamic Render Path",
@@ -96,6 +114,6 @@
       "note": ""
     }
   ],
-  "updated": "2016-02-11 13:06:34 +0000",
+  "updated": "2016-04-06 17:12:22 +0100",
   "brakeman_version": "3.1.3"
 }

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -158,3 +158,7 @@ en:
             information.
           </p>
         visitor_banned_label: "%{name} (%{date}) is banned"
+  staff_info:
+    not_available:
+      staff_info_service_unavailable: >-
+        Staff info service is temporarily unavailable. Please check back later.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,4 +52,7 @@ Rails.application.routes.draw do
     resources :visits, only: %i[ create show destroy ]
     post '/validations/prisoner', to: 'validations#prisoner'
   end
+
+  get '/staff', to: 'staff_info#index'
+  get '/staff/:page', to: 'staff_info#show'
 end

--- a/spec/controllers/staff_info_controller_spec.rb
+++ b/spec/controllers/staff_info_controller_spec.rb
@@ -1,0 +1,144 @@
+require 'rails_helper'
+require_relative 'untrusted_examples'
+
+RSpec.describe StaffInfoController, type: :controller do
+  around do |ex|
+    VCR.turned_off { ex.run }
+  end
+
+  before do
+    allow(Rails.configuration).to receive(:staff_info_endpoint).
+      and_return('http://example.com')
+  end
+
+  describe 'when endpoint is not set' do
+    before do
+      allow(Rails.configuration).to receive(:staff_info_endpoint).
+        and_return(nil)
+    end
+
+    subject do
+      get :index
+    end
+
+    it { is_expected.to render_template(:not_available) }
+  end
+
+  describe 'index' do
+    before do
+      stub_request(:get, "http://example.com/").
+        to_return(status: 200)
+    end
+
+    subject do
+      get :index
+    end
+
+    it { expect(response.status).to eq(200) }
+    it { is_expected.to render_template(:index) }
+    it_behaves_like 'disallows untrusted ips'
+  end
+
+  describe 'show' do
+    let!(:stub_navbar) do
+      stub_request(:get, "http://example.com/nav.md").to_return(status: 200)
+    end
+
+    context 'available page' do
+      before do
+        stub_request(:get, /changes\.md/).
+          to_return(status: 200,
+                    body: '# Markdown',
+                    headers: { 'Content-Type' => 'text/markdown' })
+      end
+
+      subject do
+        get :show, page: 'changes.md'
+      end
+
+      it { expect(response.status).to eq(200) }
+      it { is_expected.to render_template(:show) }
+      it_behaves_like 'disallows untrusted ips'
+    end
+
+    context 'pdf downloads' do
+      before do
+        stub_request(:get, /acrobat\.pdf/).
+          to_return(status: 200,
+                    body: 'pdf stuff',
+                    headers: { 'Content-Type' => 'application/pdf' })
+      end
+
+      subject do
+        get :show, page: 'acrobat.pdf'
+      end
+
+      it { is_expected.to have_http_status(200) }
+      it_behaves_like 'disallows untrusted ips'
+    end
+
+    context 'errors' do
+      subject do
+        get :show, page: :wildweasel
+      end
+
+      context 'missing page' do
+        before do
+          stub_request(:get, /wildweasel/).to_return(status: 404)
+        end
+
+        it {
+          expect { subject }.
+            to raise_error(ActionController::RoutingError, 'Not Found')
+        }
+        it_behaves_like 'disallows untrusted ips'
+      end
+
+      context 'service unavailable' do
+        before do
+          stub_request(:get, /wildweasel/).to_return(status: 503)
+        end
+
+        it { is_expected.to render_template(:not_available) }
+        it_behaves_like 'disallows untrusted ips'
+      end
+
+      context 'service unavailable' do
+        before do
+          stub_request(:get, /wildweasel/).to_return(status: 500)
+        end
+
+        it { is_expected.to render_template(:not_available) }
+        it_behaves_like 'disallows untrusted ips'
+      end
+
+      context 'timeout' do
+        before do
+          stub_request(:get, /wildweasel/).to_return(status: 408)
+        end
+
+        it { is_expected.to render_template(:not_available) }
+      end
+    end
+
+    describe '.markdown' do
+      context 'valid encoding' do
+        let(:markdown) { '#Markdown' }
+
+        it 'renders markdown' do
+          expect(controller.send(:markdown, markdown)).
+            to eq("<h1>Markdown</h1>\n")
+        end
+      end
+
+      context 'bad encoding' do
+        let(:markdown) { "#Markdown \xE2".force_encoding('ASCII-8BIT') }
+
+        it 'renders markdown with unknown character' do
+          expect(controller.send(:markdown, markdown)).
+            to eq("<h1>Markdown �</h1>\n")
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/untrusted_examples.rb
+++ b/spec/controllers/untrusted_examples.rb
@@ -1,8 +1,7 @@
 RSpec.shared_examples 'disallows untrusted ips' do
   context 'an untrusted ip' do
     before do
-      allow_any_instance_of(ActionDispatch::Request).
-        to receive(:remote_ip).
+      allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip).
         and_return('192.168.1.0')
     end
 


### PR DESCRIPTION
The old app used a gem with an engine to include these pages. It was out
of date, and made updating content problematic. This proxies a static
website published to S3 in html, markdown, pdf and pngs/jpegs
directly.  

The content is published from the `prison_staff_info` private repo on
github.  Content changes should be made there.  Style change should be
made here.