### PR TITLE
Stop trying to start the Sidekiq UI

### DIFF
--- a/run-sidekiq.sh
+++ b/run-sidekiq.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 export RAILS_ENV=production
-bundle exec rackup sidekiq-admin.ru -p 3000 -E production -o 0.0.0.0 &
 bundle exec sidekiq --daemon -l /var/log/sidekiq.log --environment production
 
 tail -f /usr/src/app/log/logstash_production.json


### PR DESCRIPTION
This has not been working for a long time, however it hasn't stopped the sidekiq
script from working.

There is a problem though as errors are logged via docker and this has wasted a
lot investigation time by platforms last night / today.