### PR TITLE
Track cancellations have been cancelled in Nomis

### DIFF
--- a/db/migrate/20160711135837_add_nomis_cancelled_to_cancellations.rb
+++ b/db/migrate/20160711135837_add_nomis_cancelled_to_cancellations.rb
@@ -1,0 +1,5 @@
+class AddNomisCancelledToCancellations < ActiveRecord::Migration
+  def change
+    add_column :cancellations, :nomis_cancelled, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,17 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160610101017) do
+ActiveRecord::Schema.define(version: 20160711135837) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
   create_table "cancellations", id: :uuid, default: "uuid_generate_v4()", force: :cascade do |t|
-    t.uuid     "visit_id",   null: false
-    t.string   "reason",     null: false
+    t.uuid     "visit_id",                        null: false
+    t.string   "reason",                          null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.boolean  "nomis_cancelled", default: false, null: false
   end
 
   add_index "cancellations", ["visit_id"], name: "index_cancellations_on_visit_id", unique: true, using: :btree

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -38,7 +38,9 @@ RSpec.describe Visit, type: :model do
 
     it 'creates a cancellation record' do
       expect { cancellation! }.
-        to change { Cancellation.where(visit_id: visit.id).count }.by(1)
+        to change {
+          Cancellation.where(visit_id: visit.id, nomis_cancelled: true).count
+        }.by(1)
     end
 
     it 'sends an email to the visitor' do
@@ -87,7 +89,8 @@ RSpec.describe Visit, type: :model do
       let(:visit) { FactoryGirl.create(:visit) }
 
       it 'transitions to withdrawn' do
-        expect { subject }.to change { visit.processing_state }.to('withdrawn')
+        expect { subject }.
+          to change { visit.processing_state }.to('withdrawn')
       end
     end
 
@@ -100,7 +103,9 @@ RSpec.describe Visit, type: :model do
 
       it 'creates a cancellation record' do
         expect { subject }.
-          to change { Cancellation.where(visit_id: visit.id).count }.by(1)
+          to change {
+            Cancellation.where(visit_id: visit.id, nomis_cancelled: false).count
+          }.by(1)
       end
 
       it 'sends an email to the prison' do


### PR DESCRIPTION
This is needed for the future inbox of visitor cancellations which is only going
to show cancellations that are waiting to be cancelled in Nomis.

When we are ready to deploy the cancellation inbox we'll mark all cancellations
as being Nomis cancelled.