### PR TITLE
Set NOMIS API timeouts to 1s

### DIFF
--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -2,9 +2,17 @@ require 'excon'
 
 module Nomis
   class Client
+    TIMEOUT = 1 # seconds
+
     def initialize(host)
       @host = host
-      @connection = Excon.new(host, persistent: true)
+      @connection = Excon.new(
+        host,
+        persistent: true,
+        connect_timeout: TIMEOUT,
+        read_timeout: TIMEOUT,
+        write_timeout: TIMEOUT
+      )
     end
 
     def get(route, params = {})


### PR DESCRIPTION
This will need tweaking when we get real data on the expected latency of the production system.

This allows us to leave the development NOMIS connection configured when developing locally even when not on the internal network, and to exercise the failure path.