### PR TITLE
Format Sidekiq logs in logstash format

### DIFF
--- a/config/initializers/sidekiq_logstash.rb
+++ b/config/initializers/sidekiq_logstash.rb
@@ -1,0 +1,5 @@
+require 'logstash_sidekiq_logger'
+
+log_file = Rails.root.join("log/logstash_#{Rails.env}.log")
+
+LogstashSidekiqLogger.setup(log_file)

--- a/lib/logstash_sidekiq_logger.rb
+++ b/lib/logstash_sidekiq_logger.rb
@@ -1,0 +1,60 @@
+# Sets up a new sidekiq file logger for logstash consumption.
+#
+# To do this it combines data from ActiveJob notifications and from Sidekiq
+# logs.
+#
+# ActiveJob notifications provides data on what job ran with what parameters,
+# this is obtained by setting up a subscription to the ActiveJob instrumentaton
+# that Rails provides.
+#
+# Sidekiq provides no instrumentation so the ActiveJob data is combined on a
+# custom log formatter.
+#
+# The final output looks like:
+#
+# (as single lines in the log file, output generated from
+# LogstashSidekiqLogger::Formatter#extract_log_data)
+#
+# {
+#   "job_name":"prison_mailer_request_received",
+#   "arguments":["gid://prison-visits/Visit/0125d92d-3e27-4835-bc35-7fd5fb"],
+#   "queue_name":"mailers",
+#   "status":"completed",
+#   "active_job_duration":640.827,
+#   "total_duration":691.0,
+#   "message":"[completed] 691.0 ms prison_mailer_request_received arguments
+#   "@timestamp":"2016-06-17T13:22:58.096Z",
+#   "@version":"1"
+# }
+#
+# {
+#   "job_name":"prison_mailer_request_received",
+#   "arguments":["gid://prison-visits/Visit/0125d92d-3e27-4835-bc35-7fd5fb"],
+#   "queue_name":"mailers",
+#   "status":"to_be_retried",
+#   "active_job_duration":1.194,
+#   "total_duration":4.0,
+#   "message":"[to_be_retried] 4.0 ms prison_mailer_request_received arguments
+#   "retry_number":1,
+#   "@timestamp":"2016-06-17T13:00:26.298Z",
+#   "@version":"1"
+# }
+
+require_relative 'logstash_sidekiq_logger/active_job_subscriber'
+require_relative 'logstash_sidekiq_logger/formatter'
+
+module LogstashSidekiqLogger
+  def self.setup(log_file)
+    # Listen to Rails ActiveJob instrumentation
+    ActiveJobSubscriber.attach_to :active_job
+
+    custom_sidekiq_logger = ActiveSupport::Logger.new(log_file)
+    custom_sidekiq_logger.formatter = Formatter.new
+
+    # ActiveSupport::Logger.broadcast wraps an existing logger so that logs
+    # going to that logger get broadcasted to a different logger
+    Sidekiq.
+      logger.
+      extend(ActiveSupport::Logger.broadcast(custom_sidekiq_logger))
+  end
+end

--- a/lib/logstash_sidekiq_logger/active_job_subscriber.rb
+++ b/lib/logstash_sidekiq_logger/active_job_subscriber.rb
@@ -1,0 +1,7 @@
+module LogstashSidekiqLogger
+  class ActiveJobSubscriber < ActiveSupport::LogSubscriber
+    def perform(event)
+      RequestStore.store[:performed_job] = event
+    end
+  end
+end

--- a/lib/logstash_sidekiq_logger/formatter.rb
+++ b/lib/logstash_sidekiq_logger/formatter.rb
@@ -1,0 +1,105 @@
+module LogstashSidekiqLogger
+  class Formatter < Logger::Formatter
+    def call(_severity, _time, _program_name, message)
+      store_message_failure_metadata(message)
+
+      performed_job = RequestStore.store[:performed_job]
+      return unless performed_job && message_needs_logging?(message)
+
+      data = extract_log_data(performed_job, message)
+      event = LogStash::Event.new(data)
+
+      RequestStore.clear!
+
+      "\n" + event.to_json
+    end
+
+  private
+
+    def store_message_failure_metadata(message)
+      return unless message =~ /^fail/
+
+      duration = message.match(/^fail:\s(.*)\s/).captures.first
+      RequestStore.store[:duration] = duration.to_f * 1000 # milliseconds
+    end
+
+    def failure_data(message)
+      { retry_count: message['retry_count'] }
+    end
+
+    def extract_log_data(performed_job, message)
+      data = base_log_data(performed_job, message)
+      data.merge!(failure_data(message)) unless data[:status] == 'completed'
+      data[:message] = log_message(data)
+      data
+    end
+
+    def log_message(data)
+      msg = "[#{data[:status]}] (#{data[:total_duration]} ms) "
+      msg += "#{data[:job_name]} args: #{data[:arguments]}"
+      msg
+    end
+
+    def base_log_data(performed_job, message)
+      {
+        job_name: job_name(performed_job),
+        arguments: job_arguments(performed_job),
+        queue_name: queue_name(performed_job),
+        status: calculate_status(message),
+        active_job_duration: active_job_duration(performed_job),
+        total_duration: total_duration(message)
+      }
+    end
+
+    def job_name(job)
+      arguments = job.payload[:job].arguments
+      job_class_name = arguments.first.underscore
+      method_name = arguments.second
+
+      "#{job_class_name}_#{method_name}"
+    end
+
+    def job_arguments(job)
+      arguments = job.payload[:job].arguments
+      arguments[2..-1].map do |arg|
+        arg.try(:to_global_id).try(:to_s) || arg.to_s
+      end
+    end
+
+    def queue_name(job)
+      job.payload[:job].queue_name
+    end
+
+    def calculate_status(message)
+      if message.is_a?(Hash)
+        if message['retry']
+          'to_be_retried'
+        else
+          'failed'
+        end
+      else
+        'completed'
+      end
+    end
+
+    def active_job_duration(job)
+      job.duration # milliseconds
+    end
+
+    def total_duration(message)
+      RequestStore.store[:duration] || extract_duration(message)
+    end
+
+    # Message duration is in seconds, convert to milliseconds
+    def extract_duration(message)
+      message.match(/\s(.+)\s/).captures.first.to_f * 1000
+    end
+
+    # Sidekiq logs a Hash with metadata about a failure, otherwise it is a
+    # string.
+    def message_needs_logging?(message)
+      (message.is_a?(Hash) && message.keys.include?('class')) ||
+        message =~ /^done/
+    end
+  end
+end

--- a/spec/lib/logstash_sidekiq_logger/active_job_subscriber_spec.rb
+++ b/spec/lib/logstash_sidekiq_logger/active_job_subscriber_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe LogstashSidekiqLogger::ActiveJobSubscriber do
+  let(:instance) { described_class.new }
+
+  describe "#perform" do
+    let(:job_payload) { double }
+
+    let(:event) do
+      ActiveSupport::Notifications::Event.new(
+        'active_job.perform',
+        Time.zone.now,
+        Time.zone.now,
+        2,
+        payload: job_payload
+      )
+    end
+
+    subject(:perform) { instance.perform(event) }
+
+    it 'stores the job event' do
+      perform
+      expect(RequestStore.store[:performed_job]).to eq(event)
+    end
+  end
+end

--- a/spec/lib/logstash_sidekiq_logger/formatter_spec.rb
+++ b/spec/lib/logstash_sidekiq_logger/formatter_spec.rb
@@ -1,0 +1,180 @@
+require 'rails_helper'
+
+RSpec.describe LogstashSidekiqLogger::Formatter do
+  let(:visit) { FactoryGirl.create(:visit) }
+  let(:formatter) { described_class.new }
+  let(:done_message) { 'done: 2.944 sec' }
+  let(:fail_message) { 'fail: 2.945 sec' }
+  let(:fail_hash_message) do
+    {
+      "class" => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
+      "wrapped" => "ActionMailer::DeliveryJob",
+      "queue" => "mailers",
+      "args" => job_args,
+      "locale" => "en",
+      "retry" => can_retry_job,
+      "jid" => "12db1b5e9b9ce2f1d69a06f8",
+      "created_at" => 1_466_168_392.384784,
+      "enqueued_at" => 1_466_168_392.384825,
+      "error_message" => "",
+      "error_class" => "RuntimeError",
+      "failed_at" => 1_466_168_392.5716329,
+      "retry_count" => 0
+    }
+  end
+  let(:job_args) do
+    [{
+      "job_class" => "ActionMailer::DeliveryJob",
+      "job_id" => "5962f204-9f90-4196-95bd-c7db08a9c8dd",
+      "queue_name" => "mailers",
+      "arguments" => ["PrisonMailer",
+                      "request_received",
+                      "deliver_now!",
+                      { "_aj_globalid" => visit.to_global_id }]
+    }]
+  end
+
+  after do
+    RequestStore.clear!
+  end
+
+  describe '#call' do
+    subject(:call) { formatter.call(anything, anything, anything, message) }
+    let(:logged_message) do
+      raw_message = call
+      raw_message ? JSON.parse(raw_message.chomp) : nil
+    end
+
+    describe 'without a stored active job event' do
+      before do
+        RequestStore.store[:performed_job] = nil
+      end
+
+      let(:message) { done_message }
+
+      it 'does not log a message' do
+        expect(logged_message).to be_nil
+      end
+    end
+
+    describe 'with a stored active job event' do
+      let(:job_event) do
+        double(
+          'ActiveSupportNotification',
+          duration: 1234,
+          payload: {
+            job: double(arguments: ['PrisonMailer', 'cancelled', visit, 'foo'],
+                        queue_name: 'mailers')
+          })
+      end
+
+      before do
+        RequestStore.store[:performed_job] = job_event
+      end
+
+      describe 'a random sidekiq message' do
+        let(:message) { 'rand: 2.944 sec' }
+
+        it 'does not output a message' do
+          expect(logged_message).to be_nil
+        end
+
+        it 'does not clear the request store' do
+          call
+          expect(RequestStore.store[:performed_job]).to eq(job_event)
+        end
+      end
+
+      describe 'with a successful job' do
+        let(:message) { done_message }
+
+        it 'outputs a message' do
+          expect(logged_message).
+            to include(
+              'job_name' => 'prison_mailer_cancelled',
+              'arguments' => [visit.to_global_id.to_s, 'foo'],
+              'queue_name' => 'mailers',
+              'status' => 'completed',
+              'active_job_duration' => 1234,
+              'total_duration' => 2944)
+          expect(logged_message['message']).
+            to match(Regexp.quote('[completed] (2944.0 ms)'))
+        end
+
+        it 'clears the request store' do
+          call
+          expect(RequestStore.store[:performed_job]).to be_nil
+        end
+      end
+
+      describe 'with the first failure message' do
+        let(:message) { fail_message }
+
+        it 'does not output a message' do
+          expect(logged_message).to be_nil
+        end
+
+        it 'does not clear the request store' do
+          call
+          expect(RequestStore.store[:performed_job]).to eq(job_event)
+        end
+      end
+
+      describe 'with the retriable failure message' do
+        before do
+          formatter.call(anything, anything, anything, fail_message)
+        end
+
+        let(:message) { fail_hash_message }
+        let(:can_retry_job) { true }
+
+        it 'outputs a message' do
+          expect(logged_message).
+            to include(
+              'job_name' => 'prison_mailer_cancelled',
+              'arguments' => [visit.to_global_id.to_s, 'foo'],
+              'queue_name' => 'mailers',
+              'status' => 'to_be_retried',
+              'active_job_duration' => 1234,
+              'total_duration' => 2945,
+              "retry_count" => 0)
+          expect(logged_message['message']).
+            to match(Regexp.quote('[to_be_retried] (2945.0 ms)'))
+        end
+
+        it 'clears the request store' do
+          call
+          expect(RequestStore.store[:performed_job]).to be_nil
+        end
+      end
+
+      describe 'with the a non-retriable failure message' do
+        before do
+          formatter.call(anything, anything, anything, fail_message)
+        end
+
+        let(:can_retry_job) { false }
+        let(:message) { fail_hash_message }
+
+        it 'outputs a message' do
+          expect(logged_message).
+            to include(
+              'job_name' => 'prison_mailer_cancelled',
+              'arguments' => [visit.to_global_id.to_s, 'foo'],
+              'queue_name' => 'mailers',
+              'status' => 'failed',
+              'active_job_duration' => 1234,
+              'total_duration' => 2945,
+              "retry_count" => 0)
+          expect(logged_message['message']).
+            to match(Regexp.quote('[failed] (2945.0 ms)'))
+        end
+
+        it 'clears the request store' do
+          call
+          expect(RequestStore.store[:performed_job]).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Logstash only receives http app logs which means that we have no visibility on
how the asynchronous jobs have performed when debugging issues.

It works by broadcasting the Sidekiq logs to the logstash log file and merging
event data about the processing from the Sidekiq logs and ActiveJob
instrumentation. This is necessary because Sidekiq and ActiveJob do not log
enough data by themselves. This approach is similar to the Logstasher gem that
currently formats http requests for logstasher.