### PR TITLE
Case insensitive prisoner number filtering

### DIFF
--- a/app/controllers/prison/dashboards_controller.rb
+++ b/app/controllers/prison/dashboards_controller.rb
@@ -41,7 +41,7 @@ private
 
     if prisoner_number
       visits = visits.joins(:prisoner).
-               where(prisoners: { number: prisoner_number })
+               where('prisoners.number ILIKE ?', prisoner_number.strip)
     end
 
     visits.to_a


### PR DESCRIPTION
People enter prisoner numbers inconsistently so filtering needs to take into
account this.

Long term solution is to normalise the prisoner numbers before saving them to
the database and to normalise the prisoner number filter value.