### PR TITLE
Set a real noreply email address for prison emails

### DIFF
--- a/app/mailers/prison_mailer.rb
+++ b/app/mailers/prison_mailer.rb
@@ -12,49 +12,42 @@ class PrisonMailer < ActionMailer::Base
 
   def request_received(visit)
     @visit = visit
+    preferred_date = visit.slots.first.begin_at
 
-    mail(
-      from: I18n.t('mailer.noreply', domain: smtp_settings[:domain]),
-      to: visit.prison_email_address,
-      subject: default_i18n_subject(
-        full_name: visit.prisoner_full_name,
-        request_date: format_date_without_year(visit.slots.first.begin_at)
-      )
-    )
+    mail_prison(visit,
+                full_name: visit.prisoner_full_name,
+                request_date: format_date_without_year(preferred_date))
   end
 
   def booked(visit)
     @visit = visit
 
-    mail(
-      from: I18n.t('mailer.noreply', domain: smtp_settings[:domain]),
-      to: visit.prison_email_address,
-      subject: default_i18n_subject(prisoner: visit.prisoner_full_name)
-    )
+    mail_prison(visit, prisoner: visit.prisoner_full_name)
   end
 
   def rejected(visit)
     @visit = visit
 
-    mail(
-      from: I18n.t('mailer.noreply', domain: smtp_settings[:domain]),
-      to: visit.prison_email_address,
-      subject: default_i18n_subject(prisoner: visit.prisoner_full_name)
-    )
+    mail_prison(visit, prisoner: visit.prisoner_full_name)
   end
 
   def cancelled(visit)
     @visit = visit
 
     mark_this_highest_priority
-    mail(
-      from: I18n.t('mailer.noreply', domain: smtp_settings[:domain]),
-      to: visit.prison_email_address,
-      subject: default_i18n_subject(cancelled_attributes(visit))
-    )
+
+    mail_prison(visit, cancelled_attributes(visit))
   end
 
 private
+
+  def mail_prison(visit, i18n_options = {})
+    mail(
+      from: I18n.t('mailer.noreply', domain: smtp_settings[:domain]),
+      to: visit.prison_email_address,
+      subject: default_i18n_subject(i18n_options)
+    )
+  end
 
   def cancelled_attributes(visit)
     {

--- a/app/mailers/prison_mailer.rb
+++ b/app/mailers/prison_mailer.rb
@@ -15,8 +15,8 @@ class PrisonMailer < ActionMailer::Base
     preferred_date = visit.slots.first.begin_at
 
     mail_prison(visit,
-                full_name: visit.prisoner_full_name,
-                request_date: format_date_without_year(preferred_date))
+      full_name: visit.prisoner_full_name,
+      request_date: format_date_without_year(preferred_date))
   end
 
   def booked(visit)
@@ -43,7 +43,7 @@ private
 
   def mail_prison(visit, i18n_options = {})
     mail(
-      from: I18n.t('mailer.noreply', domain: smtp_settings[:domain]),
+      from: I18n.t('mailer.noreply', domain: noreply_domain),
       to: visit.prison_email_address,
       subject: default_i18n_subject(i18n_options)
     )
@@ -63,5 +63,11 @@ private
 
   def set_locale
     I18n.locale = I18n.default_locale
+  end
+
+  # The whitelabel settings in Sendgrid also means that the domain we use to
+  # send emails gets set up to receive emails.
+  def noreply_domain
+    'robot.' + smtp_settings[:domain]
   end
 end

--- a/spec/mailers/prison_mailer/booked_spec.rb
+++ b/spec/mailers/prison_mailer/booked_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe PrisonMailer, '.booked' do
   end
 
   include_examples 'template checks'
+  include_examples 'noreply checks'
 
   it 'sends an email confirming the booking' do
     expect(mail.subject).

--- a/spec/mailers/prison_mailer/cancelled_spec.rb
+++ b/spec/mailers/prison_mailer/cancelled_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe PrisonMailer, '.cancelled' do
   let(:prisoner) {
     create(:prisoner, first_name: 'Arthur', last_name: 'Raffles')
   }
+  let(:visit) { create(:cancelled_visit, prisoner: prisoner, slot_granted: '2015-11-06T16:00/17:00') }
 
   let(:mail) { described_class.cancelled(visit) }
 
@@ -15,8 +16,10 @@ RSpec.describe PrisonMailer, '.cancelled' do
     end
   end
 
+  include_examples 'template checks'
+  include_examples 'noreply checks'
+
   context 'cancelled visit' do
-    let(:visit) { create(:cancelled_visit, prisoner: prisoner, slot_granted: '2015-11-06T16:00/17:00') }
     include_examples 'template checks'
 
     it 'sends an email notifyting the prison of the cancellation' do

--- a/spec/mailers/prison_mailer/rejected_spec.rb
+++ b/spec/mailers/prison_mailer/rejected_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe PrisonMailer, '.rejected' do
   end
 
   include_examples 'template checks'
+  include_examples 'noreply checks'
 
   it 'sends an email reporting the rejection' do
     expect(mail.subject).

--- a/spec/mailers/prison_mailer/request_received_spec.rb
+++ b/spec/mailers/prison_mailer/request_received_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe PrisonMailer, '.request_received' do
   end
 
   include_examples 'template checks'
+  include_examples 'noreply checks'
 
   it 'reports the request' do
     expect(mail.subject).

--- a/spec/mailers/shared_mailer_examples.rb
+++ b/spec/mailers/shared_mailer_examples.rb
@@ -4,3 +4,9 @@ RSpec.shared_examples 'template checks' do
     expect(html).not_to match(/translation missing/)
   end
 end
+
+RSpec.shared_examples 'noreply checks' do
+  it "sets a noreply subdomain for the 'from' header" do
+    expect(mail.from.first).to match(/@robot./)
+  end
+end


### PR DESCRIPTION
Some prisons reply to the emails they get thinking that they get sent to the
visitor, instead get sent to Sendgrid.

This is because with Sendgrid whitelabel settings they set up an MX record that
accepts emails to all inboxes, so emails sent there don't bounce.

This change fixes this with Sendgrid recommended 'solution', which is to send
the email from a fake subdomain from the one used in the whitelabel. This
preserves the whitelabel functionality with the correct anti spam signatures
and make the emails bounce if people reply to them.