### PR TITLE
Use staff subdomain for prison urls

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,8 +4,6 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
   config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options =
-    { host: 'localhost', protocol: 'http', port: '3000' }
   config.action_mailer.smtp_settings =
     { address: 'localhost', port: 1025, domain: 'localhost' }
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -9,11 +9,6 @@ Rails.application.configure do
     enable_starttls_auto: true
   }
 
-  service_url = URI.parse(ENV.fetch('SERVICE_URL'))
-  config.action_mailer.default_url_options = {
-    host: service_url.hostname, protocol: service_url.scheme
-  }
-
   config.cache_classes = true
   config.eager_load = true
   config.consider_all_requests_local       = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,8 +10,6 @@ Rails.application.configure do
   config.action_dispatch.show_exceptions = false
   config.active_job.queue_adapter = :test
   config.action_mailer.delivery_method = :test
-  config.action_mailer.default_url_options =
-    { host: 'localhost', protocol: 'https', port: '3000' }
   config.active_support.test_order = :random
   config.active_support.deprecation = :stderr
 

--- a/config/initializers/mailer_url_configuration.rb
+++ b/config/initializers/mailer_url_configuration.rb
@@ -1,0 +1,15 @@
+configurator = lambda do |mailer_klass, env_name|
+  local_url_value = 'http://localhost:3000'
+  url_value = Rails.env.production? ? ENV.fetch(env_name) : local_url_value
+
+  service_url = URI.parse(url_value)
+
+  mailer_klass.default_url_options = {
+    protocol: service_url.scheme,
+    host: service_url.hostname,
+    port: service_url.port
+  }
+end
+
+configurator.call(PrisonMailer, 'STAFF_SERVICE_URL')
+configurator.call(VisitorMailer, 'PUBLIC_SERVICE_URL')


### PR DESCRIPTION
We want staff emails to use a subdomain so that requests can be routed to the
pvb2, without this they'd be routed to the public app once deployed.