### PR TITLE
Added missing OAuth site configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ form `postgres://myuser:mypass@localhost/somedatabase`.
 
 Google Analytics ID, used for the Performance Platform.
 
+#### `MOJSSO_ID, MOJSSO_SECRET, MOJSSO_URL`
+
+Configuration for OAuth based sign-on.
+
 #### `PRISON_ESTATE_IPS`
 
 A semicolon- or comma-separated list of IP addresses or CIDR ranges. Users on

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -2,12 +2,13 @@ require 'mojsso'
 
 app_id = ENV.fetch('MOJSSO_ID', nil)
 app_secret = ENV.fetch('MOJSSO_SECRET', nil)
+sso_url = ENV.fetch('MOJSSO_URL', 'http://localhost:5000')
 
-unless app_id && app_secret
-  STDOUT.puts '[WARN] MOJSSO_ID and/or MOJSSO_SECRET not configured'
+unless app_id && app_secret && sso_url
+  STDOUT.puts '[WARN] MOJSSO_ID/MOJSSO_SECRET/MOJSSO_URL not configured'
 end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   # provider :developer unless Rails.env.production?
-  provider :mojsso, app_id, app_secret
+  provider :mojsso, app_id, app_secret, client_options: { site: sso_url }
 end

--- a/lib/mojsso.rb
+++ b/lib/mojsso.rb
@@ -4,9 +4,7 @@ module OmniAuth
   module Strategies
     class Mojsso < OmniAuth::Strategies::OAuth2
       option :name, 'mojsso'
-      option :client_options,
-        site: 'http://localhost:5000',
-        authorize_url: 'http://localhost:5000/oauth/authorize'
+      option :client_options, site: ''
 
       uid do
         raw_info.fetch('id')


### PR DESCRIPTION
The authorize_url config option is unnecessary: the /oauth/authorize path is the default (see oauth gem)