### PR TITLE
Cardiff don't work weekends

### DIFF
--- a/db/seeds/prisons/CFI-cardiff.yml
+++ b/db/seeds/prisons/CFI-cardiff.yml
@@ -14,6 +14,7 @@ translations:
 email_address: socialvisits.cardiff@hmps.gsi.gov.uk
 phone_no: 029 20923327
 enabled: true
+works_weekends: false
 booking_window: 14
 recurring:
   mon:


### PR DESCRIPTION
Attempt to resolve metrics queries - Cardiff believe their stats are setup to include weekends as working days.