### PR TITLE
Fingerprint Excon and ApiError's sent to Sentry

### DIFF
--- a/app/services/nomis/api.rb
+++ b/app/services/nomis/api.rb
@@ -34,7 +34,7 @@ module Nomis
         Instrumentation.append_to_log(valid_offender_lookup: !!response['found'])
       end
     rescue APIError => e
-      Raven.capture_exception(e)
+      Raven.capture_exception(e, fingerprint: %w[nomis api_error])
       NullOffender.new(api_call_successful: false)
     end
 

--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -65,11 +65,11 @@ module Nomis
         error = "(invalid-JSON) #{body[0, 80]}"
       end
 
-      Raven.capture_exception(e)
+      Raven.capture_exception(e, fingerprint: excon_fingerprint)
       raise APIError,
         "Unexpected status #{e.response.status} calling #{api_method}: #{error}"
     rescue Excon::Errors::Error => e
-      Raven.capture_exception(e)
+      Raven.capture_exception(e, fingerprint: excon_fingerprint)
       raise APIError, "Exception #{e.class} calling #{api_method}: #{e}"
     end
     # rubocop:enable Metrics/MethodLength
@@ -102,6 +102,10 @@ module Nomis
         token: client_token
       }
       JWT.encode(payload, client_key, 'ES256')
+    end
+
+    def excon_fingerprint
+      %w[nomis excon]
     end
   end
 end

--- a/spec/services/nomis/client_spec.rb
+++ b/spec/services/nomis/client_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Nomis::Client do
     end
 
     it 'sends the error to sentry' do
-      expect(Raven).to receive(:capture_exception).with(error)
+      expect(Raven).to receive(:capture_exception).with(error, fingerprint: %w[nomis excon])
 
       expect { subject.get(path, params) }.to raise_error(Nomis::APIError)
     end
@@ -81,7 +81,7 @@ RSpec.describe Nomis::Client do
     end
 
     it 'sends the error to sentry' do
-      expect(Raven).to receive(:capture_exception).with(error)
+      expect(Raven).to receive(:capture_exception).with(error, fingerprint: %w[nomis excon])
 
       expect { subject.get(path, params) }.to raise_error(Nomis::APIError)
     end


### PR DESCRIPTION
This will make these error's to be rolled up together in Sentry. It should solve
the issue of these errors introducing noise because we'll be able to snooze
them.