### PR TITLE
Ensure that the timeline is ordered correctly

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --color
 --require spec_helper
---backtrace

--- a/app/services/visit_timeline.rb
+++ b/app/services/visit_timeline.rb
@@ -24,7 +24,7 @@ class VisitTimeline
   end
 
   def events
-    events = @visit.visit_state_changes.reverse.map.with_index { |state, i|
+    events = visit_state_changes.reverse.map.with_index { |state, i|
       build_event_from_state_change(state, last: i.zero?)
     }
 
@@ -33,6 +33,10 @@ class VisitTimeline
   end
 
 private
+
+  def visit_state_changes
+    @visit.visit_state_changes.sort { |a, b| a.created_at <=> b.created_at }
+  end
 
   def build_requested_event(last:)
     Event.new(

--- a/spec/services/visit_timeline_spec.rb
+++ b/spec/services/visit_timeline_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe VisitTimeline do
           visit: visit,
           user: nil,
           reason: 'booked_in_error').tap(&:cancel!)
+
+        VisitStateChange.
+          find_by!(visit_state: 'cancelled').
+          update!(created_at: 1.minute.from_now)
         visit.reload
       end
 


### PR DESCRIPTION
Fixes ordering of the timeline by sorting by creation date. This will also fix flakey failures that happen in CI from time to time.

Ideally we would have a sort key to enforce linearibility of the state changes, in practice creation dates should have enough precision in production.