### PR TITLE
Fix Url too long for IE

### DIFF
--- a/app/assets/javascripts/modules/moj.emailPreview.js
+++ b/app/assets/javascripts/modules/moj.emailPreview.js
@@ -17,7 +17,7 @@
 
       var ajaxOptions = {
         url:    event.target.href,
-        method: 'POST',
+        method: 'POST', // not all browsers support PUT and DELETE
         data:   $(this.el).serialize()
       };
 

--- a/app/assets/javascripts/modules/moj.emailPreview.js
+++ b/app/assets/javascripts/modules/moj.emailPreview.js
@@ -15,9 +15,13 @@
     handleClick: function(event) {
       event.preventDefault();
 
+      // not all browsers support PUT and DELETE
+      // The form contains _method input which will be 
+      // picked up by Rack::MethodOverride and translated into 
+      // the corresponding HTTP verb.
       var ajaxOptions = {
         url:    event.target.href,
-        method: 'POST', // not all browsers support PUT and DELETE
+        method: 'POST', 
         data:   $(this.el).serialize()
       };
 

--- a/app/assets/javascripts/modules/moj.emailPreview.js
+++ b/app/assets/javascripts/modules/moj.emailPreview.js
@@ -13,7 +13,20 @@
     },
 
     handleClick: function(event) {
-      event.target.search = $(this.el).serialize();
+      event.preventDefault();
+
+      var ajaxOptions = {
+        url:    event.target.href,
+        method: 'POST',
+        data:   $(this.el).serialize()
+      };
+
+      $.ajax(ajaxOptions).done(function(data) {
+        var emailPreviewWindow = window.open("", "_blank")
+        emailPreviewWindow.document.write(data);
+      }).fail(function(xhr) {
+        alert(xhr.responseText);
+      });
     }
   };
 }());

--- a/app/controllers/prison/email_previews_controller.rb
+++ b/app/controllers/prison/email_previews_controller.rb
@@ -3,11 +3,15 @@ require 'action_mailer/inline_preview_interceptor'
 class Prison::EmailPreviewsController < ApplicationController
   include BookingResponseContext
 
-  def show
+  def update
     if booking_response.valid?
       render html: email_preview
     else
-      render text: booking_response.errors.full_messages
+      render(
+        text: booking_response.
+          errors.full_messages.to_sentence,
+        status: :not_acceptable
+      )
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
     end
 
     resources :visits, only: [] do
-      resource :email_preview, only: :show
+      resource :email_preview, only: :update
     end
 
     scope controller: :dashboards do

--- a/spec/controllers/prison/email_previews_controller_spec.rb
+++ b/spec/controllers/prison/email_previews_controller_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 RSpec.describe Prison::EmailPreviewsController do
   describe 'with an invalid booking response' do
     let(:visit) { create(:visit) }
-    let(:errors) { double(ActiveModel::Errors, full_messages: 'invalid booking response') }
+    let(:errors) { double(ActiveModel::Errors, full_messages: ['invalid booking response']) }
     let(:booking_response) { double(BookingResponse, 'valid?': false, errors:  errors) }
     before do
       expect(BookingResponse).to receive(:new).and_return(booking_response)
     end
     it 'renders the errors message' do
-      get :show, visit_id: visit.id, visit: visit.attributes
+      put :update, visit_id: visit.id, visit: visit.attributes
       expect(response.body).to include('invalid booking response')
     end
   end


### PR DESCRIPTION
**CHANGES:**
In order to circumvent URL being to long for IE the visit process form is serialised and sent using ajax.