### PR TITLE
Handle unsupported http methods gracefully

### DIFF
--- a/app/middleware/http_method_not_allowed.rb
+++ b/app/middleware/http_method_not_allowed.rb
@@ -1,0 +1,14 @@
+class HttpMethodNotAllowed
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if !env['REQUEST_METHOD'].upcase.in? ActionDispatch::Request::HTTP_METHODS
+      Rails.logger.info("Unknown Http Method: #{env['REQUEST_METHOD']}")
+      [405, { 'Content-Type' => 'text/plain' }, ['Method Not Allowed']]
+    else
+      @app.call(env)
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ require 'action_controller/railtie'
 require 'action_mailer/railtie'
 require 'action_view/railtie'
 require 'sprockets/railtie'
+require_relative '../app/middleware/http_method_not_allowed'
 
 Bundler.require(*Rails.groups)
 
@@ -62,6 +63,9 @@ module PrisonVisits
       ActionDispatch::RemoteIp::TRUSTED_PROXIES + skyscape_proxy_ips
     config.middleware.swap ActionDispatch::RemoteIp,
       ActionDispatch::RemoteIp, true, trusted_proxies
+
+    config.middleware.insert_before ActionDispatch::ParamsParser,
+      HttpMethodNotAllowed
 
     config.sendgrid_api_user = ENV['SMTP_USERNAME']
     config.sendgrid_api_key = ENV['SMTP_PASSWORD']

--- a/spec/middlewares/http_method_not_allowed_spec.rb
+++ b/spec/middlewares/http_method_not_allowed_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe HttpMethodNotAllowed do
+  describe '#call' do
+    let(:env) { { 'REQUEST_METHOD' => request_method } }
+    let(:app) { double('App') }
+    subject { described_class.new(app).call(env) }
+
+    context 'when is an allowed method' do
+      let(:request_method) { 'get' }
+
+      it 'lets the request go through' do
+        expect(app).to receive(:call).with(env)
+        subject
+      end
+    end
+
+    context 'when is not an allowed method' do
+      let(:request_method) { 'webdav' }
+
+      it 'does not let the request go through' do
+        expect(app).to_not receive(:call)
+        subject
+      end
+
+      it 'responds with a 405' do
+        status, env, body = subject
+        expect(status).to eq(405)
+        expect(env).to eq('Content-Type' => 'text/plain')
+        expect(body).to eq(['Method Not Allowed'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Rails raises an error in its middleware if the http method is not supported.
When this causes it notifies Sentry which is just noise as we don't care about
them.