### PR TITLE
Task generate all missing user logins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ gem 'rails', '~> 4.2.3'
 gem 'connection_pool'
 gem 'devise'
 gem 'excon'
+gem 'haikunator',
+  require: false,
+  git: 'git@github.com:usmanbashir/haikunator.git'
 gem 'highline', require: false
 gem 'jbuilder'
 gem 'kramdown'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: git@github.com:usmanbashir/haikunator.git
+  revision: b313a160d880395f36d4fdf58a948066f359667d
+  specs:
+    haikunator (1.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -355,6 +361,7 @@ DEPENDENCIES
   govuk_elements_rails (>= 1.1.2)
   govuk_frontend_toolkit (>= 4.6.1)
   govuk_template (~> 0.17.0)
+  haikunator!
   highline
   jbuilder
   jquery-ui-rails

--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -47,4 +47,56 @@ namespace :pvb do
 
     cli.say("User created for #{estate.name}")
   end
+
+  desc 'Create missing users'
+  task create_missing_users: :environment do
+    require 'csv'
+    require 'haikunator'
+
+    # Estates using the same email address:
+    #   - APVBU
+    #   - Everthorpe
+    #   - Isle of Wight
+    duplicate_emails =
+      Prison.
+      joins('INNER JOIN prisons p2
+             ON prisons.email_address = p2.email_address
+             AND prisons.estate_id <> p2.estate_id').
+      pluck(:email_address).
+      uniq
+
+    skipped_estates =
+      Estate.
+      joins(:prisons).
+      where(prisons: { enabled: true,
+                       email_address: duplicate_emails }).
+      pluck('estates.name').
+      uniq
+
+    missing_estates =
+      Estate.
+      joins('LEFT OUTER JOIN users ON users.estate_id = estates.id').
+      joins(:prisons).
+      where(prisons: { enabled: true }).
+      where.not(prisons: { email_address: duplicate_emails }).
+      where('users.id IS NULL').
+      group('estates.id').
+      order('estates.name asc')
+
+    data = CSV.generate(write_headers: true,
+                        headers: %i[name email password]) { |csv|
+      missing_estates.each do |estate|
+        puts "Creating account for #{estate.name}..."
+        email = estate.prisons.enabled.first.email_address
+        password = Haikunator.haikunate(100)
+        User.create!(email: email, password: password, estate: estate)
+        csv << { name: estate.name, email: email, password: password }
+      end
+    }
+
+    STDOUT.puts "CSV:\n"
+    STDOUT.puts data
+
+    STDOUT.puts "\nSkipped estates with same email address: #{skipped_estates}"
+  end
 end


### PR DESCRIPTION
Skips estates that already have user accounts and estates that share email address with other estates.