### PR TITLE
Set a connection pool for the Nomis API

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -79,5 +79,8 @@ module PrisonVisits
     end
 
     config.staff_info_endpoint = ENV.fetch('STAFF_INFO_ENDPOINT', nil)
+
+    config.connection_pool_size =
+      config.database_configuration[Rails.env]['pool'] || 5
   end
 end

--- a/spec/services/nomis/api_spec.rb
+++ b/spec/services/nomis/api_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.describe Nomis::Api do
   subject { described_class.instance }
 
+  # Ensure that we have a new instance to prevent other specs interfering
+  around do |ex|
+    Singleton.__init__(described_class)
+    ex.run
+    Singleton.__init__(described_class)
+  end
   it 'is implicitly enabled if the api host is configured' do
     expect(Rails.configuration).to receive(:nomis_api_host).and_return(nil)
     expect(described_class.enabled?).to be false


### PR DESCRIPTION
The app runs in a threaded environment so we need to make sure that we have at
least a client available for each thread. If we have less clients than threads
then we could have threads blocked while waiting for the connection to be
released.