### PR TITLE
Sign NOMIS API requests with ECDSA JWT

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ The base URL for the NOMIS API, or API gateway from which the API can be accesse
 
 #### `NOMIS_API_TOKEN` & `NOMIS_API_KEY`
 
-The `NOMIS_API_KEY` should be set to the client's private key, encoded in base64 PEM format, with explicit (not escaped) '\n' characters in place of newlines.
+The `NOMIS_API_KEY` should be set to the client's private key in DER format, encoded as Base64.
 
 The `NOMIS_API_TOKEN` is a JWT token which grants access to the NOMIS API when those requests are signed with the associated `NOMIS_API_KEY`.
 

--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -102,7 +102,7 @@ module Nomis
         iat: Time.now.to_i,
         token: client_token
       }
-      JWT.encode(payload, client_key, 'RS256')
+      JWT.encode(payload, client_key, 'ES256')
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -61,11 +61,10 @@ module PrisonVisits
 
     read_key = lambda { |string|
       begin
-        # To ease configuration use a configuration strings without newlines
-        string = string.gsub('\n', "\n")
-        OpenSSL::PKey::RSA.new(string)
-      rescue OpenSSL::PKey::RSAError
-        STDOUT.puts "[WARN] Invalid key: #{string}"
+        der = Base64.decode64(string)
+        OpenSSL::PKey::EC.new(der)
+      rescue OpenSSL::PKey::ECError => e
+        STDOUT.puts "[WARN] Invalid ECDSA key: #{e}"
         nil
       end
     }

--- a/spec/fixtures/vcr_cassettes/client-auth.yml
+++ b/spec/fixtures/vcr_cassettes/client-auth.yml
@@ -12,9 +12,9 @@ http_interactions:
       Accept:
       - application/json
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpYXQiOjE0NzUwODUwNTYsInRva2VuIjoiYXRva2VuIn0.fdufgsAUqSiKbaTQTXu5CqImxPiTeSTLD1B_TO66QBphAO1dbS-uf5pdtmGpUTQvgFCUqR4L7tQSiTigK8T_sQ
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NiJ9.eyJpYXQiOjE0Nzc2NTQ2ODUsInRva2VuIjoiYXRva2VuIn0.60zzCkaiY3QmMSFbLugXfsNnGClPOYyEse1gA06yvD7FgH0z-EyhUM3QcZaJEIK2IrnQ-ZplFILSBcQ5o_zEqg
       X-Request-Id:
-      - ''
+      - uuid
   response:
     status:
       code: 200
@@ -23,14 +23,14 @@ http_interactions:
       Server:
       - Apache-Coyote/1.1
       Server-Timing:
-      - total=44, db=34
+      - total=38, db=30
       Content-Type:
       - application/json
       Date:
-      - Wed, 28 Sep 2016 17:50:56 GMT
+      - Fri, 28 Oct 2016 11:38:06 GMT
     body:
       encoding: UTF-8
       string: '{"found":true,"offender":{"id":1055827}}'
     http_version:
-  recorded_at: Wed, 28 Sep 2016 17:50:57 GMT
+  recorded_at: Fri, 28 Oct 2016 11:38:06 GMT
 recorded_with: VCR 3.0.1


### PR DESCRIPTION
This also updates the required config format for the private key to base64(der), which avoids any confusion with newlines in ENV variables