### PR TITLE
Serialize a String instead of Array on error

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -18,7 +18,7 @@ module Api
     end
 
     rescue_from ActiveRecord::RecordInvalid do |e|
-      render_error 422, e.record.errors.full_messages
+      render_error 422, e.record.errors.full_messages.join(', ')
     end
 
   private

--- a/spec/controllers/api/feedback_controller_spec.rb
+++ b/spec/controllers/api/feedback_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Api::FeedbackController, type: :controller do
 
       it 'returns an error' do
         is_expected.to be_unprocessable
-        expect(parsed_body['message']).to eq(["Body can't be blank"])
+        expect(parsed_body['message']).to eq("Body can't be blank")
       end
     end
   end


### PR DESCRIPTION
Makes the behaviour consistent with other types of errors