### PR TITLE
Get rid of 404s for favicon

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
 
 <% content_for :head do %>
   <%= csrf_meta_tag %>
+  <%= favicon_link_tag %>
 <% end %>
 
 <% content_for :javascripts do %>


### PR DESCRIPTION
It was setup to be served via the asset pipline in application.rb, but
the tag was missing from the layout and the asset was in public, not in
app/assets/images.