### PR TITLE
Wormwood Scrubs to APVU - do not merge until 12th December

### DIFF
--- a/config/initializers/dashboard_trial.rb
+++ b/config/initializers/dashboard_trial.rb
@@ -93,6 +93,5 @@ Rails.configuration.dashboard_trial = [
   'Winchester',
   'Woolds',
   'Woodhill',
-  'Wormwood Scrubs',
   'Wymott'
 ]


### PR DESCRIPTION
APVU are going to start managing Wormwood Scrubs' visit requests.
As APVU are currently not using the dashboard, we need to remove Wormwood Scrubs from the dashboard trial.
This will re-enable emails being sent for visit requests to Wormwood Scrubs.