### PR TITLE
Set NOMS API timeout to 2 seconds

### DIFF
--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -4,7 +4,7 @@ module Nomis
   APIError = Class.new(StandardError)
 
   class Client
-    TIMEOUT = 5 # seconds
+    TIMEOUT = 2 # seconds
 
     def initialize(host, client_token, client_key)
       @host = host


### PR DESCRIPTION
The timeout needs to be stricter than the timeout in PVB public.