### PR TITLE
Fix active nav when searching

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,12 @@ module ApplicationHelper
   end
 
   def nav_link(link_text, link_path)
-    class_name = current_page?(link_path) ? 'active' : ''
+    link_options = Rails.application.routes.recognize_path(link_path)
+
+    active_link = params[:controller] == link_options[:controller] &&
+                  params[:action] == link_options[:action]
+
+    class_name = active_link ? 'active' : ''
 
     content_tag(:li, class: class_name) do
       link_to link_text, link_path

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -58,14 +58,17 @@ RSpec.describe ApplicationHelper do
 
   describe 'nav_link' do
     let(:link_text) { 'link_text' }
-    let(:link_path) { 'link/path' }
+    let(:link_path) { 'prison/inbox' }
 
     subject { helper.nav_link(link_text, link_path) }
 
     context 'when is the current page' do
       before do
         allow(helper).
-          to receive(:current_page?).with(link_path).and_return(true)
+          to receive(:params).
+          and_return(controller: 'prison/dashboards',
+                     action: 'inbox',
+                     prisoner_number: 'A1234BC')
       end
 
       it 'adds an active class' do
@@ -76,7 +79,8 @@ RSpec.describe ApplicationHelper do
     context 'when is not the current page' do
       before do
         allow(helper).
-          to receive(:current_page?).with(link_path).and_return(false)
+          to receive(:params).
+          and_return(controller: 'prison/dashboards', action: 'processed')
       end
 
       it 'does not add an active class' do


### PR DESCRIPTION
The Rails helper `current_page?` returns false if there is additional parameters. I've reworked it so that the active class is based on controller name and action.