### PR TITLE
Show an error page for authenticity errors

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,6 +2,7 @@ class ErrorsController < ApplicationController
   SUPPORTED_ERRORS = {
     404 => :'404',
     406 => :'404',
+    422 => :'503', # Invalid Authenticity Token
     500 => :'500',
     503 => :'503'
   }

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ErrorsController do
   render_views
 
-  %w[ 404 406 500 503 ].each do |status_code|
+  %w[ 404 406 422 500 503 ].each do |status_code|
     it "renders #{status_code} page with the given status" do
       allow(controller).
         to receive(:env).and_return('PATH_INFO' => "/#{status_code}")


### PR DESCRIPTION
Rails treats authenticity errors as a 422, we have no template for a 422, if
this happen it most likely mean an error on this side, so I've chosen to render
a 503 page.