### PR TITLE
Fix Kibana - Logstash format by not using 'status'

### DIFF
--- a/lib/logstash_sidekiq_logger.rb
+++ b/lib/logstash_sidekiq_logger.rb
@@ -19,7 +19,7 @@
 #   "job_name":"prison_mailer_request_received",
 #   "arguments":["gid://prison-visits/Visit/0125d92d-3e27-4835-bc35-7fd5fb"],
 #   "queue_name":"mailers",
-#   "status":"completed",
+#   "job_status":"completed",
 #   "active_job_duration":640.827,
 #   "total_duration":691.0,
 #   "message":"[completed] 691.0 ms prison_mailer_request_received arguments
@@ -31,7 +31,7 @@
 #   "job_name":"prison_mailer_request_received",
 #   "arguments":["gid://prison-visits/Visit/0125d92d-3e27-4835-bc35-7fd5fb"],
 #   "queue_name":"mailers",
-#   "status":"to_be_retried",
+#   "job_status":"to_be_retried",
 #   "active_job_duration":1.194,
 #   "total_duration":4.0,
 #   "message":"[to_be_retried] 4.0 ms prison_mailer_request_received arguments

--- a/lib/logstash_sidekiq_logger/formatter.rb
+++ b/lib/logstash_sidekiq_logger/formatter.rb
@@ -35,9 +35,8 @@ module LogstashSidekiqLogger
     end
 
     def log_message(data)
-      msg = "[#{data[:status]}] (#{data[:total_duration]} ms) "
-      msg += "#{data[:job_name]} args: #{data[:arguments]}"
-      msg
+      msg = "[#{data[:job_status]}] (#{data[:total_duration]} ms) "
+      msg + "#{data[:job_name]} args: #{data[:arguments]}"
     end
 
     def base_log_data(performed_job, message)
@@ -45,7 +44,7 @@ module LogstashSidekiqLogger
         job_name: job_name(performed_job),
         arguments: job_arguments(performed_job),
         queue_name: queue_name(performed_job),
-        status: calculate_status(message),
+        job_status: calculate_status(message),
         active_job_duration: active_job_duration(performed_job),
         total_duration: total_duration(message)
       }

--- a/spec/lib/logstash_sidekiq_logger/formatter_spec.rb
+++ b/spec/lib/logstash_sidekiq_logger/formatter_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe LogstashSidekiqLogger::Formatter do
               'job_name' => 'prison_mailer_cancelled',
               'arguments' => [visit.to_global_id.to_s, 'foo'],
               'queue_name' => 'mailers',
-              'status' => 'completed',
+              'job_status' => 'completed',
               'active_job_duration' => 1234,
               'total_duration' => 2944)
           expect(logged_message['message']).
@@ -134,7 +134,7 @@ RSpec.describe LogstashSidekiqLogger::Formatter do
               'job_name' => 'prison_mailer_cancelled',
               'arguments' => [visit.to_global_id.to_s, 'foo'],
               'queue_name' => 'mailers',
-              'status' => 'to_be_retried',
+              'job_status' => 'to_be_retried',
               'active_job_duration' => 1234,
               'total_duration' => 2945,
               "retry_count" => 0)
@@ -162,7 +162,7 @@ RSpec.describe LogstashSidekiqLogger::Formatter do
               'job_name' => 'prison_mailer_cancelled',
               'arguments' => [visit.to_global_id.to_s, 'foo'],
               'queue_name' => 'mailers',
-              'status' => 'failed',
+              'job_status' => 'failed',
               'active_job_duration' => 1234,
               'total_duration' => 2945,
               "retry_count" => 0)


### PR DESCRIPTION
Messages were being discarded because Logstash appears to have a filter rule on
the status field requiring values to be integers.

The fix gets around the issue by renaming the field to 'job_status'.