### PR TITLE
Change date and name formatting for prisons

### DIFF
--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -35,7 +35,7 @@ module DateHelper
   def format_slot_for_staff(slot)
     I18n.t(
       'formats.slot.staff',
-      date: format_date_without_year(slot.begin_at.to_date),
+      date: slot.begin_at.to_date.to_s(:nomis),
       begin: format_time_24hr(slot.begin_at),
       end: format_time_24hr(slot.end_at)
     )

--- a/app/models/booking_response.rb
+++ b/app/models/booking_response.rb
@@ -37,6 +37,7 @@ class BookingResponse
 
   delegate :slots, :prison, :to_param,
     :prisoner_full_name, :prisoner_number, :prisoner_date_of_birth,
+    :prisoner_first_name, :prisoner_last_name,
     :contact_email_address, :contact_phone_no,
     :visitors,
     :processable?, :processing_state_name,

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -54,8 +54,8 @@ class Visit < ActiveRecord::Base
     end
   end
 
-  delegate :age, :full_name, :anonymized_name, :number, :date_of_birth,
-    to: :prisoner, prefix: true
+  delegate :age, :first_name, :last_name, :full_name, :anonymized_name,
+    :number, :date_of_birth, to: :prisoner, prefix: true
 
   delegate :first_name, :last_name, :full_name, :anonymized_name,
     to: :principal_visitor, prefix: :visitor

--- a/app/views/prison/visits/_people_box.html.erb
+++ b/app/views/prison/visits/_people_box.html.erb
@@ -1,27 +1,33 @@
 <div class="people">
   <dl class="labels">
-    <dt><%= t('.prisoner') %></dt>
-    <dd><%= @booking_response.prisoner_full_name %></dd>
+    <dt><%= t('.prisoner_first_name') %></dt>
+    <dd><%= @booking_response.prisoner_first_name %></dd>
+
+    <dt><%= t('.prisoner_last_name') %></dt>
+    <dd><%= @booking_response.prisoner_last_name %></dd>
 
     <dt><%= t('.number') %></dt>
     <dd><%= @booking_response.prisoner_number %></dd>
 
     <dt><%= t('.date_of_birth') %></dt>
-    <dd><%= format_date_of_birth(@booking_response.prisoner_date_of_birth) %></dd>
+    <dd><%= @booking_response.prisoner_date_of_birth.to_s(:nomis) %></dd>
   </dl>
 
   <hr/>
 
   <% @booking_response.visitors.each_with_index do |visitor, index| %>
     <dl class="labels">
-      <dt><%= t('.visitor', n: index + 1) %></dt>
-      <dd><%= visitor.full_name %></dd>
+      <dt><%= t('.visitor_first_name', n: index + 1) %></dt>
+      <dd><%= visitor.first_name %></dd>
+
+      <dt><%= t('.visitor_last_name', n: index + 1) %></dt>
+      <dd><%= visitor.last_name %></dd>
 
       <dt><%= t('.age') %></dt>
       <dd><%= visitor.age %></dd>
 
       <dt><%= t('.date_of_birth') %></dt>
-      <dd><%= format_date_of_birth(visitor.date_of_birth) %></dd>
+      <dd><%= visitor.date_of_birth.to_s(:nomis) %></dd>
 
       <% if index.zero? %>
         <dt><%= t('.email_address') %></dt>

--- a/app/views/prison_mailer/request_received.html.erb
+++ b/app/views/prison_mailer/request_received.html.erb
@@ -1,12 +1,17 @@
 <p>
   <%= t('.prisoner') %>
-  <strong><%= @visit.prisoner_full_name %></strong>
+  <br/>
+  <%= t('.first_name') %>
+  <strong><%= @visit.prisoner_first_name %></strong>
+  <br/>
+  <%= t('.last_name') %>
+  <strong><%= @visit.prisoner_last_name %></strong>
   <br/>
   <%= t('.number') %>
   <strong><%= @visit.prisoner_number %></strong>
   <br/>
   <%= t('.date_of_birth') %>
-  <strong><%= format_date_of_birth(@visit.prisoner_date_of_birth) %></strong>
+  <strong><%= @visit.prisoner_date_of_birth.to_s(:nomis) %></strong>
 </p>
 
 <p>
@@ -21,8 +26,12 @@
 <% @visit.visitors.each_with_index do |visitor, index| %>
   <p>
     <%= t('.visitor', n: index + 1) %>
-
-    <strong><%= visitor.full_name %></strong>
+    <br/>
+    <%= t('.first_name') %>
+    <strong><%= visitor.first_name %></strong>
+    <br/>
+    <%= t('.last_name') %>
+    <strong><%= visitor.last_name %></strong>
     <br/>
 
     <%= t('.age') %>
@@ -30,7 +39,7 @@
     <br/>
 
     <%= t('.date_of_birth') %>
-    <strong><%= format_date_of_birth(visitor.date_of_birth) %></strong>
+    <strong><%= visitor.date_of_birth.to_s(:nomis) %></strong>
 
     <% if index.zero? %>
       <br/>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,2 @@
+# The format used in Nomis, allows staff to copy / paste
+Date::DATE_FORMATS[:nomis] = '%d/%m/%Y'

--- a/config/locales/en/prison_mailer.yml
+++ b/config/locales/en/prison_mailer.yml
@@ -3,6 +3,8 @@ en:
     request_received:
       subject: "Visit request for %{full_name} on %{request_date}"
       prisoner: "Prisoner:"
+      first_name: "First name:"
+      last_name: "Last name:"
       number: "Number:"
       date_of_birth: "Date of birth:"
       choice: "Choice %{n}:"

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -29,10 +29,12 @@ en:
         rejected: This request has already been rejected
         withdrawn: The visitor has withdrawn this request
       people_box:
-        prisoner: "Prisoner:"
+        prisoner: "Prisoner first name:"
+        prisoner: "Prisoner last name:"
         number: "Number:"
         date_of_birth: "Date of birth:"
-        visitor: "Visitor %{n}:"
+        visitor_first_name: "Visitor %{n} (first name):"
+        visitor_last_name: "Visitor %{n} (last name):"
         age: "Age:"
         email_address: "Email:"
         phone_no: "Phone:"

--- a/spec/features/request_a_visit_spec.rb
+++ b/spec/features/request_a_visit_spec.rb
@@ -33,7 +33,8 @@ RSpec.feature 'Booking a visit', js: true do
     expect(prison.email_address).
       to receive_email.
       with_subject(/\AVisit request for Oscar Wilde on \w+ \d+ \w+\z/).
-      and_body(/Prisoner:\s*Oscar Wilde/)
+      and_body(/First name: Oscar/).
+      and_body(/Last name: Wilde/)
     expect(visitor_email.strip).
       to receive_email.
       with_subject(/we’ve received your visit request for \w+ \d+ \w+\z/).

--- a/spec/helpers/date_helper_spec.rb
+++ b/spec/helpers/date_helper_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe DateHelper do
 
     it 'displays the date and the time of a slot' do
       expect(helper.format_slot_for_staff(slot)).
-        to eq('Thursday 5 November 13:30 - 14:45')
+        to eq('05/11/2015 13:30 - 14:45')
     end
   end
 end


### PR DESCRIPTION
Changes dates to the same as used in nomis (dd/mm/yyyy) so that staff can copy
and paste.

Also changes the way that names are serialised to make it clear what is the
first name and last name.