### PR TITLE
Use prisoner availability in slots controller

### DIFF
--- a/app/controllers/api/slots_controller.rb
+++ b/app/controllers/api/slots_controller.rb
@@ -1,17 +1,11 @@
 module Api
   class SlotsController < ApiController
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
     def index
       prison = Prison.enabled.find(params.fetch(:prison_id))
 
-      # Temporarily introduce this API parameter to facilitate experimentation
-      # (Note: using string 'true' because this is a GET parameter)
-      use_nomis = params.fetch(:use_nomis_slots, nil) == 'true'
-
       slot_availability = SlotAvailability.new(
         prison: prison,
-        use_nomis_slots: use_nomis
+        use_nomis_slots: false
       )
       slot_availability.restrict_by_prisoner(
         prisoner_number: params.fetch(:prisoner_number),
@@ -20,7 +14,5 @@ module Api
 
       @slots = slot_availability.slots
     end
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/app/models/slot_availability.rb
+++ b/app/models/slot_availability.rb
@@ -9,8 +9,8 @@ class SlotAvailability
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/AbcSize
   def restrict_by_prisoner(prisoner_number:, prisoner_dob:)
-    # Skip restriction if Nomis api is not enabled
-    return unless Nomis::Api.enabled?
+    # Skip restriction if prisoner availability is enabled
+    return unless public_prisoner_availability_enabled?
 
     offender = Nomis::Api.instance.lookup_active_offender(
       noms_id: prisoner_number,
@@ -41,7 +41,7 @@ private
   end
 
   def nomis_slots(prison)
-    return nil unless Nomis::Api.enabled?
+    return nil unless public_prisoner_availability_enabled?
 
     Nomis::Api.instance.fetch_bookable_slots(
       prison: prison,
@@ -51,5 +51,10 @@ private
   rescue Excon::Errors::Error => e
     Rails.logger.warn "Error calling the NOMIS API: #{e.inspect}"
     nil
+  end
+
+  def public_prisoner_availability_enabled?
+    Nomis::Api.enabled? &&
+      Rails.configuration.nomis_public_prisoner_availability_enabled
   end
 end

--- a/spec/controllers/api/slots_controller_spec.rb
+++ b/spec/controllers/api/slots_controller_spec.rb
@@ -51,11 +51,11 @@ RSpec.describe Api::SlotsController do
       )
     end
 
-    it 'optionally requests nomis slots from SlotAvailability' do
+    it 'ignores requests nomis slots from SlotAvailability' do
       params[:use_nomis_slots] = 'true'
 
       expect(SlotAvailability).to receive(:new).
-        with(hash_including(use_nomis_slots: true)).
+        with(hash_including(use_nomis_slots: false)).
         and_return(slot_availability)
       get :index, params
     end

--- a/spec/models/slot_availability_spec.rb
+++ b/spec/models/slot_availability_spec.rb
@@ -27,9 +27,8 @@ RSpec.describe SlotAvailability, type: :model do
   }
 
   before do
-    allow(Nomis::Api).to receive(:enabled?).and_return(true)
-    allow(Nomis::Api).to receive(:instance).
-      and_return(instance_double(Nomis::Api))
+    allow(Nomis::Api).
+      to receive(:instance).and_return(instance_double(Nomis::Api))
   end
 
   around do |example|
@@ -38,87 +37,115 @@ RSpec.describe SlotAvailability, type: :model do
     end
   end
 
-  it 'fetches slot availability from the prison by default' do
-    expect(subject.slots.map(&:iso8601)).to eq(default_prison_slots)
-  end
-
-  describe 'fetching available slots from NOMIS' do
-    subject { described_class.new(prison: prison, use_nomis_slots: true) }
-
-    it 'can request slots from NOMIS' do
-      expect(Nomis::Api.instance).to receive(:fetch_bookable_slots).
-        with(
-          prison: prison,
-          start_date: Date.parse('2016-04-06'),
-          end_date: Date.parse('2016-04-28')
-        ).
-        and_return([ConcreteSlot.parse('2016-04-12T09:00/10:00')])
-
-      expect(subject.slots.map(&:iso8601)).to eq(['2016-04-12T09:00/10:00'])
+  context 'when the api is disabled' do
+    before do
+      allow(Nomis::Api).to receive(:enabled?).and_return(false)
     end
 
-    it 'falls back to hard-coded slots if NOMIS is disabled' do
-      expect(Nomis::Api).to receive(:enabled?).and_return(false)
-      expect(Nomis::Api.instance).not_to receive(:fetch_bookable_slots)
-
-      expect(subject.slots.map(&:iso8601)).to eq(default_prison_slots)
-    end
-
-    it 'falls back to hard-coded slots if NOMIS call fails' do
-      allow(Nomis::Api.instance).to receive(:fetch_bookable_slots).
-        and_raise(Excon::Errors::Error, 'Fail')
-      expect(Rails.logger).to receive(:warn).with(
-        'Error calling the NOMIS API: #<Excon::Errors::Error: Fail>'
-      )
-
+    it 'fetches slot availability from the prison' do
       expect(subject.slots.map(&:iso8601)).to eq(default_prison_slots)
     end
   end
 
-  describe 'restricting by prisoner availability' do
-    it 'can intersect available slots with prisoner availability' do
-      offender = Nomis::Offender.new(id: 123)
-      prisoner_availability = Nomis::PrisonerAvailability.new(
-        dates: [Date.parse('2016-04-12'), Date.parse('2016-04-25')]
-      )
-
-      expect(Nomis::Api.instance).to receive(:lookup_active_offender).
-        with(noms_id: 'a1234bc', date_of_birth: Date.parse('1970-01-01')).
-        and_return(offender)
-      expect(Nomis::Api.instance).to receive(:offender_visiting_availability).
-        and_return(prisoner_availability)
-
-      subject.restrict_by_prisoner(prisoner_params)
-
-      expect(subject.slots.map(&:iso8601)).to eq(
-        [
-          '2016-04-12T09:00/10:00',
-          '2016-04-12T14:00/16:10',
-          '2016-04-25T14:00/16:10'
-        ]
-      )
+  context 'when the api is enabled' do
+    before do
+      allow(Nomis::Api).to receive(:enabled?).and_return(true)
     end
 
-    it 'returns only prison slots if the NOMIS API is disabled' do
-      expect(Nomis::Api).to receive(:enabled?).and_return(false)
-      expect(Nomis::Api.instance).not_to receive(:lookup_active_offender)
-      expect(Nomis::Api.instance).not_to receive(:offender_visiting_availability)
-
-      subject.restrict_by_prisoner(prisoner_params)
-
+    it 'fetches slot availability from the prison by default' do
       expect(subject.slots.map(&:iso8601)).to eq(default_prison_slots)
     end
 
-    it 'returns only prison slots if the NOMIS API cannot be contacted' do
-      allow(Nomis::Api.instance).to receive(:lookup_active_offender).
-        and_raise(Excon::Errors::Error, 'Lookup error')
-      expect(Rails.logger).to receive(:warn).with(
-        'Error calling the NOMIS API: #<Excon::Errors::Error: Lookup error>'
-      )
+    describe 'fetching available slots from NOMIS' do
+      subject { described_class.new(prison: prison, use_nomis_slots: true) }
 
-      subject.restrict_by_prisoner(prisoner_params)
+      context 'and the feature flag is disabled' do
+        before do
+          expect(Rails.configuration).
+            to receive(:nomis_public_prisoner_availability_enabled).
+            and_return(false)
+        end
 
-      expect(subject.slots.map(&:iso8601)).to eq(default_prison_slots)
+        it 'fetches slot availability from the prison' do
+          expect(subject.slots.map(&:iso8601)).to eq(default_prison_slots)
+        end
+      end
+
+      it 'can request slots from NOMIS' do
+        expect(Nomis::Api.instance).to receive(:fetch_bookable_slots).
+          with(
+            prison: prison,
+            start_date: Date.parse('2016-04-06'),
+            end_date: Date.parse('2016-04-28')
+          ).
+          and_return([ConcreteSlot.parse('2016-04-12T09:00/10:00')])
+
+        expect(subject.slots.map(&:iso8601)).to eq(['2016-04-12T09:00/10:00'])
+      end
+
+      it 'falls back to hard-coded slots if NOMIS is disabled' do
+        expect(Nomis::Api).to receive(:enabled?).and_return(false)
+        expect(Nomis::Api.instance).not_to receive(:fetch_bookable_slots)
+
+        expect(subject.slots.map(&:iso8601)).to eq(default_prison_slots)
+      end
+
+      it 'falls back to hard-coded slots if NOMIS call fails' do
+        allow(Nomis::Api.instance).to receive(:fetch_bookable_slots).
+          and_raise(Excon::Errors::Error, 'Fail')
+        expect(Rails.logger).to receive(:warn).with(
+          'Error calling the NOMIS API: #<Excon::Errors::Error: Fail>'
+        )
+
+        expect(subject.slots.map(&:iso8601)).to eq(default_prison_slots)
+      end
+    end
+
+    describe 'restricting by prisoner availability' do
+      it 'can intersect available slots with prisoner availability' do
+        offender = Nomis::Offender.new(id: 123)
+        prisoner_availability = Nomis::PrisonerAvailability.new(
+          dates: [Date.parse('2016-04-12'), Date.parse('2016-04-25')]
+        )
+
+        expect(Nomis::Api.instance).to receive(:lookup_active_offender).
+          with(noms_id: 'a1234bc', date_of_birth: Date.parse('1970-01-01')).
+          and_return(offender)
+        expect(Nomis::Api.instance).to receive(:offender_visiting_availability).
+          and_return(prisoner_availability)
+
+        subject.restrict_by_prisoner(prisoner_params)
+
+        expect(subject.slots.map(&:iso8601)).to eq(
+          [
+            '2016-04-12T09:00/10:00',
+            '2016-04-12T14:00/16:10',
+            '2016-04-25T14:00/16:10'
+          ]
+        )
+      end
+
+      it 'returns only prison slots if the NOMIS API is disabled' do
+        expect(Nomis::Api).to receive(:enabled?).and_return(false)
+        expect(Nomis::Api.instance).not_to receive(:lookup_active_offender)
+        expect(Nomis::Api.instance).not_to receive(:offender_visiting_availability)
+
+        subject.restrict_by_prisoner(prisoner_params)
+
+        expect(subject.slots.map(&:iso8601)).to eq(default_prison_slots)
+      end
+
+      it 'returns only prison slots if the NOMIS API cannot be contacted' do
+        allow(Nomis::Api.instance).to receive(:lookup_active_offender).
+          and_raise(Excon::Errors::Error, 'Lookup error')
+        expect(Rails.logger).to receive(:warn).with(
+          'Error calling the NOMIS API: #<Excon::Errors::Error: Lookup error>'
+        )
+
+        subject.restrict_by_prisoner(prisoner_params)
+
+        expect(subject.slots.map(&:iso8601)).to eq(default_prison_slots)
+      end
     end
   end
 end


### PR DESCRIPTION
Slots controller can also use the slot availability optionally. I've disabled
this for now with the same prisoner availability flag.

This api action will need revisiting when we start working on implementing the
prisoner availability in prod for the error handling and because public will have
different requirements.