### PR TITLE
Move query from db view into method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,6 +79,8 @@ Metrics/MethodLength:
   Exclude:
     - 'spec/**/*'
     - 'app/helpers/form_elements_helper.rb'
+    - 'app/metrics/*' # Some very long SQL based methods there.
+
 
 # Don't worry about the complexity of spec methods
 Metrics/AbcSize:

--- a/db/migrate/20160412111212_change_rejection_views_to_empty_tables.rb
+++ b/db/migrate/20160412111212_change_rejection_views_to_empty_tables.rb
@@ -1,0 +1,12 @@
+class ChangeRejectionViewsToEmptyTables < ActiveRecord::Migration
+  def change
+    drop_view :rejection_percentages
+    drop_view :rejection_percentage_by_prisons
+    drop_view :rejection_percentage_by_prison_and_calendar_weeks
+    drop_view :rejection_percentage_by_prison_and_calendar_dates
+    # Dummy tables to replace the views. These allow use of find_by_sql, which
+    # means that we don't have to manually cast the results.
+    create_table :rejection_percentage_by_prisons
+    create_table :rejection_percentage_by_prison_and_calendar_weeks
+  end
+end

--- a/spec/metrics/rejections_spec.rb
+++ b/spec/metrics/rejections_spec.rb
@@ -13,15 +13,6 @@ RSpec.describe Rejections do
     it { expect(Visit.where(processing_state: 'booked').count).to eq(6) }
     it { expect(Visit.where(processing_state: 'rejected').count).to eq(4) }
 
-    describe Rejections::RejectionPercentage do
-      it 'calculates percentages of all rejections' do
-        expect(described_class.fetch_and_format).to eq('no_allowance' => 20.0,
-                                                       'slot_unavailable' => 10.0,
-                                                       'visitor_banned' => 10.0,
-                                                       'total' => 40.0)
-      end
-    end
-
     describe Rejections::RejectionPercentageByPrison do
       before do
         mars_visits_without_dates


### PR DESCRIPTION
The use of database views for the metrics queries was seriously
hampering development.  They make rapid iteration very difficult, it is
easy to miss errors, and testing new versions cannot usually be done
without full migrations.  By pulling them out into methods in metics
classes, everything becomes easier to work with.

Rejections have been one of the more troublesome metrics, so I decided
to start here as a proof-of-concept.  I have also removed a couple of
unusued metrics that got ported from PVB1.