### PR TITLE
Fix ZendeskErrors due to stricter email validation

### DIFF
--- a/app/models/feedback_submission.rb
+++ b/app/models/feedback_submission.rb
@@ -11,8 +11,13 @@ private
   end
 
   def email_format
-    Mail::Address.new(email_address)
-  rescue Mail::Field::ParseError
-    errors.add(:email_address, 'has incorrect format')
+    return if email_address.blank?
+
+    # true overrides sendgrid validations
+    email_checker = EmailChecker.new(email_address, true)
+
+    unless email_checker.valid?
+      errors.add(:email_address, 'has incorrect format')
+    end
   end
 end

--- a/spec/models/feedback_submission_spec.rb
+++ b/spec/models/feedback_submission_spec.rb
@@ -19,16 +19,30 @@ RSpec.describe FeedbackSubmission do
         expect(subject.errors).not_to have_key(:email_address)
       end
 
-      it 'is valid when reasonable' do
-        subject.email_address = 'user@test.example.com'
-        subject.validate
-        expect(subject.errors).not_to have_key(:email_address)
+      context 'when the email checker returns true' do
+        before do
+          allow_any_instance_of(EmailChecker).
+            to receive(:valid?).and_return(true)
+        end
+
+        it 'is valid' do
+          subject.email_address = 'user@test.example.com'
+          subject.validate
+          expect(subject.errors).not_to have_key(:email_address)
+        end
       end
 
-      it 'is invalid when not an email address' do
-        subject.email_address = 'BOGUS !'
-        subject.validate
-        expect(subject.errors).to have_key(:email_address)
+      context 'when the email checker returns false' do
+        before do
+          allow_any_instance_of(EmailChecker).
+            to receive(:valid?).and_return(false)
+        end
+
+        it 'is invalid when not an email address' do
+          subject.email_address = 'BOGUS !'
+          subject.validate
+          expect(subject.errors).to have_key(:email_address)
+        end
       end
     end
   end


### PR DESCRIPTION
Zendesk has stricter email validations than just trying to parse the email
(a recent change for pvb-public). This re-introduces email checker, but without
using Sendgrid for validations.

I spent a good time trying to extend EmailChecker to be better at detecting
formatting errors, or only formatting errors (without MX checks or Sendgrid) but
it became a rabbit hole in terms of design and complexity of validating properly
the format of an email address and domain part.

At the end I decided to stick with the current formatting checks and MX
validation as is a more incremental change. In the future we could look at
improving the validation by validating the domain format.