### PR TITLE
Constrain isoweek rejection metrics to the week

### DIFF
--- a/app/metrics/rejections.rb
+++ b/app/metrics/rejections.rb
@@ -80,17 +80,23 @@ FROM (SELECT prisons.name AS prison_name,
       WHERE visits.processing_state = 'rejected'
       GROUP BY prison_name,
              prison_id,
-               year,
-               week
+             year,
+             week
       ) rejected,
      (SELECT prisons.name AS prison_name,
-             count(*) AS total_count
+             count(*) AS total_count,
+             extract(isoyear from visits.created_at)::integer AS total_year,
+             extract(week from visits.created_at)::integer AS total_week
       FROM visits
       INNER JOIN prisons ON prisons.id = visits.prison_id
       GROUP BY prison_name,
-               prison_id
-      ) booked
-WHERE rejected.prison_name = booked.prison_name
+               prison_id,
+               total_year,
+               total_week
+      ) total
+WHERE rejected.prison_name = total.prison_name
+AND year = total_year
+AND week = total_week
 GROUP BY rejected.prison_name,
          reason,
          percentage,
@@ -118,13 +124,19 @@ FROM (SELECT reason,
                week
       ) rejected,
      (SELECT prisons.name AS prison_name,
-             count(*) AS total_count
+             count(*) AS total_count,
+             extract(isoyear from visits.created_at)::integer AS total_year,
+             extract(week from visits.created_at)::integer AS total_week
       FROM visits
       INNER JOIN prisons ON prisons.id = visits.prison_id
       GROUP BY prison_name,
-               prison_id
-      ) booked
-WHERE rejected.prison_name = booked.prison_name
+               prison_id,
+               total_year,
+               total_week
+      ) total
+WHERE rejected.prison_name = total.prison_name
+AND year = total_year
+AND week = total_week
 GROUP BY rejected.prison_name,
          reason,
          percentage,

--- a/spec/metrics/rejections_spec.rb
+++ b/spec/metrics/rejections_spec.rb
@@ -67,6 +67,31 @@ RSpec.describe Rejections do
             }
         }
       end
+
+      context 'when there are visits outside of the date range' do
+        before do
+          travel_to(Time.zone.local(2016, 4, 1)) do
+            create_list(:visit, 10, prison: luna)
+          end
+        end
+
+        it 'the count is not changed for the target week' do
+          expect(described_class.fetch_and_format).to be ==
+            { 'Lunar Penal Colony' =>
+              {
+                2016 =>
+                { 5 =>
+                  {
+                    'no_allowance' => 20.00,
+                    'slot_unavailable' => 10.00,
+                    'visitor_banned' => 10.00,
+                    'total' => 40.00
+                  }
+                }
+              }
+          }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The number on production were skewed because it was dividing the weekly
count of rejections against the total count of visits for all time. This
fixes the problem.