### PR TITLE
Remove override email domain feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,17 +240,6 @@ address used when submitting feedback without an email address to Zendesk.
 
 This is used to proxy the staff information pages static site.
 
-#### `OVERRIDE_PRISON_EMAIL_DOMAIN`
-
-In order to avoid sending confusing and irrelevant messages to real prisons and
-to facilitate testing, it is possible to send all prison emails to a different
-domain.
-
-If you set `OVERRIDE_PRISON_EMAIL_DOMAIN` to `maildrop.dsd.io` and seed
-prisons, it will create or update all prisons with emails in the format
-`pvb2.(parameterized prison name)@maildrop.dsd.io`. This will ensure that
-staging and other test emails do not accidentally get sent to real prisons.
-
 #### `ZENDESK_USERNAME`, `ZENDESK_TOKEN`, `ZENDESK_URL`
 
 These are required in order to submit user feedback to Zendesk.

--- a/app/services/prison_seeder/seed_entry.rb
+++ b/app/services/prison_seeder/seed_entry.rb
@@ -1,5 +1,4 @@
 class PrisonSeeder::SeedEntry
-  OVERRIDE_KEY = 'OVERRIDE_PRISON_EMAIL_DOMAIN'
   DEFAULT_BOOKING_WINDOW = 28
   DEFAULT_LEAD_DAYS = 3
   DEFAULT_ADULT_AGE = 18
@@ -34,11 +33,7 @@ private
   end
 
   def email_address
-    if ENV.key?(OVERRIDE_KEY)
-      'pvb2.%s@%s' % [name.parameterize, ENV.fetch(OVERRIDE_KEY)]
-    else
-      hash.fetch('email_address', nil)
-    end
+    hash.fetch('email_address', nil)
   end
 
   def enabled

--- a/spec/services/prison_seeder_spec.rb
+++ b/spec/services/prison_seeder_spec.rb
@@ -120,28 +120,10 @@ RSpec.describe PrisonSeeder do
       )
     end
 
-    context 'when no override is specified' do
-      it 'uses the supplied email address' do
-        subject.import filename, hash
-        expect(Prison.find(uuid)).
-          to have_attributes(email_address: 'luna@hmps.gsi.gov.uk')
-      end
-    end
-
-    context 'when an override is specified' do
-      around do |example|
-        ENV['OVERRIDE_PRISON_EMAIL_DOMAIN'] = 'override.example.com'
-        example.run
-        ENV.delete 'OVERRIDE_PRISON_EMAIL_DOMAIN'
-      end
-
-      it 'generates a NOMIS ID-based email address' do
-        subject.import filename, hash
-        expect(Prison.find(uuid)).
-          to have_attributes(
-            email_address: 'pvb2.lunar-penal-colony@override.example.com'
-          )
-      end
+    it 'uses the supplied email address' do
+      subject.import filename, hash
+      expect(Prison.find(uuid)).
+        to have_attributes(email_address: 'luna@hmps.gsi.gov.uk')
     end
   end
 end


### PR DESCRIPTION
This was only used in staging, and is no longer required since we're sending all staging email to a fake SMTP server (mailtrap)