### PR TITLE
Not send prison emails for estates in the trial

### DIFF
--- a/app/mailers/prison_mailer.rb
+++ b/app/mailers/prison_mailer.rb
@@ -43,6 +43,8 @@ class PrisonMailer < ActionMailer::Base
 private
 
   def mail_prison(visit, i18n_options = {})
+    return if skip_email?(visit)
+
     mail(
       from: I18n.t('mailer.noreply', domain: noreply_domain),
       to: visit.prison_email_address,
@@ -70,5 +72,9 @@ private
   # send emails gets set up to receive emails.
   def noreply_domain
     'robot.' + smtp_settings[:domain]
+  end
+
+  def skip_email?(visit)
+    visit.prison.estate.name.in? Rails.configuration.dashboard_trial
   end
 end

--- a/config/initializers/dashboard_trial.rb
+++ b/config/initializers/dashboard_trial.rb
@@ -1,3 +1,5 @@
+# The dashboard trial enforces the use of the prison dashboard to process visits
+# and switches off the prison emails.
 Rails.configuration.dashboard_trial = [
   'Belmarsh',
   'Cardiff',

--- a/spec/mailers/prison_mailer/booked_spec.rb
+++ b/spec/mailers/prison_mailer/booked_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe PrisonMailer, '.booked' do
 
   include_examples 'template checks'
   include_examples 'noreply checks'
+  include_examples 'skipping email for the trial'
 
   it 'sends an email confirming the booking' do
     expect(mail.subject).

--- a/spec/mailers/prison_mailer/cancelled_spec.rb
+++ b/spec/mailers/prison_mailer/cancelled_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe PrisonMailer, '.cancelled' do
 
   include_examples 'template checks'
   include_examples 'noreply checks'
+  include_examples 'skipping email for the trial'
 
   context 'cancelled visit' do
     include_examples 'template checks'

--- a/spec/mailers/prison_mailer/rejected_spec.rb
+++ b/spec/mailers/prison_mailer/rejected_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe PrisonMailer, '.rejected' do
       )
     )
   }
+  let(:visit) { rejection.visit }
   let(:mail) { described_class.rejected(rejection.visit) }
   let(:body) { mail.html_part.body }
 
@@ -24,6 +25,7 @@ RSpec.describe PrisonMailer, '.rejected' do
 
   include_examples 'template checks'
   include_examples 'noreply checks'
+  include_examples 'skipping email for the trial'
 
   it 'sends an email reporting the rejection' do
     expect(mail.subject).

--- a/spec/mailers/prison_mailer/request_received_spec.rb
+++ b/spec/mailers/prison_mailer/request_received_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe PrisonMailer, '.request_received' do
 
   include_examples 'template checks'
   include_examples 'noreply checks'
+  include_examples 'skipping email for the trial'
 
   it 'reports the request' do
     expect(mail.subject).

--- a/spec/mailers/shared_mailer_examples.rb
+++ b/spec/mailers/shared_mailer_examples.rb
@@ -10,3 +10,13 @@ RSpec.shared_examples 'noreply checks' do
     expect(mail.from.first).to match(/@robot./)
   end
 end
+
+RSpec.shared_examples 'skipping email for the trial' do
+  it 'does not send emails for prisons in the dashboard trial' do
+    allow(Rails.configuration).
+      to receive(:dashboard_trial).
+      and_return([visit.prison.estate.name])
+
+    expect(mail.to).to be_nil
+  end
+end


### PR DESCRIPTION
Estates that are using the prison dashboards will stop using the emails as
agreed.