### PR TITLE
Sendgrid webhook to bounce incoming emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,10 @@ prisons, it will create or update all prisons with emails in the format
 `pvb2.(parameterized prison name)@maildrop.dsd.io`. This will ensure that
 staging and other test emails do not accidentally get sent to real prisons.
 
+#### `WEBHOOK_AUTH_KEY`
+
+Used in the Sendgrid webhook. Ensures that the request comes from Sendgrid.
+
 #### `ZENDESK_USERNAME`, `ZENDESK_TOKEN`, `ZENDESK_URL`
 
 These are required in order to submit user feedback to Zendesk.

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -1,0 +1,44 @@
+class WebhooksController < ApplicationController
+  before_action :authorized?
+
+  def email
+    if parsed_email.source == :prison
+      PrisonMailer.autorespond(from_address).deliver_later
+    else
+      VisitorMailer.autorespond(from_address).deliver_later
+    end
+    render text: 'Accepted.'
+  end
+
+private
+
+  def authorized?
+    authorized = pad_execution_time(0.1) {
+      params.key?(:auth) &&
+      params[:auth] == Rails.configuration.webhook_auth_key
+    }
+
+    render text: 'Unauthorized.', status: 403 unless authorized
+  end
+
+  def parsed_email
+    @parsed_email ||= ParsedEmail.parse(email_params)
+  end
+
+  def email_params
+    params.slice(:from, :to, :subject, :text, :charsets)
+  end
+
+  # To prevent timing attacks, see commit #880e8cbf in pvb1 for more info
+  def pad_execution_time(execution_time)
+    start = Time.zone.now
+    result = yield
+    stop = Time.zone.now
+    sleep execution_time - (stop - start)
+    result
+  end
+
+  def from_address
+    parsed_email.from.address
+  end
+end

--- a/app/mailers/concerns/autoresponder.rb
+++ b/app/mailers/concerns/autoresponder.rb
@@ -1,0 +1,10 @@
+module Autoresponder
+  include ActiveSupport::Concern
+
+  def autorespond(to)
+    mail(to: to,
+         subject: 'This mailbox is not monitored',
+         template_path: 'shared_mailer',
+         template_name: 'autorespond.txt')
+  end
+end

--- a/app/mailers/prison_mailer.rb
+++ b/app/mailers/prison_mailer.rb
@@ -2,6 +2,7 @@ class PrisonMailer < ActionMailer::Base
   include LogoAttachment
   include NoReply
   include DateHelper
+  include Autoresponder
   add_template_helper DateHelper
   add_template_helper LinksHelper
 

--- a/app/mailers/visitor_mailer.rb
+++ b/app/mailers/visitor_mailer.rb
@@ -2,6 +2,7 @@ class VisitorMailer < ActionMailer::Base
   include LogoAttachment
   include NoReply
   include DateHelper
+  include Autoresponder
   add_template_helper DateHelper
   add_template_helper LinksHelper
 

--- a/app/services/parsed_email.rb
+++ b/app/services/parsed_email.rb
@@ -1,0 +1,41 @@
+class ParsedEmail
+  include NonPersistedModel
+
+  ParseError = Class.new(StandardError)
+
+  attribute :from, String
+  attribute :to, String
+  attribute :subject, String
+  attribute :text, String
+
+  # rubocop:disable Metrics/AbcSize
+  def self.parse(hash)
+    hash = hash.dup
+    fail ParseError, 'Missing subject' unless hash[:subject]
+    fail ParseError, 'Missing email body' unless hash[:text]
+    charsets = JSON.parse(hash[:charsets]).with_indifferent_access
+
+    [:subject, :text].each do |field|
+      # Fields can have different encodings, normalize everything to UTF-8
+      encoding = charsets[field]
+
+      hash[field].force_encoding(encoding).encode!('UTF-8') if encoding
+    end
+
+    new new_parse(hash)
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def self.new_parse(hash)
+    {
+      to: Mail::Address.new(hash[:to]),
+      from: Mail::Address.new(hash[:from]),
+      subject: hash[:subject],
+      text: hash[:text]
+    }
+  end
+
+  def source
+    from.domain.in?(%w[hmps.gsi.gov.uk noms.gsi.gov.uk]) ? :prison : :visitor
+  end
+end

--- a/app/views/shared_mailer/autorespond.txt
+++ b/app/views/shared_mailer/autorespond.txt
@@ -1,0 +1,5 @@
+Messages sent to this email address are not read.
+
+Instead you can:
+- contact the prison (http://www.justice.gov.uk/contacts/prison-finder) - either by phone or email 
+- tell us about a problem (https://www.prisonvisits.service.gov.uk/feedback/new) you’ve had with the service. Please don’t send personal information, eg prisoner number.

--- a/config/application.rb
+++ b/config/application.rb
@@ -65,6 +65,7 @@ module PrisonVisits
 
     config.sendgrid_api_user = ENV['SMTP_USERNAME']
     config.sendgrid_api_key = ENV['SMTP_PASSWORD']
+    config.webhook_auth_key = ENV['WEBHOOK_AUTH_KEY'] || 'development_key'
 
     config.disable_sendgrid_validations =
       !ENV.key?('ENABLE_SENDGRID_VALIDATIONS') &&

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
   scope '/:locale', locale: /[a-z]{2}/ do
     get '/', to: redirect('/%{locale}/request')
 
+    post 'webhooks/email/:auth', to: 'webhooks#email'
+
     scope controller: :metrics do
       get 'metrics', action: :index
       get 'metrics/confirmed_bookings', action: :confirmed_bookings

--- a/spec/controllers/webhooks_controller_spec.rb
+++ b/spec/controllers/webhooks_controller_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe WebhooksController, type: :controller do
+  describe "#email" do
+    let(:charsets) do
+      { from: 'utf-8', to: 'utf-8', subject: 'utf-8', text: 'utf-8' }.to_json
+    end
+    let(:from) { 'default <default@example.com>' }
+    let(:params) do
+      {
+        auth: auth,
+        to: 'no-reply@example.com',
+        from: from,
+        subject: "A visit",
+        text: "Some text",
+        charsets: charsets,
+        locale: 'en'
+      }
+    end
+
+    subject { post :email, params }
+
+    context "when authorized" do
+      let(:auth) { Rails.configuration.webhook_auth_key }
+
+      context "from the visitor" do
+        let(:from) { 'John Doe <john@example.com>' }
+
+        it 'sends a reminder that the inbox is unattended' do
+          expect(VisitorMailer).
+            to receive(:autorespond).
+            with('john@example.com').
+            and_call_original
+          is_expected.to be_successful
+        end
+      end
+
+      context "from a prison" do
+        let(:from) { 'HMP Prison <prison@hmps.gsi.gov.uk>' }
+
+        it 'sends a reminder that the inbox is unattended' do
+          expect(PrisonMailer).
+            to receive(:autorespond).
+            with('prison@hmps.gsi.gov.uk').
+            and_call_original
+
+          is_expected.to be_successful
+        end
+      end
+    end
+
+    context "when unathorized" do
+      let(:auth) { 'incorrect key' }
+
+      it { is_expected.to be_forbidden }
+    end
+  end
+end

--- a/spec/mailers/prison_mailer/autorespond_spec.rb
+++ b/spec/mailers/prison_mailer/autorespond_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+require 'mailers/shared_mailer_examples'
+
+RSpec.describe PrisonMailer, '.autorespond' do
+  let(:email_address) { 'example@example.com' }
+  let(:mail) { described_class.autorespond(email_address) }
+
+  it_behaves_like 'an email that notifies of unnatended mailbox'
+end

--- a/spec/mailers/shared_mailer_examples.rb
+++ b/spec/mailers/shared_mailer_examples.rb
@@ -4,3 +4,10 @@ RSpec.shared_examples 'template checks' do
     expect(html).not_to match(/translation missing/)
   end
 end
+
+RSpec.shared_examples 'an email that notifies of unnatended mailbox' do
+  it 'sends an email to the sender' do
+    expect(mail.to).to include(email_address)
+    expect(mail.subject).to eq('This mailbox is not monitored')
+  end
+end

--- a/spec/mailers/visitor_mailer/autorespond_spec.rb
+++ b/spec/mailers/visitor_mailer/autorespond_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+require 'mailers/shared_mailer_examples'
+
+RSpec.describe VisitorMailer, '.autorespond' do
+  let(:email_address) { 'example@example.com' }
+  let(:mail) { described_class.autorespond(email_address) }
+
+  it_behaves_like 'an email that notifies of unnatended mailbox'
+end

--- a/spec/services/parsed_email_spec.rb
+++ b/spec/services/parsed_email_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe ParsedEmail do
+  context "given valid data" do
+    let :data do
+      {
+        from: "Some Dude <some.dude@digital.justice.gov.uk>",
+        to: 'test@example.com',
+        text: "some text",
+        charsets: { to: "UTF-8", html: "utf-8", subject: "UTF-8", from: "UTF-8", text: "utf-8" }.to_json,
+        subject: "important email"
+      }
+    end
+
+    it "parses the email" do
+      expect(described_class.parse(data)).to be_valid
+    end
+
+    it "reports the source as coming in from a visitor" do
+      expect(described_class.parse(data).source).to eq(:visitor)
+    end
+  end
+
+  context "given data from hotmail.com" do
+    let :data do
+      {
+        from: "=?ISO-8859-1?Q?Keld_J=F8rn_Simonsen?= <keld@dkuug.dk>",
+        to: 'test@example.com',
+        text: "æ".encode('windows-1252'),
+        charsets: { to: "utf-8", subject: "windows-1252", from: "utf-8", text: "windows-1252" }.to_json,
+        subject: "Wøt up?".encode('windows-1252')
+      }
+    end
+
+    it "parses the email" do
+      email = described_class.parse(data)
+      expect(email).to be_valid
+
+      expect(email.from.display_name).to eq("Keld Jørn Simonsen")
+      expect(email.subject).to eq("Wøt up?")
+      expect(email.text).to eq("æ")
+    end
+  end
+
+  context "when an e-mail from the prison comes in" do
+    let(:data) do
+      {
+        from: from,
+        to: 'test@example.com',
+        text: "some text",
+        charsets: { to: "UTF-8", html: "utf-8", subject: "UTF-8", from: "UTF-8", text: "utf-8" }.to_json,
+        subject: "important email"
+      }
+    end
+
+    context 'from a hmps subdomain' do
+      let(:from) { "HMP Prison <prison@hmps.gsi.gov.uk>" }
+
+      it "reports the source as 'prison'" do
+        expect(described_class.parse(data).source).to eq(:prison)
+      end
+    end
+
+    context 'from a noms subdomain' do
+      let(:from) { 'HMP Prison <prison@noms.gsi.gov.uk>' }
+
+      it "reports the source as 'prison'" do
+        expect(described_class.parse(data).source).to eq(:prison)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sendgrid does not provide mailboxes, all emails are accepted and is up to the
integrators to do something via the webhooks notifications.

This means that emails sent to the noreply email address don't bounce off
automatically, and need to be handled with a webhook so that an email can be
sent to the sender letting them know that the email address is unattended.