### PR TITLE
Requesting visitor must be 18

### DIFF
--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -3,7 +3,6 @@ class Prison < ActiveRecord::Base
 
   MAX_VISITORS = 6
   MAX_ADULTS = 3
-  MIN_ADULTS = 1
   REQUESTING_VISITOR_MIN_AGE = 18
 
   has_many :visits, dependent: :destroy
@@ -60,8 +59,6 @@ class Prison < ActiveRecord::Base
 
     if adults > MAX_ADULTS
       target.errors.add field, :too_many_adults, max: MAX_ADULTS, age: adult_age
-    elsif adults < MIN_ADULTS
-      target.errors.add field, :too_few_adults, min: MIN_ADULTS, age: adult_age
     end
   end
 

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -49,7 +49,9 @@ class Prison < ActiveRecord::Base
   end
 
   def validate_visitor_ages_on(target, field, ages)
-    return if ages.blank?
+    # This validation does not apply if there are no visitors
+    return if ages.empty?
+
     adults, _children = ages.partition { |a| adult?(a) }.map(&:length)
     # For simplicity’s sake, this operates on the possibly unsafe assumption
     # that the first visitor is always going to be the requesting visitor.

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -16,8 +16,8 @@ en:
         visitors_step:
           attributes:
             general:
-              requestor_must_be_over_18:
-                The person requesting the visit must be over the age of 18
+              lead_visitor_age:
+                The person requesting the visit must be over the age of %{min}
               too_many_adults:
                 You can book a maximum of %{max} visitors over the age of
                 %{age} on this visit

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -18,8 +18,6 @@ en:
             general:
               requestor_must_be_over_18:
                 The person requesting the visit must be over the age of 18
-              too_few_adults:
-                There must be at least one adult visitor
               too_many_adults:
                 You can book a maximum of %{max} visitors over the age of
                 %{age} on this visit

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -16,6 +16,8 @@ en:
         visitors_step:
           attributes:
             general:
+              requestor_must_be_over_18:
+                The person requesting the visit must be over the age of 18
               too_few_adults:
                 There must be at least one adult visitor
               too_many_adults:

--- a/spec/features/request_a_visit_spec.rb
+++ b/spec/features/request_a_visit_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature 'Booking a visit', js: true do
     enter_visitor_information date_of_birth: Date.new(2014, 11, 30)
     click_button 'Continue'
 
-    expect(page).to have_text('There must be at least one adult visitor')
+    expect(page).to have_text('The person requesting the visit must be over the age of 18')
   end
 
   scenario 'review and edit' do

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe Prison, type: :model do
       end
 
       it 'makes the request invalid' do
-        expect(target.errors).to receive(:add).with('adults', :requestor_must_be_over_18)
+        expect(target.errors).to receive(:add).with('adults', :lead_visitor_age, min: 18)
         subject.validate_visitor_ages_on(target, 'adults', group)
       end
     end
@@ -296,7 +296,7 @@ RSpec.describe Prison, type: :model do
       end
 
       it 'makes the request invalid' do
-        expect(target.errors).not_to receive(:add).with('adults', :requestor_must_be_over_18)
+        expect(target.errors).not_to receive(:add).with('adults', :lead_visitor_age)
         subject.validate_visitor_ages_on(target, 'adults', group)
       end
     end

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Prison, type: :model do
     subject.weekend_processing = false
   end
 
+
   describe 'first_bookable_date' do
     #
     #    Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo
@@ -257,6 +258,48 @@ RSpec.describe Prison, type: :model do
           'cy' => { 'address' => 'XXXXXXX' }
         }
         expect(subject.address).to eq('XXXXXXX')
+      end
+    end
+  end
+
+
+  describe '.validate_visitor_ages_on' do
+    context 'when there aren’t any visitors' do
+      let(:target) { double('target').as_null_object }
+      let(:group) { [] }
+
+      it 'skips the vaildation silently' do
+        expect{
+          subject.validate_visitor_ages_on(target, 'adults', group)
+        }.not_to raise_error
+      end
+    end
+
+    context 'when the visit is requested by someone under 18' do
+      let(:target) { double('target').as_null_object }
+      let(:group) { [12, 15, 18] }
+
+      before do
+        allow(subject).to receive(:adult?).and_return(false, false, true)
+      end
+
+      it 'makes the request invalid' do
+        expect(target.errors).to receive(:add).with('adults', :requestor_must_be_over_18)
+        subject.validate_visitor_ages_on(target, 'adults', group)
+      end
+    end
+
+    context 'when the visit is requested by someone over 18' do
+      let(:target) { double('target').as_null_object }
+      let(:group) { [18, 15, 18] }
+
+      before do
+        allow(subject).to receive(:adult?).and_return(true, false, true)
+      end
+
+      it 'makes the request invalid' do
+        expect(target.errors).not_to receive(:add).with('adults', :requestor_must_be_over_18)
+        subject.validate_visitor_ages_on(target, 'adults', group)
       end
     end
   end

--- a/spec/models/prison_spec.rb
+++ b/spec/models/prison_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Prison, type: :model do
     subject.weekend_processing = false
   end
 
-
   describe 'first_bookable_date' do
     #
     #    Th Fr Sa Su Mo Tu We Th Fr Sa Su Mo
@@ -261,7 +260,6 @@ RSpec.describe Prison, type: :model do
       end
     end
   end
-
 
   describe '.validate_visitor_ages_on' do
     context 'when there aren’t any visitors' do

--- a/spec/models/visitors_step_spec.rb
+++ b/spec/models/visitors_step_spec.rb
@@ -225,25 +225,13 @@ RSpec.describe VisitorsStep do
       end
     end
 
-    it 'is valid if there is one adult visitor' do
-      subject.visitors = [
-        {
-          first_name:  'John',
-          last_name:  'Johnson',
-          date_of_birth:  { day:  '1', month:  '12', year:  '2002' }
-        }
-      ]
-      subject.validate
-      expect(subject.errors).not_to have_key(:general)
-    end
-
     it 'is valid if there are 3 adult and 3 child visitors' do
       subject.visitors = [
         {
           first_name:  'John',
           last_name:  'Johnson',
           date_of_birth:  {
-            day:  '1', month:  '12', year:  '2002' # 13 today
+            day:  '1', month:  '12', year:  '1990' # First visitor > 18
           }
         },
         {
@@ -292,7 +280,7 @@ RSpec.describe VisitorsStep do
           first_name:  'John',
           last_name:  'Johnson',
           date_of_birth:  {
-            day:  '1', month:  '12', year:  '2002' # 13 today
+            day:  '1', month:  '12', year:  '1970'
           }
         },
         {
@@ -356,7 +344,7 @@ RSpec.describe VisitorsStep do
       ]
       subject.validate
       expect(subject.errors[:general]).to include(
-        'There must be at least one adult visitor'
+        'The person requesting the visit must be over the age of 18'
       )
     end
   end


### PR DESCRIPTION
The 'lead visitor' (i.e. the visitor making the request) must be over 18
years of age, even if the prison has a lower threshold for 'adult_age'.