### PR TITLE
Automate selection of 'slot unavailable' reason

### DIFF
--- a/app/decorators/visit_decorator.rb
+++ b/app/decorators/visit_decorator.rb
@@ -6,6 +6,7 @@ class VisitDecorator < Draper::Decorator
     :prisoner_existance_error,
     :prisoner_availability_unknown?,
     :slot_availability_unknown?,
+    :slots_unavailable?,
     to: :nomis_checker
 
   def prisoner_details_incorrect

--- a/app/services/null_staff_nomis_checker.rb
+++ b/app/services/null_staff_nomis_checker.rb
@@ -20,4 +20,8 @@ class NullStaffNomisChecker
   def prisoner_availability_enabled?
     false
   end
+
+  def slots_unavailable?
+    false
+  end
 end

--- a/app/services/staff_nomis_checker.rb
+++ b/app/services/staff_nomis_checker.rb
@@ -63,6 +63,13 @@ class StaffNomisChecker
         staff_prisons_with_slot_availability.include?(@visit.prison_name)
   end
 
+  def slots_unavailable?
+    @visit.slots.all? do |s|
+      s.to_date <= Date.current ||
+        errors_for(s).include?(SlotAvailabilityValidation::SLOT_NOT_AVAILABLE)
+    end
+  end
+
 private
 
   def prisoner_check_enabled?

--- a/app/views/prison/visits/_visit_date_section.html.erb
+++ b/app/views/prison/visits/_visit_date_section.html.erb
@@ -40,7 +40,7 @@
   <div class="column-two-thirds push-top">
       <%= error_container f, :slot_granted do %>
       <label class="block-label">
-        <%= f.radio_button :slot_granted, Rejection::SLOT_UNAVAILABLE, { class: 'js-Conditional' }%>
+        <%= f.radio_button :slot_granted, Rejection::SLOT_UNAVAILABLE, { checked: @visit.slots_unavailable?, class: 'js-Conditional' }%>
         <%= t('.none_available') %>
       </label>
     <% end %>

--- a/spec/services/null_staff_nomis_checker_spec.rb
+++ b/spec/services/null_staff_nomis_checker_spec.rb
@@ -20,4 +20,8 @@ RSpec.describe NullStaffNomisChecker do
   describe '#prisoner_availability_enabled?' do
     it { expect(subject.prisoner_availability_enabled?).to eq(false) }
   end
+
+  describe '#slots_unavailable?' do
+    it { expect(subject.slots_unavailable?).to eq(false) }
+  end
 end


### PR DESCRIPTION
When all the slots are either expired (today or older) or not available based on
slot availability.

For prisons that don't have slot availability selected only the expiry check
applies.