### PR TITLE
Serialize visits consistently

### DIFF
--- a/app/controllers/api/visits_controller.rb
+++ b/app/controllers/api/visits_controller.rb
@@ -44,6 +44,8 @@ module Api
       @visit = BookingRequestCreator.new.create!(
         prisoner_step, visitors_step, slots_step, I18n.locale
       )
+
+      render :show
     end
 
     def show
@@ -55,6 +57,8 @@ module Api
       if @visit.can_cancel?
         @visit.cancel!
       end
+
+      render :show
     end
 
   private

--- a/app/models/visitor.rb
+++ b/app/models/visitor.rb
@@ -9,6 +9,10 @@ class Visitor < ActiveRecord::Base
     order(sort_index: :asc)
   end
 
+  def allowed?
+    !(banned || not_on_list)
+  end
+
   def self.allowed
     where(banned: false, not_on_list: false)
   end

--- a/app/views/api/visits/create.json.jbuilder
+++ b/app/views/api/visits/create.json.jbuilder
@@ -1,8 +1,0 @@
-json.visit do
-  json.id @visit.id
-  json.processing_state @visit.processing_state
-  json.prison_id @visit.prison.id
-  json.confirm_by @visit.confirm_by
-  json.contact_email_address @visit.contact_email_address
-  json.slots @visit.slots.map(&:iso8601)
-end

--- a/app/views/api/visits/destroy.json.jbuilder
+++ b/app/views/api/visits/destroy.json.jbuilder
@@ -1,4 +1,0 @@
-json.visit do
-  json.id @visit.id
-  json.processing_state @visit.processing_state
-end

--- a/app/views/api/visits/show.json.jbuilder
+++ b/app/views/api/visits/show.json.jbuilder
@@ -1,4 +1,14 @@
 json.visit do
   json.id @visit.id
   json.processing_state @visit.processing_state
+  json.prison_id @visit.prison.id
+  json.confirm_by @visit.confirm_by
+  json.contact_email_address @visit.contact_email_address
+  json.slots @visit.slots.map(&:iso8601)
+  json.slot_granted @visit.slot_granted&.iso8601
+
+  json.visitors @visit.visitors do |visitor|
+    json.anonymized_name visitor.anonymized_name
+    json.allowed !visitor.banned && !visitor.not_on_list
+  end
 end

--- a/app/views/api/visits/show.json.jbuilder
+++ b/app/views/api/visits/show.json.jbuilder
@@ -9,6 +9,6 @@ json.visit do
 
   json.visitors @visit.visitors do |visitor|
     json.anonymized_name visitor.anonymized_name
-    json.allowed !visitor.banned && !visitor.not_on_list
+    json.allowed visitor.allowed?
   end
 end

--- a/spec/controllers/api/visits_controller_spec.rb
+++ b/spec/controllers/api/visits_controller_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe Api::VisitsController do
       }
     }
 
+    specify do expect(post :create, params).to render_template(:show) end
+
     it 'creates a new visit booking request' do
       expect { post :create, params }.to change(Visit, :count).by(1)
 
@@ -118,6 +120,8 @@ RSpec.describe Api::VisitsController do
       }
     }
 
+    specify do expect(get :show, params).to render_template(:show) end
+
     it 'returns visit status' do
       get :show, params
       expect(response).to have_http_status(:ok)
@@ -143,6 +147,8 @@ RSpec.describe Api::VisitsController do
     let(:mailing) {
       double(Mail::Message, deliver_later: nil)
     }
+
+    specify do expect(delete :destroy, params).to render_template(:show) end
 
     it 'cancels a visit request' do
       delete :destroy, params

--- a/spec/models/visitor_spec.rb
+++ b/spec/models/visitor_spec.rb
@@ -1,9 +1,41 @@
 require 'rails_helper'
 
 RSpec.describe Visitor do
+  subject(:instance) { described_class.new }
+
   it { is_expected.to belong_to(:visit) }
   it { is_expected.to validate_presence_of(:visit) }
   it { is_expected.to validate_presence_of(:first_name) }
   it { is_expected.to validate_presence_of(:last_name) }
   it { is_expected.to validate_presence_of(:date_of_birth) }
+
+  describe '#allowed?' do
+    subject { instance.allowed? }
+
+    before do
+      instance.not_on_list = not_on_list
+      instance.banned = banned
+    end
+
+    context 'when not banned or is the contact list' do
+      let(:not_on_list) { false }
+      let(:banned) { false }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when banned' do
+      let(:not_on_list) { false }
+      let(:banned) { true }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when not in the contact list' do
+      let(:not_on_list) { true }
+      let(:banned) { false }
+
+      it { is_expected.to eq(false) }
+    end
+  end
 end


### PR DESCRIPTION
Make the serialisation consistent regardless of the API action. This is needed
so that PVB Public can show more information on the visit show page.

It also adds additional fields that Public needs.