### PR TITLE
Handle zendesk_client not configured

### DIFF
--- a/app/jobs/zendesk_tickets_job.rb
+++ b/app/jobs/zendesk_tickets_job.rb
@@ -8,7 +8,7 @@ class ZendeskTicketsJob < ActiveJob::Base
 
   # rubocop:disable Metrics/MethodLength
   def perform(feedback)
-    unless Rails.configuration.zendesk_client
+    unless Rails.configuration.try(:zendesk_client)
       fail 'Cannot create Zendesk ticket since Zendesk not configured'
     end
 

--- a/spec/jobs/zendesk_tickets_job_spec.rb
+++ b/spec/jobs/zendesk_tickets_job_spec.rb
@@ -14,16 +14,18 @@ RSpec.describe ZendeskTicketsJob, type: :job do
   let(:client) { double(ZendeskAPI::Client) }
   let(:ticket) { double(ZendeskAPI::Ticket, save!: nil) }
 
-  before :each do
+  before do
     Rails.configuration.zendesk_client = client
   end
 
-  it 'raises an error if Zendesk is not configured' do
-    Rails.configuration.zendesk_client = nil
+  context 'Zendesk is not configured' do
+    it 'raises an error if Zendesk is not configured' do
+      allow(Rails).to receive(:configuration).and_return(Class.new)
 
-    expect {
-      subject.perform_now(feedback)
-    }.to raise_error('Cannot create Zendesk ticket since Zendesk not configured')
+      expect {
+        subject.perform_now(feedback)
+      }.to raise_error('Cannot create Zendesk ticket since Zendesk not configured')
+    end
   end
 
   it 'creates a ticket with feedback and custom fields' do


### PR DESCRIPTION
If a Rails configuration is not set, then the method is not defined. Inside the
Zendesk job we check the value of Rails.configuration.zendesk_client, but that
raises a NoMethodError if it does not exist so the code to raise an error is
never executed.