### PR TITLE
Retry Nomis API failed requests

### DIFF
--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -21,7 +21,7 @@ module Nomis
     end
 
     def get(route, params = {})
-      request(:get, route, params)
+      request(:get, route, params, idempotent: true)
     end
 
   # def post(route, params)
@@ -32,7 +32,7 @@ module Nomis
 
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/AbcSize
-    def request(method, route, params)
+    def request(method, route, params, idempotent:)
       # For cleanliness, strip initial / if supplied
       route = route.sub(%r{^\/}, '')
       path = "/nomisapi/#{route}"
@@ -42,6 +42,8 @@ module Nomis
         method: method,
         path: path,
         expects: [200],
+        idempotent: idempotent,
+        retry_limit: 2,
         headers: {
           'Accept' => 'application/json',
           'Authorization' => auth_header,

--- a/spec/fixtures/vcr_cassettes/lookup_active_offender-error.yml
+++ b/spec/fixtures/vcr_cassettes/lookup_active_offender-error.yml
@@ -27,4 +27,31 @@ http_interactions:
       string: 'internal server error'
     http_version:
   recorded_at: Tue, 29 Mar 2016 14:49:54 GMT
+- request:
+    method: get
+    uri: http://172.22.16.2:8080/nomisapi/lookup/active_offender?date_of_birth=1976-06-12&noms_id=A1459AE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.47.0
+      Accept:
+      - application/json
+  response:
+    status:
+      code: 500
+      message: ''
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 29 Mar 2016 14:49:29 GMT
+    body:
+      encoding: UTF-8
+      string: 'internal server error'
+    http_version:
+  recorded_at: Tue, 29 Mar 2016 14:49:54 GMT
 recorded_with: VCR 3.0.1


### PR DESCRIPTION
This should solve EOFError caused by terminated persistent connections by the
server and other flakey errors that we are getting from the API.

Marking the request as idempotent (if possible) is what Excon recommends for
solving EOFError's. Internally idemptoent requests that fail have the connection
reset.

The retry limit is set to 2, the minimum, which will reset stale connections
and avoid hitting the rate limiting.