### PR TITLE
Serialize visits consistently

### DIFF
--- a/app/controllers/api/visits_controller.rb
+++ b/app/controllers/api/visits_controller.rb
@@ -44,6 +44,8 @@ module Api
       @visit = BookingRequestCreator.new.create!(
         prisoner_step, visitors_step, slots_step, I18n.locale
       )
+
+      render :show
     end
 
     def show
@@ -55,6 +57,8 @@ module Api
       if @visit.can_cancel?
         @visit.cancel!
       end
+
+      render :show
     end
 
   private

--- a/app/views/api/visits/create.json.jbuilder
+++ b/app/views/api/visits/create.json.jbuilder
@@ -1,8 +1,0 @@
-json.visit do
-  json.id @visit.id
-  json.processing_state @visit.processing_state
-  json.prison_id @visit.prison.id
-  json.confirm_by @visit.confirm_by
-  json.contact_email_address @visit.contact_email_address
-  json.slots @visit.slots.map(&:iso8601)
-end

--- a/app/views/api/visits/destroy.json.jbuilder
+++ b/app/views/api/visits/destroy.json.jbuilder
@@ -1,4 +1,0 @@
-json.visit do
-  json.id @visit.id
-  json.processing_state @visit.processing_state
-end

--- a/app/views/api/visits/show.json.jbuilder
+++ b/app/views/api/visits/show.json.jbuilder
@@ -1,4 +1,9 @@
 json.visit do
   json.id @visit.id
   json.processing_state @visit.processing_state
+  json.prison_id @visit.prison.id
+  json.confirm_by @visit.confirm_by
+  json.contact_email_address @visit.contact_email_address
+  json.slots @visit.slots.map(&:iso8601)
+  json.slot_granted @visit.slot_granted&.iso8601
 end

--- a/spec/controllers/api/visits_controller_spec.rb
+++ b/spec/controllers/api/visits_controller_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe Api::VisitsController do
       }
     }
 
+    specify do expect(post :create, params).to render_template(:show) end
+
     it 'creates a new visit booking request' do
       expect { post :create, params }.to change(Visit, :count).by(1)
 
@@ -118,6 +120,8 @@ RSpec.describe Api::VisitsController do
       }
     }
 
+    specify do expect(get :show, params).to render_template(:show) end
+
     it 'returns visit status' do
       get :show, params
       expect(response).to have_http_status(:ok)
@@ -143,6 +147,8 @@ RSpec.describe Api::VisitsController do
     let(:mailing) {
       double(Mail::Message, deliver_later: nil)
     }
+
+    specify do expect(delete :destroy, params).to render_template(:show) end
 
     it 'cancels a visit request' do
       delete :destroy, params


### PR DESCRIPTION
Make the serialisation consistent regardless of the API action. This is needed
so that PVB Public can show more information on the visit show page.