### PR TITLE
Update Excon to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     docile (1.1.5)
     equalizer (0.0.11)
     erubis (2.7.0)
-    excon (0.47.0)
+    excon (0.49.0)
     execjs (2.6.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)


### PR DESCRIPTION
Bumping Excon to latest version so that pvb-public and pvb2 use the same version