### PR TITLE
Propagate the request id to nomis API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'pg'
 gem 'premailer-rails'
 gem 'puma'
 gem 'redcarpet'
+gem 'request_store'
 gem 'sass-rails', '~> 5.0'
 gem 'scenic', '>= 1.2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,7 @@ GEM
     rake (10.5.0)
     redcarpet (3.3.4)
     redis (3.2.2)
+    request_store (1.3.1)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -355,6 +356,7 @@ DEPENDENCIES
   rails (~> 4.2.3)
   rake (< 11.0)
   redcarpet
+  request_store
   rspec-rails (~> 3.0)
   rubocop
   rubocop-rspec

--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -28,7 +28,8 @@ module Nomis
         path: path,
         expects: [200],
         headers: {
-          'Accept' => 'application/json'
+          'Accept' => 'application/json',
+          'X-Request-Id' => RequestStore.store[:request_id]
         }
       }.deep_merge(params_options(method, params))
 

--- a/spec/services/nomis/api_spec.rb
+++ b/spec/services/nomis/api_spec.rb
@@ -18,6 +18,28 @@ RSpec.describe Nomis::Api do
     }.to raise_error(Nomis::DisabledError, 'Nomis API is disabled')
   end
 
+  describe 'setting a unique request id', vcr: { cassette_name: 'lookup_active_offender' } do
+    let(:params) {
+      {
+        noms_id: 'A1459AE',
+        date_of_birth: Date.parse('1976-06-12')
+      }
+    }
+
+    subject { super().lookup_active_offender(params) }
+
+    before do
+      RequestStore.store[:request_id] = 'uuid'
+    end
+
+    it 'on a header' do
+      subject
+
+      expect(WebMock).to have_requested(:get, /\w/).
+        with(headers: { 'X-Request-Id' => 'uuid' })
+    end
+  end
+
   describe 'lookup_active_offender', vcr: { cassette_name: 'lookup_active_offender' } do
     let(:params) {
       {


### PR DESCRIPTION
Stores the request id coming from X-Request-Id header and uses for request
logging and to pass it through to the Nomis API.