### PR TITLE
Set the puma threads max to be the db pool size

### DIFF
--- a/config/puma_prod.rb
+++ b/config/puma_prod.rb
@@ -1,0 +1,4 @@
+require 'yaml'
+db_pool = YAML.load_file('config/database.yml')['production']['pool']
+
+threads 0, db_pool

--- a/run.sh
+++ b/run.sh
@@ -11,5 +11,5 @@ migrate_and_seed)
     bundle exec rake db:migrate db:seed
     ;;
 esac
-bundle exec rails server -d --binding 0.0.0.0
+bundle exec puma -b tcp://0.0.0.0:3000 -d -C config/puma_prod.rb
 tail -f /usr/src/app/log/logstash_production.json


### PR DESCRIPTION
Fixes an issue where Puma can accept a request but error out because the DB pool
times out. This happened a couple of months ago when the Sendgrid API started
becoming unresponsive and we didn't have a pool of Sendgrid clients.

The fix prevents the puma and DB pools be out of sync by using the same source
for the max number of threads

This is similar to how Rails 5 will be configured by default with Puma [1].
Although with Rails 5 Puma can be configured via the command line with `rails s`
so we can revisit this when we upgrade.

[1] https://blog.heroku.com/archives/2016/5/2/container_ready_rails_5