### PR TITLE
Prevent visitors from cancelling expired visits

### DIFF
--- a/app/controllers/api/visits_controller.rb
+++ b/app/controllers/api/visits_controller.rb
@@ -54,7 +54,7 @@ module Api
 
     def destroy
       @visit = Visit.find(params[:id])
-      if @visit.can_cancel_or_withdraw?
+      if @visit.visitor_can_cancel_or_withdraw?
         @visit.visitor_cancel_or_withdraw!
       end
 

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -94,23 +94,22 @@ cancellations.id IS NULL OR cancellations.nomis_cancelled = :nomis_cancelled
     VisitorMailer.cancelled(self).deliver_later
   end
 
-  def can_cancel_or_withdraw?
-    can_cancel? || can_withdraw?
+  def visitor_can_cancel_or_withdraw?
+    (can_cancel? && slot_granted.begin_at >= Time.now.utc) ||
+      can_withdraw?
   end
 
   def visitor_cancel_or_withdraw!
-    fail "Can't cancel or withdraw visit #{id}" unless can_cancel_or_withdraw?
+    unless visitor_can_cancel_or_withdraw?
+      fail "Can't cancel or withdraw visit #{id}"
+    end
 
     if can_cancel?
-      cancellation!(Cancellation::VISITOR_CANCELLED, nomis_cancelled: false)
-      PrisonMailer.cancelled(self).deliver_later
+      process_cancellation_and_send_email
       return
     end
 
-    if can_withdraw?
-      withdraw!
-      return
-    end
+    withdraw! if can_withdraw?
   end
 
   delegate :age, :first_name, :last_name, :full_name, :anonymized_name,
@@ -120,6 +119,11 @@ cancellations.id IS NULL OR cancellations.nomis_cancelled = :nomis_cancelled
     :date_of_birth, to: :principal_visitor, prefix: :visitor
 
   alias_method :processable?, :requested?
+
+  def process_cancellation_and_send_email
+    cancellation!(Cancellation::VISITOR_CANCELLED, nomis_cancelled: false)
+    PrisonMailer.cancelled(self).deliver_later
+  end
 
   def principal_visitor
     visitors.first

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -160,17 +160,33 @@ RSpec.describe Visit, type: :model do
     end
   end
 
-  describe '#can_cancel_or_withdraw?' do
-    subject { visit.can_cancel_or_withdraw? }
+  describe '#visitor_can_cancel_or_withdraw?' do
+    subject { visit.visitor_can_cancel_or_withdraw? }
 
     context 'when it can be withdrawn' do
       let(:visit) { FactoryGirl.create(:visit) }
       it { is_expected.to eq(true) }
     end
 
-    context 'when it can be cancelled' do
-      let(:visit) { FactoryGirl.create(:booked_visit) }
-      it { is_expected.to eq(true) }
+    context 'when the visit is booked' do
+      context 'and has not yet started' do
+        let(:prison) { FactoryGirl.create(:prison) }
+        let(:visit) do
+          FactoryGirl.create(:booked_visit,
+            prison: prison,
+            slot_granted: prison.available_slots.first)
+        end
+        it { is_expected.to eq(true) }
+      end
+
+      context 'and has already started' do
+        let(:visit) do
+          FactoryGirl.create(
+            :booked_visit,
+            slot_granted: ConcreteSlot.new(2015, 11, 6, 16, 0, 17, 0))
+        end
+        it { is_expected.to eq(false) }
+      end
     end
 
     context "when it can't be cancelled or withdrawn" do


### PR DESCRIPTION
This ensures that visitors can't cancelled booked visits that have expired and allowing staff to cancel visits without restrictions.