### PR TITLE
Send sidekiq logstash logs to Docker

### DIFF
--- a/run-sidekiq.sh
+++ b/run-sidekiq.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 export RAILS_ENV=production
 bundle exec rackup sidekiq-admin.ru -p 3000 -E production -o 0.0.0.0 &
-bundle exec sidekiq -l /var/log/sidekiq.log --environment production
+bundle exec sidekiq --daemon -l /var/log/sidekiq.log --environment production
+
+tail -f /usr/src/app/log/logstash_production.json


### PR DESCRIPTION
Tail the logstash file on the Docker Sidekiq script so that they get sent to
logstash.