### PR TITLE
Reuse logstasher json file for sidekiq

### DIFF
--- a/config/initializers/sidekiq_logstash.rb
+++ b/config/initializers/sidekiq_logstash.rb
@@ -1,5 +1,5 @@
 require 'logstash_sidekiq_logger'
 
-log_file = Rails.root.join("log/logstash_#{Rails.env}.log")
+log_file = Rails.root.join("log/logstash_#{Rails.env}.json")
 
 LogstashSidekiqLogger.setup(log_file)


### PR DESCRIPTION
Starts using the same file that gets used to send data to logstash.

Tested in staging with the .log file and works as expected.