### PR TITLE
Handle unknown formats in request a booking

### DIFF
--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -6,7 +6,10 @@ class BookingRequestsController < ApplicationController
     @steps = processor.steps
     @step_name = processor.step_name
     append_to_log booking_step_rendered: processor.step_name
-    render processor.step_name
+
+    respond_to do |format|
+      format.html { render processor.step_name }
+    end
   end
 
   def create
@@ -16,7 +19,10 @@ class BookingRequestsController < ApplicationController
     @step_name = processor.step_name
     append_to_log booking_step_rendered: processor.step_name
     append_to_log visit_id: @visit.id if @visit
-    render processor.step_name
+
+    respond_to do |format|
+      format.html { render processor.step_name }
+    end
   end
 
 private

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,7 @@
 class ErrorsController < ApplicationController
   SUPPORTED_ERRORS = {
     404 => :'404',
+    406 => :'404',
     500 => :'500',
     503 => :'503'
   }
@@ -8,6 +9,7 @@ class ErrorsController < ApplicationController
   # Otherwise erroring POST requests can fail the CSRF check when rendering the
   # error page...
   skip_before_action :verify_authenticity_token
+  before_action :set_html_format, only: :show
 
   def show
     status_code = params.fetch(:status_code).to_i
@@ -15,11 +17,19 @@ class ErrorsController < ApplicationController
     # Explicity protect against rendering an unexpected template (although such
     # a situation should not be possible with a correct routes definition)
     template_to_render = SUPPORTED_ERRORS.fetch(status_code)
-
-    render template_to_render, status: status_code
+    render template_to_render, status: status_code, format: :html
   end
 
   def test
     fail 'This is an test exception'
+  end
+
+private
+
+  # We always want to render html back. Without this the moj_template gem errors
+  # out trying to find a template of an unknown extension when requesting an
+  # unknown format.
+  def set_html_format
+    request.format = :html
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,12 +3,12 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "02ab7b803c65898228495f502abdf9c6f3e623f025bafec655c1a547ef03dcf3",
+      "fingerprint": "8c390dff3f40970d84fbba866e35c1f62e8ea4629c767e5df706bf873bc39f40",
       "message": "Render path contains parameter value",
       "file": "app/controllers/errors_controller.rb",
-      "line": 19,
+      "line": 20,
       "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => { 404 => :\"404\", 500 => :\"500\", 503 => :\"503\" }.fetch(params.fetch(:status_code).to_i), { :status => params.fetch(:status_code).to_i })",
+      "code": "render(action => { 404 => :\"404\", 406 => :\"404\", 500 => :\"500\", 503 => :\"503\" }.fetch(params.fetch(:status_code).to_i), { :status => params.fetch(:status_code).to_i, :format => :html })",
       "render_path": null,
       "location": {
         "type": "method",
@@ -114,6 +114,6 @@
       "note": ""
     }
   ],
-  "updated": "2016-04-06 17:12:22 +0100",
+  "updated": "2016-04-12 12:56:28 +0100",
   "brakeman_version": "3.1.3"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   get '/', to: redirect(ENV.fetch('GOVUK_START_PAGE', '/en/request'))
 
-  %w[ 404 500 503 ].each do |code|
+  %w[ 404 406 500 503 ].each do |code|
     match code, to: 'errors#show', status_code: code, via: %i[ get post ]
   end
   match 'exception', to: 'errors#test', via: %i[ get post ]

--- a/spec/controllers/booking_requests_controller_spec.rb
+++ b/spec/controllers/booking_requests_controller_spec.rb
@@ -75,6 +75,16 @@ RSpec.describe BookingRequestsController do
     end
   end
 
+  context 'with an unknown format' do
+    subject do
+      lambda {
+        get :index, locale: 'en', format: 'random'
+      }
+    end
+
+    it { is_expected.to raise_error(ActionController::UnknownFormat) }
+  end
+
   context 'passing a hash as the prison_id' do
     before do
       allow(Prison).to receive(:find_by).and_call_original

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ErrorsController do
   render_views
 
-  %w[ 404 500 503 ].each do |status_code|
+  %w[ 404 406 500 503 ].each do |status_code|
     it "renders #{status_code} page with the given status" do
       get :show, status_code: status_code
       expect(response.status).to eq(status_code.to_i)


### PR DESCRIPTION
Requesting a random format will cause Rails to try to search for a template with
a matching file extension. Since the file does not exist it raises a 500.

Adding `respond_to` in an action will only match on the formats specified by the
block. If a request is of an unknown format it raises an
`ActionController::UnknownFormat` which gets translated with a request with an
error code 406.

While this works for these endpoints it doesn't catch all endpoints, for that
there are 2 possible approaches:
  - one is to use the `responders` gem that was extracted from Rails 3 and use
  it on on the ApplicationController
  - change the routes so that they match on the format

I'd leave investigating this solutions until we deploy the public app and cleanup
pvb2.