### PR TITLE
Validate format FeedbackSubmission#email_address

### DIFF
--- a/app/models/feedback_submission.rb
+++ b/app/models/feedback_submission.rb
@@ -1,6 +1,6 @@
 class FeedbackSubmission < ActiveRecord::Base
   validates :body, presence: true
-  validate :validate_email
+  validate :email_format
 
   before_validation :strip_email_address, on: :create
 
@@ -10,9 +10,9 @@ private
     self.email_address = email_address.strip
   end
 
-  def validate_email
-    return unless email_address.present?
-    email_checker = EmailChecker.new(email_address)
-    errors.add :email_address, email_checker.message unless email_checker.valid?
+  def email_format
+    Mail::Address.new(email_address)
+  rescue Mail::Field::ParseError
+    errors.add(:email_address, 'has incorrect format')
   end
 end

--- a/spec/models/feedback_submission_spec.rb
+++ b/spec/models/feedback_submission_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe FeedbackSubmission do
       end
 
       it 'is invalid when not an email address' do
-        subject.email_address = 'BOGUS!'
+        subject.email_address = 'BOGUS !'
         subject.validate
         expect(subject.errors).to have_key(:email_address)
       end


### PR DESCRIPTION
Validate only the format of the email_address for feedback submissions as
discussed. Uses the format validation that the EmailChecker does.