### PR TITLE
Correct overdue and waiting counts for all prisons

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,7 +79,7 @@ Metrics/MethodLength:
   Exclude:
     - 'spec/**/*'
     - 'app/helpers/form_elements_helper.rb'
-    - 'app/metrics/*' # Some very long SQL based methods there.
+    - 'app/metrics/**/*' # Some very long SQL based methods there.
 
 
 # Don't worry about the complexity of spec methods

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -81,7 +81,8 @@ private
       counts: week_counts(date),
       overdue_counts: week_overdue_counts(date),
       percentiles: week_percentiles(date),
-      rejections: week_rejections(date)
+      rejections: week_rejections(date),
+      timings: week_timings(date)
     }
   end
 
@@ -96,7 +97,8 @@ private
       counts: Counters::CountVisitsByPrisonAndState.fetch_and_format,
       overdue_counts: Overdue::CountOverdueVisitsByPrison.fetch_and_format,
       percentiles: Percentiles::DistributionByPrison.fetch_and_format,
-      rejections: Rejections::RejectionPercentageByPrison.fetch_and_format
+      rejections: Rejections::RejectionPercentageByPrison.fetch_and_format,
+      timings: Timings::TimelyAndOverdue.fetch_and_format
     }
   end
 

--- a/app/metrics/metrics_presenter.rb
+++ b/app/metrics/metrics_presenter.rb
@@ -1,9 +1,10 @@
 class MetricsPresenter
-  def initialize(counts:, overdue_counts:, percentiles:, rejections:)
+  def initialize(counts:, overdue_counts:, percentiles:, rejections:, timings:)
     @counts = counts
     @overdue_counts = overdue_counts
     @percentiles = percentiles
     @rejections = rejections
+    @timings = timings
     @summaries = {}
   end
 
@@ -16,7 +17,7 @@ class MetricsPresenter
   end
 
   def overdue_count(prison_name)
-    summary_for(prison_name).overdue_count
+    summary_for(prison_name).processed_overdue
   end
 
   def end_to_end_percentile(prison_name, percentile)
@@ -36,10 +37,12 @@ class MetricsPresenter
     overdue_count = @overdue_counts[prison_name]
     percentiles = @percentiles[prison_name]
     rejections = @rejections[prison_name]
+    timings = @timings[prison_name]
 
     PrisonSummaryMetricsPresenter.new(counts: counts,
                                       overdue_count: overdue_count,
                                       percentiles: percentiles,
-                                      rejections: rejections)
+                                      rejections: rejections,
+                                      timings: timings)
   end
 end

--- a/app/views/metrics/_all_prisons.html.erb
+++ b/app/views/metrics/_all_prisons.html.erb
@@ -31,7 +31,7 @@
         <td class="narrow left-border <%= prison.finder_slug -%>-total">
           <%= dataset.total_visits(prison.name) %>
         </td>
-        <td class="narrow">
+        <td class="narrow <%= prison.finder_slug -%>-waiting">
           <%= dataset.visits_in_state(prison.name, 'requested') %>
         </td>
         <td class="narrow <%= prison.finder_slug -%>-overdue">

--- a/spec/features/metrics_spec.rb
+++ b/spec/features/metrics_spec.rb
@@ -9,22 +9,37 @@ RSpec.feature 'Metrics', js: true do
     # Shared examples are booked within the first week of February, 2106. The
     # controller tracks one week behind the current date.
     let(:date_today) { Time.zone.local(2016, 2, 8) }
-
-    before do
+    let!(:visits) do
       book_a_luna_visit_late
       reject_a_luna_visit_late
       book_a_mars_visit_late
       luna_visit
+    end
 
-      travel_to(date_today) do
-        visit(metrics_path(locale: 'en'))
+    context 'weekly' do
+      before do
+        travel_to(date_today) do
+          visit(metrics_path(locale: 'en'))
+        end
+      end
+
+      it 'has the correct overdue and waiting values' do
+        expect(page).to have_selector('.luna-overdue', text: 2)
+        expect(page).to have_selector('.mars-overdue', text: 1)
+        expect(page).to have_selector('.luna-waiting', text: 1)
       end
     end
 
-    it 'has the correct overdue and waiting values' do
-      expect(page).to have_selector('.luna-overdue', text: 2)
-      expect(page).to have_selector('.mars-overdue', text: 1)
-      expect(page).to have_selector('.luna-waiting', text: 1)
+    context 'all time' do
+      before do
+        visit(metrics_path(locale: 'en', range: 'all_time'))
+      end
+
+      it 'has the correct overdue and waiting values' do
+        expect(page).to have_selector('.luna-overdue', text: 2)
+        expect(page).to have_selector('.mars-overdue', text: 1)
+        expect(page).to have_selector('.luna-waiting', text: 1)
+      end
     end
   end
 

--- a/spec/features/metrics_spec.rb
+++ b/spec/features/metrics_spec.rb
@@ -6,22 +6,25 @@ RSpec.feature 'Metrics', js: true do
 
   context 'overdue' do
     include_examples 'create visits with dates'
+    # Shared examples are booked within the first week of February, 2106. The
+    # controller tracks one week behind the current date.
+    let(:date_today) { Time.zone.local(2016, 2, 8) }
 
     before do
+      book_a_luna_visit_late
+      reject_a_luna_visit_late
+      book_a_mars_visit_late
       luna_visit
-      luna_visit
-      mars_visit
 
-      # Shared examples are booked within the first week of February, 2106. The
-      # controller tracks one week behind the current date.
-      travel_to Time.zone.local(2016, 2, 13) do
+      travel_to(date_today) do
         visit(metrics_path(locale: 'en'))
       end
     end
 
-    it 'has the correct overdue values' do
+    it 'has the correct overdue and waiting values' do
       expect(page).to have_selector('.luna-overdue', text: 2)
       expect(page).to have_selector('.mars-overdue', text: 1)
+      expect(page).to have_selector('.luna-waiting', text: 1)
     end
   end
 

--- a/spec/metrics/metrics_presenter_spec.rb
+++ b/spec/metrics/metrics_presenter_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe MetricsPresenter do
   let(:overdue_counts) { {} }
   let(:percentiles) { {} }
   let(:rejections) { {} }
+  let(:timings) { {} }
   let(:prison_name) { 'Cardiff' }
 
   let(:instance) do
@@ -12,7 +13,8 @@ RSpec.describe MetricsPresenter do
       counts: counts,
       overdue_counts: overdue_counts,
       percentiles: percentiles,
-      rejections: rejections
+      rejections: rejections,
+      timings: timings
     )
   end
 
@@ -44,7 +46,7 @@ RSpec.describe MetricsPresenter do
 
     before do
       allow_any_instance_of(PrisonSummaryMetricsPresenter).
-        to receive(:overdue_count).and_return(2)
+        to receive(:processed_overdue).and_return(2)
     end
 
     it { is_expected.to eq(2) }
@@ -114,6 +116,12 @@ RSpec.describe MetricsPresenter do
         'other' => 'bar'
       }
     end
+    let(:timings) do
+      {
+        name => 'Prison timings',
+        'other' => 'bar'
+      }
+    end
     let(:name) { 'Cardiff' }
 
     subject { instance.build_summary_for(name) }
@@ -121,7 +129,8 @@ RSpec.describe MetricsPresenter do
     before do
       expect(PrisonSummaryMetricsPresenter).to receive(:new).
         with(counts: 'Prison counts', overdue_count: 'Prison overdue count',
-             percentiles: 'Prison percentiles', rejections: 'Prison rejections').
+             percentiles: 'Prison percentiles', rejections: 'Prison rejections',
+             timings: 'Prison timings').
         and_call_original
     end
 


### PR DESCRIPTION
The correct counts are being shown in summary.  However, the index
method uses different logic, which shows the same count for both.  This
changes the overdue count to use the same logic as the summary
count-i.e. that overdue visits are those visits that were
*processed* late.