### PR TITLE
Fix acceptances being rejected in some scenarios

### DIFF
--- a/app/models/booking_response.rb
+++ b/app/models/booking_response.rb
@@ -67,10 +67,14 @@ class BookingResponse
   end
 
   def unlisted_visitors
+    return [] unless visitor_not_on_list
+
     visitors.select { |v| unlisted_visitor_ids.include?(v.id) }
   end
 
   def banned_visitors
+    return [] unless visitor_banned
+
     visitors.select { |v| banned_visitor_ids.include?(v.id) }
   end
 
@@ -78,8 +82,8 @@ private
 
   def at_least_one_valid_visitor?
     visitors.
-      reject { |visitor| visitor.id.in? unlisted_visitor_ids }.
-      reject { |visitor| visitor.id.in? banned_visitor_ids }.
+      reject { |visitor| visitor.in? unlisted_visitors }.
+      reject { |visitor| visitor.in? banned_visitors }.
       any? { |visitor| visitor.age >= ADULT_AGE }
   end
 

--- a/spec/models/booking_response_spec.rb
+++ b/spec/models/booking_response_spec.rb
@@ -36,12 +36,27 @@ RSpec.describe BookingResponse, type: :model do
       context 'and all visitors are unlisted' do
         before do
           subject.selection = 'slot_0'
-          subject.visitor_not_on_list = true
           subject.unlisted_visitor_ids = visit.visitors.map(&:id)
         end
 
-        it 'is not bookable' do
-          expect(subject).not_to be_bookable
+        context 'and visitor_not_on_list is true' do
+          before do
+            subject.visitor_not_on_list = true
+          end
+
+          it 'is not bookable' do
+            expect(subject).not_to be_bookable
+          end
+        end
+
+        context 'and visitor_not_on_list is false' do
+          before do
+            subject.visitor_not_on_list = false
+          end
+
+          it 'is bookable' do
+            expect(subject).to be_bookable
+          end
         end
       end
 
@@ -73,12 +88,27 @@ RSpec.describe BookingResponse, type: :model do
       context 'and all visitors are banned' do
         before do
           subject.selection = 'slot_0'
-          subject.visitor_banned = true
           subject.banned_visitor_ids = visit.visitors.map(&:id)
         end
 
-        it 'is not bookable' do
-          expect(subject).not_to be_bookable
+        context 'and visitor_banned is true' do
+          before do
+            subject.visitor_banned = true
+          end
+
+          it 'is not bookable' do
+            expect(subject).not_to be_bookable
+          end
+        end
+
+        context 'and visitor_banned is false' do
+          before do
+            subject.visitor_banned = false
+          end
+
+          it 'is bookable' do
+            expect(subject).to be_bookable
+          end
         end
       end
     end


### PR DESCRIPTION
When the form had a selected banned or not on list visitor but the visitor
banned / not on contact list checkboxes were unchecked and the visit was
accepted the visit was process as rejected because there were no available
adults.

This happened because the frontend sends the visitor ids even though when the
checkbox is deselected and the backend only took into account the not allowed
visitor ids.

This commit fixes this by taking into account the deselected checkboxes and
ignoring any visitor ids that are sent. Ideally we'd also get the front end to
not send any visitor ids if the checkboxes are deselected.