### PR TITLE
Fix no reply getting set to invalid value

### DIFF
--- a/app/mailers/concerns/no_reply.rb
+++ b/app/mailers/concerns/no_reply.rb
@@ -1,7 +1,0 @@
-module NoReply
-  extend ActiveSupport::Concern
-
-  included do
-    default from: I18n.t('mailer.noreply', domain: smtp_settings[:domain])
-  end
-end

--- a/app/mailers/prison_mailer.rb
+++ b/app/mailers/prison_mailer.rb
@@ -1,6 +1,5 @@
 class PrisonMailer < ActionMailer::Base
   include LogoAttachment
-  include NoReply
   include DateHelper
   add_template_helper DateHelper
   add_template_helper LinksHelper
@@ -16,6 +15,7 @@ class PrisonMailer < ActionMailer::Base
     @visit = visit
 
     mail(
+      from: I18n.t('mailer.noreply', domain: smtp_settings[:domain]),
       to: visit.prison_email_address,
       subject: default_i18n_subject(
         full_name: visit.prisoner_full_name,
@@ -28,6 +28,7 @@ class PrisonMailer < ActionMailer::Base
     @visit = visit
 
     mail(
+      from: I18n.t('mailer.noreply', domain: smtp_settings[:domain]),
       to: visit.prison_email_address,
       subject: default_i18n_subject(prisoner: visit.prisoner_full_name)
     )
@@ -37,6 +38,7 @@ class PrisonMailer < ActionMailer::Base
     @visit = visit
 
     mail(
+      from: I18n.t('mailer.noreply', domain: smtp_settings[:domain]),
       to: visit.prison_email_address,
       subject: default_i18n_subject(prisoner: visit.prisoner_full_name)
     )
@@ -47,16 +49,21 @@ class PrisonMailer < ActionMailer::Base
 
     mark_this_highest_priority
     mail(
+      from: I18n.t('mailer.noreply', domain: smtp_settings[:domain]),
       to: visit.prison_email_address,
-      subject: default_i18n_subject(
-        prisoner: visit.prisoner_full_name,
-        date: format_date_without_year(visit.slot_granted),
-        status: visit.processing_state.upcase
-      )
+      subject: default_i18n_subject(cancelled_attributes(visit))
     )
   end
 
 private
+
+  def cancelled_attributes(visit)
+    {
+      prisoner: visit.prisoner_full_name,
+      date: format_date_without_year(visit.slot_granted),
+      status: visit.processing_state.upcase
+    }
+  end
 
   def smoke_test?
     visit && SmokeTestEmailCheck.new(visit.contact_email_address).matches?

--- a/app/mailers/visitor_mailer.rb
+++ b/app/mailers/visitor_mailer.rb
@@ -1,6 +1,5 @@
 class VisitorMailer < ActionMailer::Base
   include LogoAttachment
-  include NoReply
   include DateHelper
   add_template_helper DateHelper
   add_template_helper LinksHelper
@@ -33,6 +32,7 @@ private
     @visit = visit
 
     mail(
+      from: I18n.t('mailer.noreply', domain: smtp_settings[:domain]),
       to: visit.contact_email_address,
       reply_to: visit.prison_email_address,
       subject: default_i18n_subject(i18n_options)


### PR DESCRIPTION
With the recent change to configure the mailers in the initializer it meant that
the NoReply concern was being lodaded before the translations were available.
The result of this was the the 'from' address was set to a String from I18n
saying there was no translation available.

This branch fixes this by setting the 'from' field at runtime instead.