### PR TITLE
Dashboards routes and controllers

### DIFF
--- a/app/controllers/interface_controller.rb
+++ b/app/controllers/interface_controller.rb
@@ -1,5 +1,0 @@
-class InterfaceController < ApplicationController
-  def index
-    @visit = Visit.all
-  end
-end

--- a/app/controllers/prison/dashboards_controller.rb
+++ b/app/controllers/prison/dashboards_controller.rb
@@ -1,0 +1,11 @@
+class Prison::DashboardsController < ApplicationController
+  before_action :authorize_prison_request
+
+  def index
+    @estates = Estate.order('name asc').all
+  end
+
+  def show
+    @estate = Estate.find_by(finder_slug: params[:estate_id])
+  end
+end

--- a/app/views/prison/dashboards/index.html.erb
+++ b/app/views/prison/dashboards/index.html.erb
@@ -1,0 +1,11 @@
+<% content_for :header do %>
+  <%= t('.title') %>
+<% end %>
+
+<ul>
+<% @estates.each do |estate| %>
+  <li>
+    <%= link_to estate.name, prison_estate_dashboard_path(estate.finder_slug) %>
+  </li>
+<% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,11 @@ Rails.application.routes.draw do
 
     namespace :prison do
       resources :visits, only: %i[ show update ]
+
+      scope controller: :dashboards do
+        get '/', action: :index, as: 'dashboards_root'
+        get '/:estate_id', to: :show, as: 'estate_dashboard'
+      end
     end
 
     resources :booking_requests, path: 'request', only: %i[ index create ]
@@ -58,6 +63,4 @@ Rails.application.routes.draw do
 
   get '/staff', to: 'staff_info#index'
   get '/staff/:page', to: 'staff_info#show'
-
-  get '/interface', to: 'interface#index'
 end

--- a/spec/controllers/prison/dashboards_controller_spec.rb
+++ b/spec/controllers/prison/dashboards_controller_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+require_relative '../untrusted_examples'
+
+RSpec.describe Prison::DashboardsController, type: :controller do
+  subject { get :index, locale: 'en' }
+
+  it_behaves_like 'disallows untrusted ips'
+
+  context '#index' do
+    subject { get :index, locale: 'en' }
+
+    it { is_expected.to be_successful }
+  end
+
+  context '#show' do
+    let(:estate) { FactoryGirl.create(:estate) }
+    subject { get :show, estate_id: estate.finder_slug, locale: 'en' }
+
+    it { is_expected.to be_successful }
+  end
+end


### PR DESCRIPTION
Adds an index with links to each estate dashboard, and an empty dashboard.