### PR TITLE
Handle and report errors from the Nomis API

### DIFF
--- a/app/services/nomis/api.rb
+++ b/app/services/nomis/api.rb
@@ -36,8 +36,7 @@ module Nomis
       )
 
       build_offender(response)
-    rescue APIError => e
-      Raven.capture_exception(e)
+    rescue APIError
       NullOffender.new(api_call_successful: false)
     end
 

--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -68,9 +68,12 @@ module Nomis
         error = "(invalid-JSON) #{body[0, 80]}"
       end
 
+      Raven.capture_exception(e)
       raise APIError,
         "Unexpected status #{e.response.status} calling #{api_method}: #{error}"
     rescue Excon::Errors::Error => e
+
+      Raven.capture_exception(e)
       raise APIError, "Exception #{e.class} calling #{api_method}: #{e}"
     end
     # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
Handle and report errors from the Nomis API.

400 / 500 errors raise an APIError and it logs the error to Sentry.