### PR TITLE
Prevent easily double processing a visit

### DIFF
--- a/app/controllers/prison/email_previews_controller.rb
+++ b/app/controllers/prison/email_previews_controller.rb
@@ -20,8 +20,11 @@ private
   end
 
   def booking_response
-    @booking_response ||=
-      BookingResponse.new(visit: Visit.new(visit_params))
+    @booking_response ||= begin
+      visit = load_visit
+      visit.assign_attributes(visit_params)
+      BookingResponse.new(visit: visit)
+    end
   end
 
   def visitor_mailer

--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -4,15 +4,11 @@ class Prison::VisitsController < ApplicationController
   before_action :require_login_during_trial,
     only: %w[show nomis_cancelled process_visit update]
   before_action :cancellation_reason_set, only: :cancel
+  before_action :visit_is_processable, only: [:process_visit, :update]
 
   def process_visit
     @visit            = load_visit.decorate
     @booking_response = BookingResponse.new(visit: @visit)
-
-    unless @visit.processable?
-      flash[:notice] = t('already_processed', scope: [:prison, :flash])
-      redirect_to visit_page(@visit)
-    end
   end
 
   # rubocop:disable Metrics/MethodLength
@@ -64,6 +60,14 @@ class Prison::VisitsController < ApplicationController
   end
 
 private
+
+  def visit_is_processable
+    visit = load_visit
+    unless visit.processable?
+      flash[:notice] = t('already_processed', scope: [:prison, :flash])
+      redirect_to visit_page(visit)
+    end
+  end
 
   def cancellation_response
     @_cancellation_response ||=

--- a/app/views/prison/visits/process_visit.html.erb
+++ b/app/views/prison/visits/process_visit.html.erb
@@ -8,7 +8,6 @@
   <%= f.hidden_field :slot_option_2  %>
   <%= f.hidden_field :prisoner_id  %>
   <%= f.hidden_field :principal_visitor_id  %>
-  <%= f.hidden_field :processing_state  %>
   <% @visit.visitors.each do |visitor| %>
     <%= hidden_field_tag 'visit[visitor_ids][]', visitor.id  %>
   <% end %>

--- a/spec/features/process_a_request_spec.rb
+++ b/spec/features/process_a_request_spec.rb
@@ -386,5 +386,31 @@ RSpec.feature 'Processing a request', js: true do
         with_subject(/COPY of booking rejection for Oscar Wilde/).
         and_body(/This is a copy of the booking rejection email sent to the visitor/)
     end
+
+    scenario 'trying to double process a visit' do
+      Capybara.using_session('window1') do
+        visit prison_visit_process_path(vst, locale: 'en')
+
+        check 'Prisoner details are incorrect'
+      end
+
+      Capybara.using_session('window2') do
+        visit prison_visit_process_path(vst, locale: 'en')
+
+        check 'Prisoner details are incorrect'
+      end
+
+      Capybara.using_session('window1') do
+        click_button 'Process'
+
+        expect(page).to have_text('Thank you for processing the visit')
+      end
+
+      Capybara.using_session('window2') do
+        click_button 'Process'
+
+        expect(page).to have_text("Visit can't be processed")
+      end
+    end
   end
 end


### PR DESCRIPTION
It was possible to process a visit twice by opening the process page in 2 tabs
and processing them separately.

This change makes it a lot less likely to happen, but still possible. To avoid
it completely we need a state machine that enforces linearibility.