### PR TITLE
Add instrumentation to API logs

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -7,8 +7,6 @@ module Api
     before_action :store_request_id
     before_action :enforce_json
 
-    after_action :log_api_counters
-
     rescue_from ActionController::ParameterMissing do |e|
       render_error 422, "Missing parameter: #{e.param}"
     end
@@ -49,19 +47,6 @@ module Api
       RequestStore.store[:request_id] = request.uuid
       Instrumentation.append_to_log(request_id: RequestStore.store[:request_id])
       Raven.extra_context(request_id: RequestStore.store[:request_id])
-    end
-
-    def log_api_counters
-      Instrumentation.append_to_log(api_request_count: api_request_count)
-      Instrumentation.append_to_log(api_error_count:   api_error_count)
-    end
-
-    def api_request_count
-      RequestStore.store[:api_request_count]
-    end
-
-    def api_error_count
-      RequestStore.store[:api_error_count]
     end
 
     def enforce_json

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -7,6 +7,8 @@ module Api
     before_action :store_request_id
     before_action :enforce_json
 
+    after_action :log_api_counters
+
     rescue_from ActionController::ParameterMissing do |e|
       render_error 422, "Missing parameter: #{e.param}"
     end
@@ -40,15 +42,26 @@ module Api
     # part of Rails' instrumentation code, and is run after each request.
     def append_info_to_payload(payload)
       super
-
-      payload[:custom_log_items] = {
-        request_id: RequestStore.store[:request_id]
-      }
+      payload[:custom_log_items] = Instrumentation.custom_log_items
     end
 
     def store_request_id
       RequestStore.store[:request_id] = request.uuid
+      Instrumentation.append_to_log(request_id: RequestStore.store[:request_id])
       Raven.extra_context(request_id: RequestStore.store[:request_id])
+    end
+
+    def log_api_counters
+      Instrumentation.append_to_log(api_request_count: api_request_count)
+      Instrumentation.append_to_log(api_error_count:   api_error_count)
+    end
+
+    def api_request_count
+      RequestStore.store[:api_request_count]
+    end
+
+    def api_error_count
+      RequestStore.store[:api_error_count]
     end
 
     def enforce_json

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,8 +10,6 @@ class ApplicationController < ActionController::Base
   before_action :log_current_estates
   before_action :log_current_user
 
-  after_action :log_api_counters
-
   helper LinksHelper
   helper_method :current_user
   helper_method :sso_identity
@@ -125,18 +123,5 @@ private
     if current_user
       append_to_log(user_id: current_user.id)
     end
-  end
-
-  def log_api_counters
-    append_to_log(api_request_count: api_request_count)
-    append_to_log(api_error_count:   api_error_count)
-  end
-
-  def api_request_count
-    RequestStore.store[:api_request_count]
-  end
-
-  def api_error_count
-    RequestStore.store[:api_error_count]
   end
 end

--- a/app/services/instrumentation.rb
+++ b/app/services/instrumentation.rb
@@ -23,6 +23,11 @@ module Instrumentation
       result
     end
 
+    def inc_custom_log_item(item)
+      old_value = custom_log_items[item] || 0
+      append_to_log(item => old_value + 1)
+    end
+
   private
 
     def time_action

--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -113,13 +113,11 @@ module Nomis
     end
 
     def increment_request_count
-      RequestStore.store[:api_request_count] ||= 0
-      RequestStore.store[:api_request_count] += 1
+      Instrumentation.inc_custom_log_item(:api_request_count)
     end
 
     def increment_error_count
-      RequestStore.store[:api_error_count] ||= 0
-      RequestStore.store[:api_error_count] += 1
+      Instrumentation.inc_custom_log_item(:api_error_count)
     end
   end
 end

--- a/spec/services/instrumentation_spec.rb
+++ b/spec/services/instrumentation_spec.rb
@@ -15,6 +15,19 @@ RSpec.describe Instrumentation do
     RequestStore.clear!
   end
 
+  describe '.inc_custom_log_item' do
+    it 'adds new items with a value of 1' do
+      expect(described_class.inc_custom_log_item(:foo)).
+        to eq(foo: 1)
+    end
+
+    it 'increments existing values' do
+      described_class.inc_custom_log_item(:foo)
+      expect(described_class.inc_custom_log_item(:foo)).
+        to eq(foo: 2)
+    end
+  end
+
   describe '.append_to_log' do
     it 'adds' do
       expect(described_class.append_to_log(fu: 'bar')).

--- a/spec/services/nomis/client_spec.rb
+++ b/spec/services/nomis/client_spec.rb
@@ -71,7 +71,8 @@ RSpec.describe Nomis::Client do
     it 'increments the request count' do
       expect {
         subject.get(path, params)
-      }.to raise_error(Nomis::APIError).and change { RequestStore.store[:api_request_count] }.from(nil).to(1)
+      }.to raise_error(Nomis::APIError).
+        and change { Instrumentation.custom_log_items[:api_request_count] }.from(nil).to(1)
     end
   end
 
@@ -101,7 +102,8 @@ RSpec.describe Nomis::Client do
     it 'increments the api error count' do
       expect {
         subject.get(path, params)
-      }.to raise_error(Nomis::APIError).and change { RequestStore.store[:api_error_count] }.from(nil).to(1)
+      }.to raise_error(Nomis::APIError).
+        and change { Instrumentation.custom_log_items[:api_request_count] }.from(nil).to(1)
     end
   end
 


### PR DESCRIPTION
We were recording other data that wasn't being added to the logs for API calls.