### PR TITLE
Revert "Add irbrc file"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,1 @@
-
 config/*.example
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY config/irbrc.example ~/.irbrc
-
 ENV UNICORN_PORT 3000
 EXPOSE $UNICORN_PORT
 


### PR DESCRIPTION
Reverts ministryofjustice/prison-visits-2#649

Docker builds have been failing since this was merged because irbc.example file is not available for the COPY docker command.