### PR TITLE
Renable the 'staff' subdomain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM ministryofjustice/ruby:2.3.0-webapp-onbuild
 ENV UNICORN_PORT 3000
 EXPOSE $UNICORN_PORT
 
-RUN RAILS_ENV=production SERVICE_URL=foo bundle exec rake assets:precompile --trace
+RUN RAILS_ENV=production PUBLIC_SERVICE_URL=foo STAFF_SERVICE_URL=foo bundle exec rake assets:precompile --trace
 
 ENTRYPOINT ["./run.sh"]

--- a/README.md
+++ b/README.md
@@ -244,10 +244,15 @@ Make sure the secret is at least 30 characters and all random, no regular words
 or you’ll be exposed to dictionary attacks. You can use `rake secret` to
 generate a secure secret key.
 
-#### `SERVICE_URL`
+#### `PUBLIC_SERVICE_URL`
 
-This is used to build links in emails. It must be set in the production
-environment to `https://www.prisonvisits.service.gov.uk/`.
+This is used to build public links in emails. It must be set in the production
+environment to `https://prisonvisits.service.gov.uk/`.
+
+#### `STAFF_SERVICE_URL`
+
+This is used to build staff links in emails. It must be set in the production
+environment to `https://staff.prisonvisits.service.gov.uk/`.
 
 #### `SESSION_SECRET_KEY`
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,8 +4,6 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
   config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.default_url_options =
-    { host: 'localhost', protocol: 'http', port: '3000' }
   config.action_mailer.smtp_settings =
     { address: 'localhost', port: 1025, domain: 'localhost' }
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -9,11 +9,6 @@ Rails.application.configure do
     enable_starttls_auto: true
   }
 
-  service_url = URI.parse(ENV.fetch('SERVICE_URL'))
-  config.action_mailer.default_url_options = {
-    host: service_url.hostname, protocol: service_url.scheme
-  }
-
   config.cache_classes = true
   config.eager_load = true
   config.consider_all_requests_local       = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,8 +10,6 @@ Rails.application.configure do
   config.action_dispatch.show_exceptions = false
   config.active_job.queue_adapter = :test
   config.action_mailer.delivery_method = :test
-  config.action_mailer.default_url_options =
-    { host: 'localhost', protocol: 'https', port: '3000' }
   config.active_support.test_order = :random
   config.active_support.deprecation = :stderr
 

--- a/config/initializers/mailer_url_configuration.rb
+++ b/config/initializers/mailer_url_configuration.rb
@@ -1,0 +1,15 @@
+configurator = lambda do |mailer_klass, env_name|
+  local_url_value = 'http://localhost:3000'
+  url_value = Rails.env.production? ? ENV.fetch(env_name) : local_url_value
+
+  service_url = URI.parse(url_value)
+
+  mailer_klass.default_url_options = {
+    protocol: service_url.scheme,
+    host: service_url.hostname,
+    port: service_url.port
+  }
+end
+
+configurator.call(PrisonMailer, 'STAFF_SERVICE_URL')
+configurator.call(VisitorMailer, 'PUBLIC_SERVICE_URL')


### PR DESCRIPTION
Renable the 'staff' subdomain on staff email urls.

This reverts commit fe2df2830d4d9c45e0f47a0b45655b878bc410e2, reversing
changes made to 7443e3ec4b7014b9ca12dde911362a5f0f53675a.