### PR TITLE
Reduce sidekiq concurrency from 25 -> 5

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bin/rails server -p $PORT
-worker: bundle exec sidekiq
+worker: bundle exec sidekiq -c 5


### PR DESCRIPTION
We don’t need such high concurrency, and are running out of redis connections on heroku.