### PR TITLE
Add feature flags for prisoner availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,13 @@ prisoner validity.
 
 (Optional) By default it is false.
 
+#### `NOMIS_STAFF_PRISONER_AVAILABILITY_ENABLED`, `NOMIS_PUBLIC_PRISONER_AVAILABILITY_ENABLED`
+
+If `true` then the Nomis API will be used for staff or public to check the
+prisoner availability.
+
+(Optional) By default it is false.
+
 #### `PRISON_ESTATE_IPS`
 
 A semicolon- or comma-separated list of IP addresses or CIDR ranges. Users on

--- a/app/services/staff_nomis_checker.rb
+++ b/app/services/staff_nomis_checker.rb
@@ -27,11 +27,12 @@ class StaffNomisChecker
   end
 
   def prisoner_availability_unknown?
-    @nomis_api_enabled && prisoner_availability_validation.unknown_result?
+    prisoner_availability_enabled? &&
+      prisoner_availability_validation.unknown_result?
   end
 
   def errors_for(slot)
-    return [] unless @nomis_api_enabled && offender.valid?
+    return [] unless prisoner_availability_enabled? && offender.valid?
 
     [
       prisoner_availability_validation.date_error(slot.to_date)
@@ -39,6 +40,11 @@ class StaffNomisChecker
   end
 
 private
+
+  def prisoner_availability_enabled?
+    @nomis_api_enabled &&
+      Rails.configuration.nomis_staff_prisoner_availability_enabled
+  end
 
   def prisoner_check_enabled?
     @nomis_api_enabled &&

--- a/config/application.rb
+++ b/config/application.rb
@@ -87,6 +87,17 @@ module PrisonVisits
       ENV['NOMIS_STAFF_PRISONER_CHECK_ENABLED'].try(:downcase) == 'true'
 
     config.nomis_public_prisoner_check_enabled =
-      ENV['NOMIS_STAFF_PRISONER_CHECK_ENABLED'].try(:downcase) == 'true'
+      ENV['NOMIS_PUBLIC_PRISONER_CHECK_ENABLED'].try(:downcase) == 'true'
+
+    # Prisoner availability depends on the prisoner check flag because to check
+    # the availability we need to call the api used in the prisoner check to get
+    # the offender id.
+    config.nomis_staff_prisoner_availibility_enabled =
+      config.nomis_staff_prisoner_check_enabled &&
+      ENV['NOMIS_STAFF_PRISONER_AVAILABILITY_ENABLED'].try(:downcase) == 'true'
+
+    config.nomis_public_prisoner_availability_enabled =
+      config.nomis_public_prisoner_check_enabled &&
+      ENV['NOMIS_PUBLIC_PRISONER_AVAILABILITY_ENABLED'].try(:downcase) == 'true'
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -27,4 +27,7 @@ Rails.application.configure do
 
   config.nomis_staff_prisoner_check_enabled = true
   config.nomis_public_prisoner_check_enabled = true
+
+  config.nomis_staff_prisoner_availability_enabled = true
+  config.nomis_public_prisoner_availability_enabled = true
 end

--- a/spec/services/staff_nomis_checker_spec.rb
+++ b/spec/services/staff_nomis_checker_spec.rb
@@ -78,6 +78,18 @@ RSpec.describe StaffNomisChecker do
       it { is_expected.to eq(false) }
     end
 
+    context 'when the api is enabled and the flag is disabled' do
+      let(:enabled) { true }
+
+      before do
+        allow(Rails.configuration).
+          to receive(:nomis_staff_prisoner_availability_enabled).
+          and_return(false)
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
     context 'when the validator returns unknown' do
       before do
         allow_any_instance_of(PrisonerAvailabilityValidation).
@@ -105,6 +117,18 @@ RSpec.describe StaffNomisChecker do
 
     context 'when the nomis api is not enabled' do
       let(:enabled) { false }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when the api is enabled and the flag is disabled' do
+      let(:enabled) { true }
+
+      before do
+        allow(Rails.configuration).
+          to receive(:nomis_staff_prisoner_availability_enabled).
+          and_return(false)
+      end
 
       it { is_expected.to be_empty }
     end


### PR DESCRIPTION
Enabled by an environment variable. It also depends on the prisoner check
feature flag being enabled, the reason is that to use prisoner availability it
needs to use the same api as the prisoner check.