### PR TITLE
Visit cancellations by staff

### DIFF
--- a/app/assets/stylesheets/_notification.scss
+++ b/app/assets/stylesheets/_notification.scss
@@ -1,0 +1,4 @@
+.notification {
+  border: 4px solid $button-colour;
+  padding: $gutter-half;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -54,6 +54,7 @@
 @import "helpers";
 @import "moj-overrides";
 @import "navigation";
+@import "notification";
 @import "tag";
 
 // Candidates for re-usable components

--- a/app/controllers/api/visits_controller.rb
+++ b/app/controllers/api/visits_controller.rb
@@ -54,8 +54,8 @@ module Api
 
     def destroy
       @visit = Visit.find(params[:id])
-      if @visit.can_cancel?
-        @visit.cancel!
+      if @visit.can_cancel_or_withdraw?
+        @visit.visitor_cancel_or_withdraw!
       end
 
       render :show

--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -26,6 +26,14 @@ class Prison::VisitsController < ApplicationController
     @estate = @visit.prison.estate
   end
 
+  def cancel
+    if visit.can_cancel?
+      visit.cancel!
+      VisitorMailer.cancelled(visit).deliver_later
+    end
+    redirect_to prison_deprecated_visit_path(visit)
+  end
+
 private
 
   def visit

--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -4,6 +4,10 @@ class Prison::VisitsController < ApplicationController
 
   def process_visit
     @booking_response = BookingResponse.new(visit: visit)
+
+    unless @booking_response.processable?
+      redirect_to prison_deprecated_visit_path(visit)
+    end
   end
 
   def update

--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -6,6 +6,7 @@ class Prison::VisitsController < ApplicationController
     @booking_response = BookingResponse.new(visit: visit)
 
     unless @booking_response.processable?
+      flash[:notice] = t('already_processed', scope: [:prison, :flash])
       redirect_to prison_deprecated_visit_path(visit)
     end
   end
@@ -15,6 +16,7 @@ class Prison::VisitsController < ApplicationController
     if @booking_response.valid?
       @visit = @booking_response.visit
       BookingResponder.new(@booking_response).respond!
+      flash[:notice] = t('process_thank_you', scope: [:prison, :flash])
       redirect_to prison_deprecated_visit_path(@visit)
     else
       render :process_visit
@@ -33,6 +35,9 @@ class Prison::VisitsController < ApplicationController
   def cancel
     if visit.can_cancel?
       visit.staff_cancellation!(params[:cancellation_reason])
+      flash[:notice] = t('visit_cancelled', scope: [:prison, :flash])
+    else
+      flash[:notice] = t('already_cancelled', scope: [:prison, :flash])
     end
     redirect_to prison_deprecated_visit_path(visit)
   end

--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -9,10 +9,16 @@ class Prison::VisitsController < ApplicationController
   def update
     @booking_response = BookingResponse.new(booking_response_params)
     if @booking_response.valid?
+      @visit = @booking_response.visit
       BookingResponder.new(@booking_response).respond!
+      redirect_to prison_deprecated_visit_path(@visit)
     else
       render :process_visit
     end
+  end
+
+  def deprecated_show
+    @visit = visit
   end
 
   def show

--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -28,8 +28,7 @@ class Prison::VisitsController < ApplicationController
 
   def cancel
     if visit.can_cancel?
-      visit.cancel!
-      VisitorMailer.cancelled(visit).deliver_later
+      visit.staff_cancellation!(params[:cancellation_reason])
     end
     redirect_to prison_deprecated_visit_path(visit)
   end

--- a/app/mailers/prison_mailer.rb
+++ b/app/mailers/prison_mailer.rb
@@ -21,6 +21,7 @@ class PrisonMailer < ActionMailer::Base
 
   def booked(visit)
     @visit = visit
+    @override_cancel_link = true
 
     mail_prison(visit, prisoner: visit.prisoner_full_name)
   end

--- a/app/mailers/visitor_mailer.rb
+++ b/app/mailers/visitor_mailer.rb
@@ -25,6 +25,13 @@ class VisitorMailer < ActionMailer::Base
       date: format_date_without_year(visit.first_date)
   end
 
+  def cancelled(visit)
+    I18n.locale = visit.locale
+    mail_visitor visit,
+      prison_name: visit.prison_name,
+      date: format_date_without_year(visit.date)
+  end
+
 private
 
   def mail_visitor(visit, i18n_options = {})

--- a/app/models/cancellation.rb
+++ b/app/models/cancellation.rb
@@ -1,0 +1,10 @@
+class Cancellation < ActiveRecord::Base
+  REASONS = %w[
+    slot_unavailable
+    prisoner_moved
+  ]
+
+  belongs_to :visit
+
+  validates :reason, inclusion: { in: REASONS }
+end

--- a/app/models/cancellation.rb
+++ b/app/models/cancellation.rb
@@ -1,8 +1,12 @@
 class Cancellation < ActiveRecord::Base
-  REASONS = %w[
+  VISITOR_CANCELLED = 'visitor_cancelled'
+
+  STAFF_REASONS = %w[
     slot_unavailable
     prisoner_moved
   ]
+
+  REASONS = STAFF_REASONS + [VISITOR_CANCELLED]
 
   belongs_to :visit
 

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -6,6 +6,7 @@ class Visit < ActiveRecord::Base
   has_many :visitors, dependent: :destroy
   has_many :visit_state_changes, dependent: :destroy
   has_one :rejection, dependent: :destroy
+  has_one :cancellation, dependent: :destroy
 
   validates :prison, :prisoner,
     :contact_email_address, :contact_phone_no, :slot_option_0,
@@ -21,6 +22,7 @@ class Visit < ActiveRecord::Base
   end
 
   delegate :reason, to: :rejection, prefix: true
+  delegate :reason, to: :cancellation, prefix: true
   delegate :privileged_allowance_available?, :privileged_allowance_expires_on,
     :allowance_will_renew?, :allowance_renews_on,
     to: :rejection

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -55,11 +55,7 @@ class Visit < ActiveRecord::Base
   end
 
   def staff_cancellation!(reason)
-    transaction do
-      cancel!
-      Cancellation.create!(visit: self, reason: reason)
-    end
-
+    cancellation!(reason)
     VisitorMailer.cancelled(self).deliver_later
   end
 
@@ -71,7 +67,7 @@ class Visit < ActiveRecord::Base
     fail "Can't cancel or withdraw visit #{id}" unless can_cancel_or_withdraw?
 
     if can_cancel?
-      cancel!
+      cancellation!(Cancellation::VISITOR_CANCELLED)
       PrisonMailer.cancelled(self).deliver_later
       return
     end
@@ -117,5 +113,14 @@ class Visit < ActiveRecord::Base
 
   def unlisted_visitors
     visitors.unlisted
+  end
+
+private
+
+  def cancellation!(reason)
+    transaction do
+      cancel!
+      Cancellation.create!(visit: self, reason: reason)
+    end
   end
 end

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -47,7 +47,6 @@ class Visit < ActiveRecord::Base
 
     event :cancel do
       transition booked: :cancelled
-      transition rejected: :rejected
     end
 
     event :withdraw do

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -53,6 +53,15 @@ class Visit < ActiveRecord::Base
     end
   end
 
+  def staff_cancellation!(reason)
+    transaction do
+      cancel!
+      Cancellation.create!(visit: self, reason: reason)
+    end
+
+    VisitorMailer.cancelled(self).deliver_later
+  end
+
   def can_cancel_or_withdraw?
     can_cancel? || can_withdraw?
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
     </header>
 
     <% if notice.present? %>
-      <p class="validation-summary">
+      <p class="notification">
         <%= notice %>
       </p>
     <% end %>

--- a/app/views/prison/visits/deprecated_show.html.erb
+++ b/app/views/prison/visits/deprecated_show.html.erb
@@ -12,7 +12,7 @@
   <div class='grid-row'>
     <div class='column-one-half'>
       <%= form_tag prison_cancel_visit_path(@visit, locale: 'en'), method: :delete, class: 'form' do -%>
-        <% Cancellation::REASONS.each_with_index do |reason, index| %>
+        <% Cancellation::STAFF_REASONS.each_with_index do |reason, index| %>
           <label>
             <%= radio_button_tag 'cancellation_reason', reason, index.zero? %>
             <%= t(".#{reason}") %>

--- a/app/views/prison/visits/deprecated_show.html.erb
+++ b/app/views/prison/visits/deprecated_show.html.erb
@@ -7,18 +7,20 @@
 </p>
 
 <% if @visit.can_cancel? %>
-  <h2><%= t('.cancel_title') %></h2>
+  <h2 class="heading-medium"><%= t('.cancel_title') %></h2>
   <p><%= t('.cancel_description') %></p>
   <div class='grid-row'>
     <div class='column-one-half'>
       <%= form_tag prison_cancel_visit_path(@visit, locale: 'en'), method: :delete, class: 'form' do -%>
-        <% Cancellation::STAFF_REASONS.each_with_index do |reason, index| %>
-          <label>
-            <%= radio_button_tag 'cancellation_reason', reason, index.zero? %>
-            <%= t(".#{reason}") %>
-          </label>
-          <br/>
-        <% end %>
+        <fieldset>
+          <% Cancellation::STAFF_REASONS.each_with_index do |reason, index| %>
+            <label class="block-label" for="cancellation_reason_<%= reason %>">
+              <%= radio_button_tag 'cancellation_reason', reason, index.zero? %>
+              <%= t(".#{reason}") %>
+            </label>
+            <br/>
+          <% end %>
+        </fieldset>
         <div class='form-group'>
           <%= submit_tag t('.cancel_button'), class: 'button' %>
         </div>

--- a/app/views/prison/visits/deprecated_show.html.erb
+++ b/app/views/prison/visits/deprecated_show.html.erb
@@ -5,3 +5,17 @@
 <p>
   <%= t(".#{@visit.processing_state}") %>
 </p>
+
+<% if @visit.can_cancel? %>
+  <h2><%= t('.cancel_title') %></h2>
+  <p><%= t('.cancel_description') %></p>
+  <div class='grid-row'>
+    <div class='column-one-half'>
+      <%= form_tag prison_cancel_visit_path(@visit, locale: 'en'), method: :delete, class: 'form' do -%>
+        <div class='form-group'>
+          <%= submit_tag t('.cancel_button'), class: 'button' %>
+        </div>
+      <% end -%>
+    </div>
+  </div>
+<% end %>

--- a/app/views/prison/visits/deprecated_show.html.erb
+++ b/app/views/prison/visits/deprecated_show.html.erb
@@ -3,7 +3,14 @@
 <% end %>
 
 <p>
-  <%= t(".#{@visit.processing_state}") %>
+  <% case @visit.processing_state %>
+  <% when 'cancelled' %>
+    <%= t(".#{@visit.processing_state}",
+      date: format_date_without_year(@visit.date),
+      prisoner: @visit.prisoner_full_name) %>
+  <% else %>
+    <%= t(".#{@visit.processing_state}") %>
+  <% end %>
 </p>
 
 <% if @visit.can_cancel? %>

--- a/app/views/prison/visits/deprecated_show.html.erb
+++ b/app/views/prison/visits/deprecated_show.html.erb
@@ -3,5 +3,5 @@
 <% end %>
 
 <p>
-  <%= t(".#{@booking_response.processing_state_name}") %>
+  <%= t(".#{@visit.processing_state}") %>
 </p>

--- a/app/views/prison/visits/deprecated_show.html.erb
+++ b/app/views/prison/visits/deprecated_show.html.erb
@@ -12,6 +12,13 @@
   <div class='grid-row'>
     <div class='column-one-half'>
       <%= form_tag prison_cancel_visit_path(@visit, locale: 'en'), method: :delete, class: 'form' do -%>
+        <% Cancellation::REASONS.each_with_index do |reason, index| %>
+          <label>
+            <%= radio_button_tag 'cancellation_reason', reason, index.zero? %>
+            <%= t(".#{reason}") %>
+          </label>
+          <br/>
+        <% end %>
         <div class='form-group'>
           <%= submit_tag t('.cancel_button'), class: 'button' %>
         </div>

--- a/app/views/prison/visits/process_visit.html.erb
+++ b/app/views/prison/visits/process_visit.html.erb
@@ -4,29 +4,25 @@
 
 <%= render('people_box') %>
 
-<% if @booking_response.processable? %>
-  <div class="processing-form confirmations">
-    <%= t('.introduction_html') %>
-    <%=
-      form_for(
-        @booking_response,
-        url: prison_visit_path(@booking_response),
-        method: :put,
-        html: { class: 'js-SubmitOnce' }
-      ) do |f|
-    %>
-      <%= render('visit_date_section', f: f) %>
-      <%= render('visiting_allowance_section', f: f) %>
-      <%= render('issue_with_prisoner_section', f: f) %>
-      <%= render('issue_with_visitors_section', f: f) %>
+<div class="processing-form confirmations">
+  <%= t('.introduction_html') %>
+  <%=
+    form_for(
+      @booking_response,
+      url: prison_visit_path(@booking_response),
+      method: :put,
+      html: { class: 'js-SubmitOnce' }
+    ) do |f|
+  %>
+<%= render('visit_date_section', f: f) %>
+<%= render('visiting_allowance_section', f: f) %>
+<%= render('issue_with_prisoner_section', f: f) %>
+<%= render('issue_with_visitors_section', f: f) %>
 
-      <div class="actions">
-        <div class="primary-actions">
-          <%= f.submit(t('.submit'), class: 'button button-primary') %>
-        </div>
-      </div>
-    <% end %>
+<div class="actions">
+  <div class="primary-actions">
+    <%= f.submit(t('.submit'), class: 'button button-primary') %>
   </div>
-<% else %>
-  <h2><%= t(".#{@booking_response.processing_state_name}") %></h2>
-<% end %>
+</div>
+    <% end %>
+</div>

--- a/app/views/visitor_mailer/booked.html.erb
+++ b/app/views/visitor_mailer/booked.html.erb
@@ -49,7 +49,11 @@
 <h2><%= t('.cancel_change_title') %></h2>
 
 <p>
-  <%= t('.cancel_html', url: link_directory.visit_status(@visit, locale: I18n.locale)) %>
+  <% if @override_cancel_link %>
+    <%= t('.cancel_html', url: prison_deprecated_visit_url(@visit, locale: I18n.locale)) %>
+  <% else %>
+    <%= t('.cancel_html', url: link_directory.visit_status(@visit, locale: I18n.locale)) %>
+  <% end %>
 </p>
 
 <p><%= t(".want_to_change") %></p>

--- a/app/views/visitor_mailer/cancelled.html.erb
+++ b/app/views/visitor_mailer/cancelled.html.erb
@@ -1,0 +1,11 @@
+<p><%= t('.salutation', name: @visit.visitor_first_name) %></p>
+
+<p><%= t('.details') %></p>
+
+<p><%= t('.any_questions_html',
+         url: link_directory.prison_finder(@visit.prison),
+         phone_no: @visit.prison_phone_no) %></p>
+
+<p>
+  <small><%= t('.visit_id') %> <%= @visit.id %></small>
+</p>

--- a/app/views/visitor_mailer/cancelled.html.erb
+++ b/app/views/visitor_mailer/cancelled.html.erb
@@ -1,6 +1,14 @@
 <p><%= t('.salutation', name: @visit.visitor_first_name) %></p>
 
-<p><%= t('.details') %></p>
+<% case @visit.cancellation_reason %>
+<% when 'slot_unavailable' %>
+  <p><%= t('.slot_unavailable_html',
+           prisoner: @visit.prisoner_full_name,
+           prison: @visit.prison_name,
+           date: format_date_without_year(@visit.date)) %>
+<% when 'prisoner_moved' %>
+  <p><%= t('prisoner_moved_html', scope: [:visitor_mailer, :rejected]) %></p>
+<% end %>
 
 <p><%= t('.any_questions_html',
          url: link_directory.prison_finder(@visit.prison),

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -164,3 +164,13 @@ en:
         <a href="http://www.surveygizmo.com/s3/2527768/?q=%{prison}">quick survey</a>.
       survey_thanks:
         Thanks for your help.
+    cancelled:
+      subject: "CANCELLED: Your %{prison_name} prison visit for %{date}"
+      salutation: Dear %{name},
+      details: Your visit can't no longer take place, apologies.
+      any_questions_html:
+        If you have any questions, visit the
+        <a href="%{url}">prison website</a> or call the prison on
+        <strong>%{phone_no}</strong>.
+      visit_id: "Visit ID:"
+

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -167,7 +167,10 @@ en:
     cancelled:
       subject: "CANCELLED: Your %{prison_name} prison visit for %{date}"
       salutation: Dear %{name},
-      details: Your visit can't no longer take place, apologies.
+      slot_unavailable_html: >-
+        We’re sorry but your visit on %{date} to visit
+        <strong>%{prisoner}</strong> at <strong>%{prison}</strong>
+        is no longer available for visits.
       any_questions_html:
         If you have any questions, visit the
         <a href="%{url}">prison website</a> or call the prison on

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -168,9 +168,9 @@ en:
       subject: "CANCELLED: Your %{prison_name} prison visit for %{date}"
       salutation: Dear %{name},
       slot_unavailable_html: >-
-        We’re sorry but your visit on %{date} to visit
-        <strong>%{prisoner}</strong> at <strong>%{prison}</strong>
-        is no longer available for visits.
+        We’re sorry but %{date} is no longer available.
+        Your visit to %{prisoner} at %{prison} has been cancelled.
+
       any_questions_html:
         If you have any questions, visit the
         <a href="%{url}">prison website</a> or call the prison on

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -27,7 +27,7 @@ en:
     visits:
       calendar:
         today: Today
-      update:
+      deprecated_show:
         title: Thank you
         booked: A confirmation email has been sent to the visitor.
         rejected: A rejection email has been sent to the visitor.

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -37,7 +37,7 @@ en:
         booked: This request has been accepted, a confirmation email has been sent to the visitor.
         rejected: This request has been rejected, a rejection email has been sent to the visitor.
         withdrawn: The visitor has withdrawn this request.
-        cancelled: The visit has been cancelled.
+        cancelled: The visit on %{date} to %{prisoner} is cancelled.
         cancel_title: Cancel this visit
         cancel_description: If this visit can't no longer take place, you can cancel it. This will email the visitor to let them know.
         cancel_button: Cancel visit

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -28,9 +28,11 @@ en:
       calendar:
         today: Today
       deprecated_show:
-        title: Thank you
-        booked: A confirmation email has been sent to the visitor.
-        rejected: A rejection email has been sent to the visitor.
+        title: Visit details
+        booked: This request has been accepted, a confirmation email has been sent to the visitor.
+        rejected: This request has been rejected, a rejection email has been sent to the visitor.
+        withdrawn: The visitor has withdrawn this request.
+        cancelled: The visit has been cancelled.
         cancel_title: Cancel this visit
         cancel_description: If this visit can't no longer take place, you can cancel it. This will email the visitor to let them know.
         cancel_button: Cancel visit
@@ -53,10 +55,6 @@ en:
             </li>
           </ul>
         submit: Send email
-        booked: This request has already been accepted
-        cancelled: The visitor has cancelled this booking
-        rejected: This request has already been rejected
-        withdrawn: The visitor has withdrawn this request
       people_box:
         prisoner: "Prisoner first name:"
         prisoner: "Prisoner last name:"

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -34,6 +34,8 @@ en:
         cancel_title: Cancel this visit
         cancel_description: If this visit can't no longer take place, you can cancel it. This will email the visitor to let them know.
         cancel_button: Cancel visit
+        slot_unavailable: The date is no longer available.
+        prisoner_moved: The prisoner has moved.
       process_visit:
         title: Process a visit request
         introduction_html: |

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -1,5 +1,10 @@
 en:
   prison:
+    flash:
+      already_processed: The visit has already been processed
+      process_thank_you: Thank you for processing the visit
+      visit_cancelled: The visit has been cancelled
+      already_cancelled: The visit is no longer cancellable
     dashboards:
       navigation:
         requested: Requested visits

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -31,6 +31,9 @@ en:
         title: Thank you
         booked: A confirmation email has been sent to the visitor.
         rejected: A rejection email has been sent to the visitor.
+        cancel_title: Cancel this visit
+        cancel_description: If this visit can't no longer take place, you can cancel it. This will email the visitor to let them know.
+        cancel_button: Cancel visit
       process_visit:
         title: Process a visit request
         introduction_html: |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
         get '/visits/deprecated/:id',
           action: :deprecated_show,
           as: :deprecated_visit
+        delete '/visits/:id', action: :cancel, as: :cancel_visit
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,9 @@ Rails.application.routes.draw do
       scope controller: :visits do
         get '/visits/:id', action: :process_visit, as: :visit_process
         put '/visits/:id', action: :update, as: :visit
+        get '/visits/deprecated/:id',
+          action: :deprecated_show,
+          as: :deprecated_visit
       end
     end
   end

--- a/db/migrate/20160603081312_add_cancellations.rb
+++ b/db/migrate/20160603081312_add_cancellations.rb
@@ -1,0 +1,12 @@
+class AddCancellations < ActiveRecord::Migration
+  def change
+    create_table :cancellations, id: :uuid do |t|
+      t.uuid :visit_id, null: false
+      t.string :reason, null: false
+      t.timestamps
+    end
+
+    add_foreign_key :cancellations, :visits
+    add_index :cancellations, :visit_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,11 +11,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160412111212) do
+ActiveRecord::Schema.define(version: 20160603081312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
+
+  create_table "cancellations", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
+    t.uuid     "visit_id",   null: false
+    t.string   "reason",     null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "cancellations", ["visit_id"], name: "index_cancellations_on_visit_id", unique: true, using: :btree
 
   create_table "estates", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
     t.string   "name",                  null: false
@@ -127,6 +136,7 @@ ActiveRecord::Schema.define(version: 20160412111212) do
 
   add_index "visits", ["prison_id"], name: "index_visits_on_prison_id", using: :btree
 
+  add_foreign_key "cancellations", "visits"
   add_foreign_key "prisons", "estates"
   add_foreign_key "rejections", "visits"
   add_foreign_key "visitors", "visits"

--- a/spec/controllers/prison/visits_controller_spec.rb
+++ b/spec/controllers/prison/visits_controller_spec.rb
@@ -39,7 +39,12 @@ RSpec.describe Prison::VisitsController, type: :controller do
     let(:visit) { FactoryGirl.create(:booked_visit) }
     let(:mailing) { double(Mail::Message, deliver_later: nil) }
 
-    subject { delete :cancel, id: visit.id, locale: 'en' }
+    subject do
+      delete :cancel,
+        id: visit.id,
+        cancellation_reason: 'slot_unavailable',
+        locale: 'en'
+    end
 
     it_behaves_like 'disallows untrusted ips'
 
@@ -48,11 +53,6 @@ RSpec.describe Prison::VisitsController, type: :controller do
     it 'cancels the visit' do
       expect { subject }.
         to change { visit.reload.processing_state }.to('cancelled')
-    end
-
-    it 'sends an email to the visitor' do
-      expect(VisitorMailer).to receive(:cancelled).and_return(mailing)
-      subject
     end
   end
 end

--- a/spec/controllers/prison/visits_controller_spec.rb
+++ b/spec/controllers/prison/visits_controller_spec.rb
@@ -34,4 +34,25 @@ RSpec.describe Prison::VisitsController, type: :controller do
 
     it_behaves_like 'disallows untrusted ips'
   end
+
+  describe '#cancel' do
+    let(:visit) { FactoryGirl.create(:booked_visit) }
+    let(:mailing) { double(Mail::Message, deliver_later: nil) }
+
+    subject { delete :cancel, id: visit.id, locale: 'en' }
+
+    it_behaves_like 'disallows untrusted ips'
+
+    it { is_expected.to redirect_to(prison_deprecated_visit_path(visit)) }
+
+    it 'cancels the visit' do
+      expect { subject }.
+        to change { visit.reload.processing_state }.to('cancelled')
+    end
+
+    it 'sends an email to the visitor' do
+      expect(VisitorMailer).to receive(:cancelled).and_return(mailing)
+      subject
+    end
+  end
 end

--- a/spec/controllers/prison/visits_controller_spec.rb
+++ b/spec/controllers/prison/visits_controller_spec.rb
@@ -8,13 +8,23 @@ RSpec.describe Prison::VisitsController, type: :controller do
     subject do
       put :update,
         id: visit.id,
-        booking_response: { selection: 'slot_0' },
+        booking_response: booking_response,
         locale: 'en'
     end
 
-    it { is_expected.to render_template('process_visit') }
+    let(:booking_response) { { selection: 'slot_0' } }
 
     it_behaves_like 'disallows untrusted ips'
+
+    context 'when invalid' do
+      it { is_expected.to render_template('process_visit') }
+    end
+
+    context 'when valid' do
+      let(:booking_response) { { selection: 'slot_0', reference_no: 'none' } }
+
+      it { is_expected.to redirect_to(prison_deprecated_visit_path(visit)) }
+    end
   end
 
   describe '#show' do

--- a/spec/controllers/prison/visits_controller_spec.rb
+++ b/spec/controllers/prison/visits_controller_spec.rb
@@ -2,7 +2,22 @@ require 'rails_helper'
 require_relative '../untrusted_examples'
 
 RSpec.describe Prison::VisitsController, type: :controller do
-  let(:visit) { create(:visit) }
+  let(:visit) { FactoryGirl.create(:visit) }
+
+  describe '#process_visit' do
+    subject do
+      get :process_visit, id: visit.id, locale: 'en'
+    end
+
+    context 'when is processable' do
+      it { is_expected.to render_template('process_visit') }
+    end
+
+    context 'when is unprocessble' do
+      let!(:visit) { FactoryGirl.create(:booked_visit) }
+      it { is_expected.to redirect_to(prison_deprecated_visit_path(visit)) }
+    end
+  end
 
   describe '#update' do
     subject do

--- a/spec/controllers/prison/visits_controller_spec.rb
+++ b/spec/controllers/prison/visits_controller_spec.rb
@@ -69,5 +69,11 @@ RSpec.describe Prison::VisitsController, type: :controller do
       expect { subject }.
         to change { visit.reload.processing_state }.to('cancelled')
     end
+
+    context 'when the visit is already cancelled' do
+      let(:visit) { FactoryGirl.create(:cancelled_visit) }
+
+      it { is_expected.to redirect_to(prison_deprecated_visit_path(visit)) }
+    end
   end
 end

--- a/spec/factories/cancellations.rb
+++ b/spec/factories/cancellations.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :cancellation do
+    association :visit, processing_state: 'cancelled'
+    reason 'prisoner_moved'
+  end
+end

--- a/spec/factories/visits.rb
+++ b/spec/factories/visits.rb
@@ -51,6 +51,10 @@ FactoryGirl.define do
 
     factory :cancelled_visit do
       processing_state 'cancelled'
+
+      slot_granted do |v|
+        v.slot_option_0
+      end
     end
 
     factory :rejected_visit do

--- a/spec/features/process_a_request_spec.rb
+++ b/spec/features/process_a_request_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Processing a request', js: true do
     let(:vst) { create(:cancelled_visit) }
 
     scenario 'is not allowed' do
-      expect(page).to have_text('The visitor has cancelled this booking')
+      expect(page).to have_text('The visit has been cancelled.')
       expect(page).not_to have_text('Send email')
     end
   end
@@ -51,7 +51,7 @@ RSpec.feature 'Processing a request', js: true do
     let(:vst) { create(:booked_visit) }
 
     scenario 'is not allowed' do
-      expect(page).to have_text('This request has already been accepted')
+      expect(page).to have_text('This request has been accepted')
       expect(page).not_to have_text('Send email')
     end
   end
@@ -60,7 +60,7 @@ RSpec.feature 'Processing a request', js: true do
     let(:vst) { create(:rejected_visit) }
 
     scenario 'is not allowed' do
-      expect(page).to have_text('This request has already been rejected')
+      expect(page).to have_text('This request has been rejected')
       expect(page).not_to have_text('Send email')
     end
   end
@@ -72,7 +72,7 @@ RSpec.feature 'Processing a request', js: true do
 
       click_button 'Send email'
 
-      expect(page).to have_text('A confirmation email has been sent to the visitor')
+      expect(page).to have_text('a confirmation email has been sent to the visitor')
 
       vst.reload
       expect(vst).to be_booked
@@ -106,7 +106,7 @@ RSpec.feature 'Processing a request', js: true do
 
         click_button 'Send email'
 
-        expect(page).to have_text('A confirmation email has been sent to the visitor')
+        expect(page).to have_text('a confirmation email has been sent to the visitor')
 
         vst.reload
         expect(vst).to be_booked
@@ -133,7 +133,7 @@ RSpec.feature 'Processing a request', js: true do
 
         click_button 'Send email'
 
-        expect(page).to have_text('A confirmation email has been sent to the visitor')
+        expect(page).to have_text('a confirmation email has been sent to the visitor')
 
         vst.reload
         expect(vst).to be_booked
@@ -156,7 +156,7 @@ RSpec.feature 'Processing a request', js: true do
 
     click_button 'Send email'
 
-    expect(page).to have_text('A rejection email has been sent to the visitor')
+    expect(page).to have_text('a rejection email has been sent to the visitor')
 
     vst.reload
     expect(vst).to be_rejected
@@ -181,7 +181,7 @@ RSpec.feature 'Processing a request', js: true do
 
     click_button 'Send email'
 
-    expect(page).to have_text('A rejection email has been sent to the visitor')
+    expect(page).to have_text('a rejection email has been sent to the visitor')
 
     vst.reload
     expect(vst).to be_rejected
@@ -204,7 +204,7 @@ RSpec.feature 'Processing a request', js: true do
 
     click_button 'Send email'
 
-    expect(page).to have_text('A rejection email has been sent to the visitor')
+    expect(page).to have_text('a rejection email has been sent to the visitor')
 
     vst.reload
     expect(vst.rejection_reason).to eq('prisoner_details_incorrect')
@@ -225,7 +225,7 @@ RSpec.feature 'Processing a request', js: true do
 
     click_button 'Send email'
 
-    expect(page).to have_text('A rejection email has been sent to the visitor')
+    expect(page).to have_text('a rejection email has been sent to the visitor')
 
     vst.reload
     expect(vst.rejection_reason).to eq('prisoner_moved')
@@ -251,7 +251,7 @@ RSpec.feature 'Processing a request', js: true do
 
     click_button 'Send email'
 
-    expect(page).to have_text('A rejection email has been sent to the visitor')
+    expect(page).to have_text('a rejection email has been sent to the visitor')
 
     vst.reload
     expect(vst.rejection_reason).to eq('visitor_not_on_list')
@@ -278,7 +278,7 @@ RSpec.feature 'Processing a request', js: true do
 
     click_button 'Send email'
 
-    expect(page).to have_text('A rejection email has been sent to the visitor')
+    expect(page).to have_text('a rejection email has been sent to the visitor')
 
     vst.reload
     expect(vst.rejection_reason).to eq('visitor_banned')

--- a/spec/features/process_a_request_spec.rb
+++ b/spec/features/process_a_request_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Processing a request', js: true do
     let(:vst) { create(:cancelled_visit) }
 
     scenario 'is not allowed' do
-      expect(page).to have_text('The visit has been cancelled.')
+      expect(page).to have_text('The visit has already been processed')
       expect(page).not_to have_text('Send email')
     end
   end

--- a/spec/mailers/prison_mailer/booked_spec.rb
+++ b/spec/mailers/prison_mailer/booked_spec.rb
@@ -26,4 +26,9 @@ RSpec.describe PrisonMailer, '.booked' do
       to match(/COPY of booking confirmation for Arthur Raffles/)
     expect(mail.body.encoded).to match(visit.prison.name)
   end
+
+  it 'links to the prison visit show page' do
+    expect(mail.body.encoded).
+      to match(prison_deprecated_visit_path(visit, locale: 'en'))
+  end
 end

--- a/spec/mailers/visitor_mailer/cancelled_spec.rb
+++ b/spec/mailers/visitor_mailer/cancelled_spec.rb
@@ -4,9 +4,11 @@ require 'mailers/shared_mailer_examples'
 RSpec.describe VisitorMailer, '.cancelled' do
   let(:visit) { create(:cancelled_visit) }
   let(:mail) { described_class.cancelled(visit) }
+  let(:reason) { 'slot_unavailable' }
 
   before do
     ActionMailer::Base.deliveries.clear
+    FactoryGirl.create(:cancellation, visit: visit, reason: reason)
   end
 
   around do |example|
@@ -22,5 +24,17 @@ RSpec.describe VisitorMailer, '.cancelled' do
     expect(mail.subject).
       to match(
         /CANCELLED: Your #{prison_name} prison visit for Monday 12 October/)
+  end
+
+  context 'when the slot is no longer available' do
+    let(:reason) { 'slot_unavailable' }
+
+    it { expect(mail.html_part.body).to match(/no longer available/) }
+  end
+
+  context 'when the prisoner has moved' do
+    let(:reason) { 'prisoner_moved' }
+
+    it { expect(mail.html_part.body).to match(/has moved prison/) }
   end
 end

--- a/spec/mailers/visitor_mailer/cancelled_spec.rb
+++ b/spec/mailers/visitor_mailer/cancelled_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+require 'mailers/shared_mailer_examples'
+
+RSpec.describe VisitorMailer, '.cancelled' do
+  let(:visit) { create(:cancelled_visit) }
+  let(:mail) { described_class.cancelled(visit) }
+
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  around do |example|
+    travel_to Date.new(2015, 10, 1) do
+      example.call
+    end
+  end
+
+  include_examples 'template checks'
+
+  it 'sends an email notifying of the visit cancellation' do
+    prison_name = visit.prison_name
+    expect(mail.subject).
+      to match(
+        /CANCELLED: Your #{prison_name} prison visit for Monday 12 October/)
+  end
+end

--- a/spec/metrics/shared_examples_for_metrics.rb
+++ b/spec/metrics/shared_examples_for_metrics.rb
@@ -132,13 +132,13 @@ RSpec.shared_examples 'create visits with dates' do
 
   def withdraw_a_luna_visit_late
     travel_to Time.zone.local(2016, 2, 5) do
-      luna_visit.cancel!
+      luna_visit.withdraw!
     end
   end
 
   def withdraw_a_luna_visit_on_time
     travel_to Time.zone.local(2016, 2, 2) do
-      luna_visit.cancel!
+      luna_visit.withdraw!
     end
   end
 

--- a/spec/models/cancellation_spec.rb
+++ b/spec/models/cancellation_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Cancellation, model: true do
+  describe 'validation' do
+    it 'enforces no more than one per visit' do
+      cancellation = FactoryGirl.create(:cancellation)
+      expect {
+        FactoryGirl.create(:cancellation, visit: cancellation.visit)
+      }.to raise_exception(ActiveRecord::RecordNotUnique)
+    end
+
+    it 'enforces the foreign key constraint' do
+      expect {
+        FactoryGirl.create(:cancellation, visit_id: SecureRandom.uuid)
+      }.to raise_exception(ActiveRecord::InvalidForeignKey)
+    end
+
+    it 'checks the reason code is allowed' do
+      cancellation = FactoryGirl.build_stubbed(:cancellation)
+      cancellation.reason = 'random'
+      expect(cancellation).to be_invalid
+      expect(cancellation.errors[:reason]).to be_present
+    end
+  end
+end

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -98,6 +98,11 @@ RSpec.describe Visit, type: :model do
         expect { subject }.to change { visit.processing_state }.to('cancelled')
       end
 
+      it 'creates a cancellation record' do
+        expect { subject }.
+          to change { Cancellation.where(visit_id: visit.id).count }.by(1)
+      end
+
       it 'sends an email to the prison' do
         expect(PrisonMailer).to receive(:cancelled).with(visit).and_return(mailing)
         subject


### PR DESCRIPTION
We know that prison staff cancel visits, we are unsure how they do this since there is no ability to cancel as staff. One possibility is that they use the 'cancel' link in the copy of the visitors email that they get.

This PR changes the link url that gets generated on the copied visitor view to a new page where the staff can cancel a visit. This cancellation then gets email to the visitor instead of the prison.

The page where the cancellation is rendered is a new show page adapted from the 'updated' template. Ideally we'd use the new show page we've done for the dashboards. We should switch the redirect to the proper show page once we 'launch' the dashboards (as well as adding the ability to cancel from the dashboard show page)