### PR TITLE
Feature flags to control prisoner checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,13 @@ The `NOMIS_API_TOKEN` is a JWT token which grants access to the NOMIS API when t
 
 (Optional) If not set API calls will be sent without an Authorization header.
 
+#### `NOMIS_STAFF_PRISONER_CHECK_ENABLED`, `NOMIS_PUBLIC_PRISONER_CHECK_ENABLED`
+
+If `true` then the Nomis API will be used for staff or public to check the
+prisoner validity.
+
+(Optional) By default it is false.
+
 #### `PRISON_ESTATE_IPS`
 
 A semicolon- or comma-separated list of IP addresses or CIDR ranges. Users on

--- a/app/services/api_prisoner_checker.rb
+++ b/app/services/api_prisoner_checker.rb
@@ -1,6 +1,7 @@
 class ApiPrisonerChecker
   def initialize(noms_id:, date_of_birth:)
-    @offender = if Nomis::Api.enabled?
+    @offender = if Nomis::Api.enabled? &&
+                   Rails.configuration.nomis_public_prisoner_check_enabled
                   Nomis::Api.instance.lookup_active_offender(
                     noms_id:       noms_id,
                     date_of_birth: date_of_birth

--- a/app/services/staff_nomis_checker.rb
+++ b/app/services/staff_nomis_checker.rb
@@ -10,7 +10,8 @@ class StaffNomisChecker
   end
 
   def prisoner_existance_status
-    return NOT_LIVE unless @nomis_api_enabled
+    return NOT_LIVE unless prisoner_check_enabled?
+
     case prisoner_existance_error
     when nil
       VALID
@@ -38,6 +39,11 @@ class StaffNomisChecker
   end
 
 private
+
+  def prisoner_check_enabled?
+    @nomis_api_enabled &&
+      Rails.configuration.nomis_staff_prisoner_check_enabled
+  end
 
   def prisoner_validation
     @prisoner_validation ||= PrisonerValidation.new(offender).tap(&:valid?)

--- a/config/application.rb
+++ b/config/application.rb
@@ -82,5 +82,11 @@ module PrisonVisits
 
     config.connection_pool_size =
       config.database_configuration[Rails.env]['pool'] || 5
+
+    config.nomis_staff_prisoner_check_enabled =
+      ENV['NOMIS_STAFF_PRISONER_CHECK_ENABLED'] == 'true'
+
+    config.nomis_public_prisoner_check_enabled =
+      ENV['NOMIS_STAFF_PRISONER_CHECK_ENABLED'] == 'true'
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -24,4 +24,7 @@ Rails.application.configure do
   config.nomis_api_host = 'http://172.22.16.2:8080/'
   config.nomis_api_token = nil
   config.nomis_api_key = nil
+
+  config.nomis_staff_prisoner_check_enabled = true
+  config.nomis_public_prisoner_check_enabled = true
 end

--- a/spec/services/api_prisoner_checker_spec.rb
+++ b/spec/services/api_prisoner_checker_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe ApiPrisonerChecker do
         allow(Nomis::Api).to receive(:enabled?).and_return(true)
       end
 
+      context 'and the check is disabled for public' do
+        before do
+          allow(Rails.configuration).
+            to receive(:nomis_public_prisoner_check_enabled).
+            and_return(false)
+        end
+
+        it { is_expected.to be_valid }
+      end
+
       context 'and the api is working' do
         before do
           expect(Nomis::Api.instance).

--- a/spec/services/staff_nomis_checker_spec.rb
+++ b/spec/services/staff_nomis_checker_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe StaffNomisChecker do
       it { is_expected.to eq('not_live') }
     end
 
+    describe 'api is configured and the check is disabled for staff' do
+      let(:enabled) { true }
+
+      before do
+        allow(Rails.configuration).
+          to receive(:nomis_staff_prisoner_check_enabled).
+          and_return(false)
+      end
+
+      it { is_expected.to eq('not_live') }
+    end
+
     describe 'when the nomis api is live' do
       before do
         expect(PrisonerValidation).to receive(:new).with(offender).and_return(validator)


### PR DESCRIPTION
Introduces 2 feature flags that control the prisoner checks using the Nomis API
for staff or the public.