### PR TITLE
Fix rejection calculations

### DIFF
--- a/db/migrate/20160407141410_update_rejection_percentage_by_prison_and_calendar_weeks_to_version_3.rb
+++ b/db/migrate/20160407141410_update_rejection_percentage_by_prison_and_calendar_weeks_to_version_3.rb
@@ -1,0 +1,5 @@
+class UpdateRejectionPercentageByPrisonAndCalendarWeeksToVersion3 < ActiveRecord::Migration
+  def change
+    update_view :rejection_percentage_by_prison_and_calendar_weeks, version: 3, revert_to_version: 2
+  end
+end

--- a/db/migrate/20160407142204_update_rejection_percentage_by_prisons_to_version_2.rb
+++ b/db/migrate/20160407142204_update_rejection_percentage_by_prisons_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdateRejectionPercentageByPrisonsToVersion2 < ActiveRecord::Migration
+  def change
+    update_view :rejection_percentage_by_prisons, version: 2, revert_to_version: 1
+  end
+end

--- a/db/migrate/20160407142305_update_rejection_percentages_to_version_2.rb
+++ b/db/migrate/20160407142305_update_rejection_percentages_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdateRejectionPercentagesToVersion2 < ActiveRecord::Migration
+  def change
+    update_view :rejection_percentages, version: 2, revert_to_version: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160406102326) do
+ActiveRecord::Schema.define(version: 20160407142305) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -299,69 +299,6 @@ ActiveRecord::Schema.define(version: 20160406102326) do
     GROUP BY v.processing_state, prisons.name, (date_part('day'::text, v.created_at))::integer, (date_part('month'::text, v.created_at))::integer, (date_part('year'::text, v.created_at))::integer;
   SQL
 
-  create_view :rejection_percentages,  sql_definition: <<-SQL
-      SELECT 'total'::character varying AS reason,
-      round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2) AS percentage
-     FROM ( SELECT count(*) AS rejected_count
-             FROM (visits
-               JOIN rejections ON ((rejections.visit_id = visits.id)))
-            WHERE ((visits.processing_state)::text = 'rejected'::text)) rejected,
-      ( SELECT count(*) AS booked_count
-             FROM visits) booked
-    GROUP BY round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2)
-  UNION
-   SELECT rejected.reason,
-      round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2) AS percentage
-     FROM ( SELECT rejections.reason,
-              count(*) AS rejected_count
-             FROM (visits
-               JOIN rejections ON ((rejections.visit_id = visits.id)))
-            WHERE ((visits.processing_state)::text = 'rejected'::text)
-            GROUP BY rejections.reason) rejected,
-      ( SELECT count(*) AS booked_count
-             FROM visits) booked
-    GROUP BY rejected.reason, round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2);
-  SQL
-
-  create_view :rejection_percentage_by_prisons,  sql_definition: <<-SQL
-      SELECT rejected.prison_name,
-      'total'::character varying AS reason,
-      round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2) AS percentage
-     FROM ( SELECT prisons.name AS prison_name,
-              count(*) AS rejected_count
-             FROM ((visits
-               JOIN prisons ON ((prisons.id = visits.prison_id)))
-               JOIN rejections ON ((rejections.visit_id = visits.id)))
-            WHERE ((visits.processing_state)::text = 'rejected'::text)
-            GROUP BY prisons.name, visits.prison_id) rejected,
-      ( SELECT prisons.name AS prison_name,
-              count(*) AS booked_count
-             FROM (visits
-               JOIN prisons ON ((prisons.id = visits.prison_id)))
-            GROUP BY prisons.name, visits.prison_id) booked
-    WHERE ((rejected.prison_name)::text = (booked.prison_name)::text)
-    GROUP BY rejected.prison_name, round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2)
-  UNION
-   SELECT rejected.prison_name,
-      rejected.reason,
-      round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2) AS percentage
-     FROM ( SELECT rejections.reason,
-              prisons.name AS prison_name,
-              count(*) AS rejected_count
-             FROM ((visits
-               JOIN prisons ON ((prisons.id = visits.prison_id)))
-               JOIN rejections ON ((rejections.visit_id = visits.id)))
-            WHERE ((visits.processing_state)::text = 'rejected'::text)
-            GROUP BY prisons.name, visits.prison_id, rejections.reason) rejected,
-      ( SELECT prisons.name AS prison_name,
-              count(*) AS booked_count
-             FROM (visits
-               JOIN prisons ON ((prisons.id = visits.prison_id)))
-            GROUP BY prisons.name, visits.prison_id) booked
-    WHERE ((rejected.prison_name)::text = (booked.prison_name)::text)
-    GROUP BY rejected.prison_name, rejected.reason, round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2);
-  SQL
-
   create_view :rejection_percentage_by_prison_and_calendar_dates,  sql_definition: <<-SQL
       SELECT rejected.prison_name,
       'total'::character varying AS reason,
@@ -407,52 +344,6 @@ ActiveRecord::Schema.define(version: 20160406102326) do
             GROUP BY prisons.name, visits.prison_id) booked
     WHERE ((rejected.prison_name)::text = (booked.prison_name)::text)
     GROUP BY rejected.prison_name, rejected.reason, round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2), (date_part('year'::text, rejected.created_at))::integer, (date_part('month'::text, rejected.created_at))::integer, (date_part('day'::text, rejected.created_at))::integer;
-  SQL
-
-  create_view :rejection_percentage_by_prison_and_calendar_weeks,  sql_definition: <<-SQL
-      SELECT rejected.prison_name,
-      'total'::text AS reason,
-      rejected.year,
-      rejected.week,
-      round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2) AS percentage
-     FROM ( SELECT prisons.name AS prison_name,
-              count(*) AS rejected_count,
-              (date_part('isoyear'::text, visits.created_at))::integer AS year,
-              (date_part('week'::text, visits.created_at))::integer AS week
-             FROM (visits
-               JOIN prisons ON ((prisons.id = visits.prison_id)))
-            WHERE ((visits.processing_state)::text = 'rejected'::text)
-            GROUP BY prisons.name, visits.prison_id, (date_part('isoyear'::text, visits.created_at))::integer, (date_part('week'::text, visits.created_at))::integer) rejected,
-      ( SELECT prisons.name AS prison_name,
-              count(*) AS booked_count
-             FROM (visits
-               JOIN prisons ON ((prisons.id = visits.prison_id)))
-            GROUP BY prisons.name, visits.prison_id) booked
-    WHERE ((rejected.prison_name)::text = (booked.prison_name)::text)
-    GROUP BY rejected.prison_name, 'total'::text, round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2), rejected.year, rejected.week
-  UNION
-   SELECT rejected.prison_name,
-      rejected.reason,
-      rejected.year,
-      rejected.week,
-      round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2) AS percentage
-     FROM ( SELECT rejections.reason,
-              prisons.name AS prison_name,
-              count(*) AS rejected_count,
-              (date_part('isoyear'::text, visits.created_at))::integer AS year,
-              (date_part('week'::text, visits.created_at))::integer AS week
-             FROM ((visits
-               JOIN prisons ON ((prisons.id = visits.prison_id)))
-               JOIN rejections ON ((rejections.visit_id = visits.id)))
-            WHERE ((visits.processing_state)::text = 'rejected'::text)
-            GROUP BY prisons.name, visits.prison_id, rejections.reason, (date_part('isoyear'::text, visits.created_at))::integer, (date_part('week'::text, visits.created_at))::integer) rejected,
-      ( SELECT prisons.name AS prison_name,
-              count(*) AS booked_count
-             FROM (visits
-               JOIN prisons ON ((prisons.id = visits.prison_id)))
-            GROUP BY prisons.name, visits.prison_id) booked
-    WHERE ((rejected.prison_name)::text = (booked.prison_name)::text)
-    GROUP BY rejected.prison_name, rejected.reason, round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2), rejected.year, rejected.week;
   SQL
 
   create_view :timely_and_overdue_by_calendar_weeks,  sql_definition: <<-SQL
@@ -501,6 +392,121 @@ ActiveRecord::Schema.define(version: 20160406102326) do
        JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text <> 'requested'::text))))
     WHERE ((date_part('epoch'::text, (vsc.created_at - v.created_at)) < (259200)::double precision) AND ((vsc.visit_state)::text = (v.processing_state)::text))
     GROUP BY prisons.name, vsc.visit_state;
+  SQL
+
+  create_view :rejection_percentage_by_prison_and_calendar_weeks,  sql_definition: <<-SQL
+      SELECT rejected.prison_name,
+      'total'::text AS reason,
+      rejected.year,
+      rejected.week,
+      round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2) AS percentage
+     FROM ( SELECT prisons.name AS prison_name,
+              count(*) AS rejected_count,
+              (date_part('isoyear'::text, visits.created_at))::integer AS year,
+              (date_part('week'::text, visits.created_at))::integer AS week
+             FROM (visits
+               JOIN prisons ON ((prisons.id = visits.prison_id)))
+            WHERE ((visits.processing_state)::text = 'rejected'::text)
+            GROUP BY prisons.name, visits.prison_id, (date_part('isoyear'::text, visits.created_at))::integer, (date_part('week'::text, visits.created_at))::integer) rejected,
+      ( SELECT prisons.name AS prison_name,
+              count(*) AS booked_count
+             FROM (visits
+               JOIN prisons ON ((prisons.id = visits.prison_id)))
+            WHERE ((visits.processing_state)::text <> 'rejected'::text)
+            GROUP BY prisons.name, visits.prison_id) booked
+    WHERE ((rejected.prison_name)::text = (booked.prison_name)::text)
+    GROUP BY rejected.prison_name, 'total'::text, round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2), rejected.year, rejected.week
+  UNION
+   SELECT rejected.prison_name,
+      rejected.reason,
+      rejected.year,
+      rejected.week,
+      round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2) AS percentage
+     FROM ( SELECT rejections.reason,
+              prisons.name AS prison_name,
+              count(*) AS rejected_count,
+              (date_part('isoyear'::text, visits.created_at))::integer AS year,
+              (date_part('week'::text, visits.created_at))::integer AS week
+             FROM ((visits
+               JOIN prisons ON ((prisons.id = visits.prison_id)))
+               JOIN rejections ON ((rejections.visit_id = visits.id)))
+            WHERE ((visits.processing_state)::text = 'rejected'::text)
+            GROUP BY prisons.name, visits.prison_id, rejections.reason, (date_part('isoyear'::text, visits.created_at))::integer, (date_part('week'::text, visits.created_at))::integer) rejected,
+      ( SELECT prisons.name AS prison_name,
+              count(*) AS booked_count
+             FROM (visits
+               JOIN prisons ON ((prisons.id = visits.prison_id)))
+            WHERE ((visits.processing_state)::text <> 'rejected'::text)
+            GROUP BY prisons.name, visits.prison_id) booked
+    WHERE ((rejected.prison_name)::text = (booked.prison_name)::text)
+    GROUP BY rejected.prison_name, rejected.reason, round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2), rejected.year, rejected.week;
+  SQL
+
+  create_view :rejection_percentage_by_prisons,  sql_definition: <<-SQL
+      SELECT rejected.prison_name,
+      'total'::character varying AS reason,
+      round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2) AS percentage
+     FROM ( SELECT prisons.name AS prison_name,
+              count(*) AS rejected_count
+             FROM ((visits
+               JOIN prisons ON ((prisons.id = visits.prison_id)))
+               JOIN rejections ON ((rejections.visit_id = visits.id)))
+            WHERE ((visits.processing_state)::text = 'rejected'::text)
+            GROUP BY prisons.name, visits.prison_id) rejected,
+      ( SELECT prisons.name AS prison_name,
+              count(*) AS booked_count
+             FROM (visits
+               JOIN prisons ON ((prisons.id = visits.prison_id)))
+            WHERE ((visits.processing_state)::text <> 'rejected'::text)
+            GROUP BY prisons.name, visits.prison_id) booked
+    WHERE ((rejected.prison_name)::text = (booked.prison_name)::text)
+    GROUP BY rejected.prison_name, round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2)
+  UNION
+   SELECT rejected.prison_name,
+      rejected.reason,
+      round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2) AS percentage
+     FROM ( SELECT rejections.reason,
+              prisons.name AS prison_name,
+              count(*) AS rejected_count
+             FROM ((visits
+               JOIN prisons ON ((prisons.id = visits.prison_id)))
+               JOIN rejections ON ((rejections.visit_id = visits.id)))
+            WHERE ((visits.processing_state)::text = 'rejected'::text)
+            GROUP BY prisons.name, visits.prison_id, rejections.reason) rejected,
+      ( SELECT prisons.name AS prison_name,
+              count(*) AS booked_count
+             FROM (visits
+               JOIN prisons ON ((prisons.id = visits.prison_id)))
+            WHERE ((visits.processing_state)::text <> 'rejected'::text)
+            GROUP BY prisons.name, visits.prison_id) booked
+    WHERE ((rejected.prison_name)::text = (booked.prison_name)::text)
+    GROUP BY rejected.prison_name, rejected.reason, round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2);
+  SQL
+
+  create_view :rejection_percentages,  sql_definition: <<-SQL
+      SELECT 'total'::character varying AS reason,
+      round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2) AS percentage
+     FROM ( SELECT count(*) AS rejected_count
+             FROM (visits
+               JOIN rejections ON ((rejections.visit_id = visits.id)))
+            WHERE ((visits.processing_state)::text = 'rejected'::text)) rejected,
+      ( SELECT count(*) AS booked_count
+             FROM visits
+            WHERE ((visits.processing_state)::text <> 'rejected'::text)) booked
+    GROUP BY round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2)
+  UNION
+   SELECT rejected.reason,
+      round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2) AS percentage
+     FROM ( SELECT rejections.reason,
+              count(*) AS rejected_count
+             FROM (visits
+               JOIN rejections ON ((rejections.visit_id = visits.id)))
+            WHERE ((visits.processing_state)::text = 'rejected'::text)
+            GROUP BY rejections.reason) rejected,
+      ( SELECT count(*) AS booked_count
+             FROM visits
+            WHERE ((visits.processing_state)::text <> 'rejected'::text)) booked
+    GROUP BY rejected.reason, round((((rejected.rejected_count)::numeric / (booked.booked_count)::numeric) * (100)::numeric), 2);
   SQL
 
 end

--- a/db/views/rejection_percentage_by_prison_and_calendar_weeks_v03.sql
+++ b/db/views/rejection_percentage_by_prison_and_calendar_weeks_v03.sql
@@ -1,0 +1,66 @@
+SELECT rejected.prison_name,
+       'total' AS reason,
+       rejected.year AS year,
+       rejected.week AS week,
+       ROUND((rejected_count::numeric / booked_count * 100),2) AS percentage
+FROM (SELECT prisons.name AS prison_name,
+             count(*) AS rejected_count,
+             extract(isoyear from visits.created_at)::integer AS year,
+             extract(week from visits.created_at)::integer AS week
+      FROM visits
+      INNER JOIN prisons ON prisons.id = visits.prison_id
+      WHERE visits.processing_state = 'rejected'
+      GROUP BY prison_name,
+             prison_id,
+               year,
+               week
+      ) rejected,
+     (SELECT prisons.name AS prison_name,
+             count(*) AS booked_count
+      FROM visits
+      INNER JOIN prisons ON prisons.id = visits.prison_id
+      WHERE visits.processing_state != 'rejected'
+      GROUP BY prison_name,
+               prison_id
+      ) booked
+WHERE rejected.prison_name = booked.prison_name
+GROUP BY rejected.prison_name,
+         reason,
+         percentage,
+         year,
+         week
+UNION
+SELECT rejected.prison_name,
+       reason,
+       rejected.year AS year,
+       rejected.week AS week,
+       ROUND((rejected_count::numeric / booked_count * 100),2) AS percentage
+FROM (SELECT reason,
+             prisons.name AS prison_name,
+             count(*) AS rejected_count,
+             extract(isoyear from visits.created_at)::integer AS year,
+             extract(week from visits.created_at)::integer AS week
+      FROM visits
+      INNER JOIN prisons ON prisons.id = visits.prison_id
+      INNER JOIN rejections ON rejections.visit_id = visits.id
+      WHERE visits.processing_state = 'rejected'
+      GROUP BY prison_name,
+             prison_id,
+               reason,
+               year,
+               week
+      ) rejected,
+     (SELECT prisons.name AS prison_name,
+             count(*) AS booked_count
+      FROM visits
+      INNER JOIN prisons ON prisons.id = visits.prison_id
+      WHERE visits.processing_state != 'rejected'
+      GROUP BY prison_name,
+               prison_id
+      ) booked
+WHERE rejected.prison_name = booked.prison_name
+GROUP BY rejected.prison_name,
+         reason,
+         percentage,
+         year,
+         week

--- a/db/views/rejection_percentage_by_prisons_v02.sql
+++ b/db/views/rejection_percentage_by_prisons_v02.sql
@@ -1,0 +1,52 @@
+SELECT rejected.prison_name,
+       'total' AS reason,
+       ROUND((rejected_count::numeric / booked_count * 100),2) AS percentage
+FROM (SELECT prisons.name AS prison_name,
+             count(*) AS rejected_count
+      FROM visits
+      INNER JOIN prisons ON prisons.id = visits.prison_id
+      INNER JOIN rejections ON rejections.visit_id = visits.id
+      WHERE visits.processing_state = 'rejected'
+      GROUP BY prison_name,
+      		   prison_id
+      ) rejected,
+     (SELECT prisons.name AS prison_name,
+             count(*) AS booked_count
+      FROM visits
+      INNER JOIN prisons ON prisons.id = visits.prison_id
+      WHERE visits.processing_state != 'rejected'
+      GROUP BY prison_name,
+               prison_id
+      ) booked
+WHERE rejected.prison_name = booked.prison_name
+GROUP BY rejected.prison_name,
+         percentage
+UNION
+SELECT rejected.prison_name,
+       reason,
+       ROUND((rejected_count::numeric / booked_count * 100),2) AS percentage
+FROM (SELECT reason,
+             prisons.name AS prison_name,
+             count(*) AS rejected_count
+      FROM visits
+      INNER JOIN prisons ON prisons.id = visits.prison_id
+      INNER JOIN rejections ON rejections.visit_id = visits.id
+      WHERE visits.processing_state = 'rejected'
+      GROUP BY prison_name,
+      		   prison_id,
+               reason
+      ) rejected,
+     (SELECT prisons.name AS prison_name,
+             count(*) AS booked_count
+      FROM visits
+      INNER JOIN prisons ON prisons.id = visits.prison_id
+      WHERE visits.processing_state != 'rejected'
+      GROUP BY prison_name,
+               prison_id
+      ) booked
+WHERE rejected.prison_name = booked.prison_name
+GROUP BY rejected.prison_name,
+         reason,
+         percentage
+
+

--- a/db/views/rejection_percentages_v02.sql
+++ b/db/views/rejection_percentages_v02.sql
@@ -1,0 +1,28 @@
+SELECT 'total' AS reason,
+       ROUND((rejected_count::numeric / booked_count * 100),2) AS percentage
+FROM (SELECT count(*) AS rejected_count
+      FROM visits
+      INNER JOIN rejections ON rejections.visit_id = visits.id
+      WHERE visits.processing_state = 'rejected'
+      ) rejected,
+     (SELECT count(*) AS booked_count
+      FROM visits
+      WHERE visits.processing_state != 'rejected'
+      ) booked
+GROUP BY percentage
+UNION
+SELECT reason,
+       ROUND((rejected_count::numeric / booked_count * 100),2) AS percentage
+FROM (SELECT reason,
+             count(*) AS rejected_count
+      FROM visits
+      INNER JOIN rejections ON rejections.visit_id = visits.id
+      WHERE visits.processing_state = 'rejected'
+      GROUP BY reason
+      ) rejected,
+     (SELECT count(*) AS booked_count
+      FROM visits
+      WHERE visits.processing_state != 'rejected'
+     ) booked
+GROUP BY reason,
+         percentage

--- a/spec/features/metrics_spec.rb
+++ b/spec/features/metrics_spec.rb
@@ -40,10 +40,10 @@ RSpec.feature 'Metrics', js: true do
 
     it 'has the correct rejection percentages' do
       # These will track the spec in spec/metrics/rejections_spec.rb
-      expect(page).to have_selector('.luna-total-rejected', text: 36.36)
-      expect(page).to have_selector('.luna-no-allowance', text: 18.18)
-      expect(page).to have_selector('.luna-visitor-banned', text: 9.09)
-      expect(page).to have_selector('.luna-slot-unavailable', text: 9.09)
+      expect(page).to have_selector('.luna-total-rejected', text: 40.00)
+      expect(page).to have_selector('.luna-no-allowance', text: 20.00)
+      expect(page).to have_selector('.luna-visitor-banned', text: 10.00)
+      expect(page).to have_selector('.luna-slot-unavailable', text: 10.00)
     end
   end
 

--- a/spec/metrics/rejections_spec.rb
+++ b/spec/metrics/rejections_spec.rb
@@ -5,31 +5,43 @@ RSpec.describe Rejections do
   context 'that are not organised by date' do
     include_examples 'create rejections without dates'
 
+    before do
+      luna_visits_without_dates
+    end
+
+    it { expect(Visit.count).to eq(14) }
+    it { expect(Visit.where(processing_state: 'booked').count).to eq(10) }
+    it { expect(Visit.where(processing_state: 'rejected').count).to eq(4) }
+
     describe Rejections::RejectionPercentage do
       it 'calculates percentages of all rejections' do
-        expect(described_class.fetch_and_format).to eq('no_allowance' => 10.0,
+        expect(described_class.fetch_and_format).to eq('no_allowance' => 20.0,
                                                        'slot_unavailable' => 10.0,
                                                        'visitor_banned' => 10.0,
-                                                       'total' => 30.0)
+                                                       'total' => 40.0)
       end
     end
 
     describe Rejections::RejectionPercentageByPrison do
+      before do
+        mars_visits_without_dates
+      end
+
       it 'calculates percentages of all rejections by prison' do
         expect(described_class.fetch_and_format).to be ==
           { 'Lunar Penal Colony' =>
             {
-              'no_allowance' => 10.0,
+              'no_allowance' => 20.0,
               'slot_unavailable' => 10.0,
               'visitor_banned' => 10.0,
-              'total' => 30.0
+              'total' => 40.0
             },
             'Martian Penal Colony' =>
             {
-              'no_allowance' => 10.0,
+              'no_allowance' => 20.0,
               'slot_unavailable' => 10.0,
               'visitor_banned' => 10.0,
-              'total' => 30.0
+              'total' => 40.0
             }
         }
       end
@@ -44,6 +56,10 @@ RSpec.describe Rejections do
         luna_visits_with_dates
       end
 
+      it { expect(Visit.count).to eq(14) }
+      it { expect(Visit.where(processing_state: 'booked').count).to eq(10) }
+      it { expect(Visit.where(processing_state: 'rejected').count).to eq(4) }
+
       it 'counts visits and groups by prison, year, calendar week and visit state' do
         expect(described_class.fetch_and_format).to be ==
           { 'Lunar Penal Colony' =>
@@ -51,10 +67,10 @@ RSpec.describe Rejections do
               2016 =>
               { 5 =>
                 {
-                  'no_allowance' => 18.18,
-                  'slot_unavailable' => 9.09,
-                  'visitor_banned' => 9.09,
-                  'total' => 36.36
+                  'no_allowance' => 20.00,
+                  'slot_unavailable' => 10.00,
+                  'visitor_banned' => 10.00,
+                  'total' => 40.00
                 }
               }
             }

--- a/spec/metrics/shared_examples_for_metrics.rb
+++ b/spec/metrics/shared_examples_for_metrics.rb
@@ -2,19 +2,21 @@ RSpec.shared_examples 'create rejections without dates' do
   let(:luna) { create(:prison, name: 'Lunar Penal Colony') }
   let(:mars) { create(:prison, name: 'Martian Penal Colony') }
 
-  let!(:luna_visits_without_dates) do
+  def luna_visits_without_dates
     make_visits(luna)
   end
 
-  let!(:mars_visits_without_dates) do
+  def mars_visits_without_dates
     make_visits(mars)
   end
 
   def make_visits(prison)
-    create_list(:visit, 7, prison: prison)
+    create_list(:booked_visit, 10, prison: prison)
+    nc = create(:rejected_visit, prison: prison)
     na = create(:rejected_visit, prison: prison)
     su = create(:rejected_visit, prison: prison)
     vb = create(:rejected_visit, prison: prison)
+    create(:rejection, visit: nc, reason: 'no_allowance')
     create(:rejection, visit: na, reason: 'no_allowance')
     create(:rejection, visit: su, reason: 'slot_unavailable')
     create(:rejection, visit: vb, reason: 'visitor_banned')
@@ -36,7 +38,7 @@ RSpec.shared_examples 'create rejections with dates' do
   end
 
   def make_visits(prison)
-    create_list(:booked_visit, 7, created_at: Time.zone.local(2016, 2, 1), prison: luna)
+    create_list(:booked_visit, 10, created_at: Time.zone.local(2016, 2, 1), prison: prison)
 
     nc = create(:rejected_visit, prison: prison, created_at: Time.zone.local(2016, 2, 1))
     na = create(:rejected_visit, prison: prison, created_at: Time.zone.local(2016, 2, 2))


### PR DESCRIPTION
The count of total visits included the rejected visits.  This was throwing the calculations off.  Compounding the problem was the fact that I had chosen odd numbers of visits when I was setting up the specs, so the error was not immediately obvious.