### PR TITLE
Validate and sanitise visit phone number

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'netaddr'
 # Pinned to 1.3.1 due to https://github.com/intridea/omniauth-oauth2/issues/81
 gem 'omniauth-oauth2', '1.3.1'
 gem 'pg'
+gem 'phonelib'
 gem 'premailer-rails'
 gem 'puma'
 gem 'redcarpet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,7 @@ GEM
       ast (~> 2.2)
     pg (0.18.4)
     phantomjs (1.9.8.0)
+    phonelib (0.6.5)
     pkg-config (1.1.7)
     poltergeist (1.9.0)
       capybara (~> 2.1)
@@ -373,6 +374,7 @@ DEPENDENCIES
   parser (~> 2.3.0.pre.6)
   pg
   phantomjs
+  phonelib
   poltergeist
   premailer-rails
   pry-byebug

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -13,6 +13,10 @@ class Visit < ActiveRecord::Base
     :processing_state,
     presence: true
 
+  validates :contact_phone_no, phone: true, on: :create
+
+  before_create :sanitise_contact_phone_no
+
   delegate :address, :email_address, :name, :phone_no, :postcode,
     to: :prison, prefix: true
   alias_attribute :first_date, :slot_option_0
@@ -72,6 +76,10 @@ cancellations.id IS NULL OR cancellations.nomis_cancelled = :nomis_cancelled
     event :withdraw do
       transition requested: :withdrawn
     end
+  end
+
+  def sanitise_contact_phone_no
+    self.contact_phone_no = Phonelib.parse(contact_phone_no).sanitized
   end
 
   def confirm_nomis_cancelled

--- a/config/initializers/phonelib.rb
+++ b/config/initializers/phonelib.rb
@@ -1,0 +1,1 @@
+Phonelib.default_country = 'GB'

--- a/spec/factories/visits.rb
+++ b/spec/factories/visits.rb
@@ -7,9 +7,7 @@ FactoryGirl.define do
       FFaker::Internet.disposable_email
     end
 
-    contact_phone_no do
-      FFaker::PhoneNumber.short_phone_number
-    end
+    contact_phone_no '07900112233'
 
     slot_option_0 do |v|
       v.prison.available_slots.first

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -25,6 +25,24 @@ RSpec.describe Visit, type: :model do
     end
   end
 
+  describe 'validations' do
+    describe 'contact_phone_no' do
+      before do
+        subject.contact_phone_no = phone_no
+      end
+
+      context 'when the phone number is valid' do
+        let(:phone_no) { '079 00 11 22 33' }
+        it { is_expected.to be_valid }
+      end
+
+      context 'when the phone number is invalid' do
+        let(:phone_no) { ' 07 00 11 22 33' }
+        it { is_expected.to_not be_valid }
+      end
+    end
+  end
+
   describe "#confirm_nomis_cancelled" do
     let(:cancellation) do
       FactoryGirl.create(:cancellation,

--- a/spec/services/depersonalizer_spec.rb
+++ b/spec/services/depersonalizer_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Depersonalizer do
       create(
         :visit,
         contact_email_address: 'user@example.com',
-        contact_phone_no: '0115 4960123'
+        contact_phone_no: '079 00112233'
       )
     }
 
@@ -85,7 +85,7 @@ RSpec.describe Depersonalizer do
       subject.remove_personal_information(Time.zone.now - 1.day)
       expect(visit.reload).to have_attributes(
         contact_email_address: 'user@example.com',
-        contact_phone_no: '0115 4960123'
+        contact_phone_no: '07900112233'
       )
     end
   end


### PR DESCRIPTION
It ensures that the phone number is valid, previous validation on PVB2 was that it had to be present, and in Public that it had be of minimum length 9.

This PR should be deployed after https://github.com/ministryofjustice/prison-visits-public/pull/72