### PR TITLE
Stop calculating unused distribution metrics

### DIFF
--- a/app/metrics/support/percentile_support.rb
+++ b/app/metrics/support/percentile_support.rb
@@ -3,11 +3,7 @@ require_relative './metrics_support'
 module PercentileSupport
   include MetricsSupport
 
-  CENTILES = [99, 95, 90, 75, 50, 25]
-
-  def centiles
-    CENTILES
-  end
+  CENTILES = [95, 50].freeze
 
   def fetch_and_format(aggregate = nil)
     ordered_counters.each_with_object({}) do |values, result|
@@ -23,6 +19,6 @@ module PercentileSupport
 private
 
   def hash_centiles(result)
-    Hash[centiles.zip(result)]
+    Hash[CENTILES.zip(result)]
   end
 end

--- a/db/migrate/20170213110434_update_distributions_to_version_2.rb
+++ b/db/migrate/20170213110434_update_distributions_to_version_2.rb
@@ -1,0 +1,8 @@
+class UpdateDistributionsToVersion2 < ActiveRecord::Migration
+  def change
+    update_view :distributions, version: 2, revert_to_version: 1
+    update_view :distribution_by_prisons, version: 2, revert_to_version: 1
+    update_view :distribution_by_prison_and_calendar_weeks, version: 2, revert_to_version: 1
+    update_view :distribution_by_prison_and_calendar_dates, version: 2, revert_to_version: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170109180349) do
+ActiveRecord::Schema.define(version: 20170213110434) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -224,44 +224,6 @@ ActiveRecord::Schema.define(version: 20170109180349) do
      FROM (visits
        JOIN prisons ON ((prisons.id = visits.prison_id)))
     GROUP BY visits.processing_state, prisons.name, (date_part('day'::text, visits.created_at))::integer, (date_part('month'::text, visits.created_at))::integer, (date_part('year'::text, visits.created_at))::integer;
-  SQL
-
-  create_view :distributions,  sql_definition: <<-SQL
-      SELECT percentile_disc((ARRAY[0.99, 0.95, 0.90, 0.75, 0.50, 0.25])::double precision[]) WITHIN GROUP (ORDER BY date_part('epoch'::text, (vsc.created_at - v.created_at))) AS percentiles
-     FROM (visits v
-       JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY ((ARRAY['booked'::character varying, 'rejected'::character varying])::text[])))));
-  SQL
-
-  create_view :distribution_by_prisons,  sql_definition: <<-SQL
-      SELECT prisons.name AS prison_name,
-      percentile_disc((ARRAY[0.99, 0.95, 0.90, 0.75, 0.50, 0.25])::double precision[]) WITHIN GROUP (ORDER BY (round(date_part('epoch'::text, (vsc.created_at - v.created_at))))::integer) AS percentiles
-     FROM ((visits v
-       JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY ((ARRAY['booked'::character varying, 'rejected'::character varying])::text[])))))
-       JOIN prisons ON ((prisons.id = v.prison_id)))
-    GROUP BY prisons.name;
-  SQL
-
-  create_view :distribution_by_prison_and_calendar_weeks,  sql_definition: <<-SQL
-      SELECT prisons.name AS prison_name,
-      percentile_disc((ARRAY[0.99, 0.95, 0.90, 0.75, 0.50, 0.25])::double precision[]) WITHIN GROUP (ORDER BY (round(date_part('epoch'::text, (vsc.created_at - v.created_at))))::integer) AS percentiles,
-      (date_part('isoyear'::text, v.created_at))::integer AS year,
-      (date_part('week'::text, v.created_at))::integer AS week
-     FROM ((visits v
-       JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY ((ARRAY['booked'::character varying, 'rejected'::character varying])::text[])))))
-       JOIN prisons ON ((prisons.id = v.prison_id)))
-    GROUP BY prisons.name, (date_part('week'::text, v.created_at))::integer, (date_part('isoyear'::text, v.created_at))::integer;
-  SQL
-
-  create_view :distribution_by_prison_and_calendar_dates,  sql_definition: <<-SQL
-      SELECT prisons.name AS prison_name,
-      percentile_disc((ARRAY[0.99, 0.95, 0.90, 0.75, 0.50, 0.25])::double precision[]) WITHIN GROUP (ORDER BY (round(date_part('epoch'::text, (vsc.created_at - v.created_at))))::integer) AS percentiles,
-      (date_part('year'::text, v.created_at))::integer AS year,
-      (date_part('month'::text, v.created_at))::integer AS month,
-      (date_part('day'::text, v.created_at))::integer AS day
-     FROM ((visits v
-       JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY ((ARRAY['booked'::character varying, 'rejected'::character varying])::text[])))))
-       JOIN prisons ON ((prisons.id = v.prison_id)))
-    GROUP BY prisons.name, (date_part('day'::text, v.created_at))::integer, (date_part('month'::text, v.created_at))::integer, (date_part('year'::text, v.created_at))::integer;
   SQL
 
   create_view :count_overdue_visits,  sql_definition: <<-SQL
@@ -519,6 +481,44 @@ ActiveRecord::Schema.define(version: 20170109180349) do
       visit_count_by_prison_and_date total
     WHERE (((rejected.prison_name)::text = (total.prison_name)::text) AND (rejected.date = total.date))
     GROUP BY rejected.prison_name, rejected.prison_id, rejected.reason, round((((rejected.rejected_count)::numeric / (total.total_count)::numeric) * (100)::numeric), 2), rejected.date;
+  SQL
+
+  create_view :distributions,  sql_definition: <<-SQL
+      SELECT percentile_disc((ARRAY[0.95, 0.50])::double precision[]) WITHIN GROUP (ORDER BY date_part('epoch'::text, (vsc.created_at - v.created_at))) AS percentiles
+     FROM (visits v
+       JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY ((ARRAY['booked'::character varying, 'rejected'::character varying])::text[])))));
+  SQL
+
+  create_view :distribution_by_prisons,  sql_definition: <<-SQL
+      SELECT prisons.name AS prison_name,
+      percentile_disc((ARRAY[0.95, 0.50])::double precision[]) WITHIN GROUP (ORDER BY (round(date_part('epoch'::text, (vsc.created_at - v.created_at))))::integer) AS percentiles
+     FROM ((visits v
+       JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY ((ARRAY['booked'::character varying, 'rejected'::character varying])::text[])))))
+       JOIN prisons ON ((prisons.id = v.prison_id)))
+    GROUP BY prisons.name;
+  SQL
+
+  create_view :distribution_by_prison_and_calendar_weeks,  sql_definition: <<-SQL
+      SELECT prisons.name AS prison_name,
+      percentile_disc((ARRAY[0.95, 0.50])::double precision[]) WITHIN GROUP (ORDER BY (round(date_part('epoch'::text, (vsc.created_at - v.created_at))))::integer) AS percentiles,
+      (date_part('isoyear'::text, v.created_at))::integer AS year,
+      (date_part('week'::text, v.created_at))::integer AS week
+     FROM ((visits v
+       JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY ((ARRAY['booked'::character varying, 'rejected'::character varying])::text[])))))
+       JOIN prisons ON ((prisons.id = v.prison_id)))
+    GROUP BY prisons.name, (date_part('week'::text, v.created_at))::integer, (date_part('isoyear'::text, v.created_at))::integer;
+  SQL
+
+  create_view :distribution_by_prison_and_calendar_dates,  sql_definition: <<-SQL
+      SELECT prisons.name AS prison_name,
+      percentile_disc((ARRAY[0.95, 0.50])::double precision[]) WITHIN GROUP (ORDER BY (round(date_part('epoch'::text, (vsc.created_at - v.created_at))))::integer) AS percentiles,
+      (date_part('year'::text, v.created_at))::integer AS year,
+      (date_part('month'::text, v.created_at))::integer AS month,
+      (date_part('day'::text, v.created_at))::integer AS day
+     FROM ((visits v
+       JOIN visit_state_changes vsc ON (((v.id = vsc.visit_id) AND ((vsc.visit_state)::text = ANY ((ARRAY['booked'::character varying, 'rejected'::character varying])::text[])))))
+       JOIN prisons ON ((prisons.id = v.prison_id)))
+    GROUP BY prisons.name, (date_part('day'::text, v.created_at))::integer, (date_part('month'::text, v.created_at))::integer, (date_part('year'::text, v.created_at))::integer;
   SQL
 
 end

--- a/db/views/distribution_by_prison_and_calendar_dates_v02.sql
+++ b/db/views/distribution_by_prison_and_calendar_dates_v02.sql
@@ -1,0 +1,14 @@
+SELECT prisons.name AS prison_name,
+       PERCENTILE_DISC(ARRAY[0.95, 0.50])
+         WITHIN GROUP (ORDER BY ROUND(EXTRACT(EPOCH FROM vsc.created_at - v.created_at))::integer) AS percentiles,
+       extract(year from v.created_at)::integer AS year,
+       extract(month from v.created_at)::integer AS month,
+       extract(day from v.created_at)::integer AS day
+FROM visits AS v
+INNER JOIN visit_state_changes AS vsc ON v.id = vsc.visit_id AND vsc.visit_state IN ('booked', 'rejected')
+INNER JOIN prisons ON prisons.id = v.prison_id
+GROUP BY prison_name,
+         day,
+         month,
+         year;
+

--- a/db/views/distribution_by_prison_and_calendar_weeks_v02.sql
+++ b/db/views/distribution_by_prison_and_calendar_weeks_v02.sql
@@ -1,0 +1,11 @@
+SELECT prisons.name AS prison_name,
+       PERCENTILE_DISC(ARRAY[0.95, 0.50])
+         WITHIN GROUP (ORDER BY ROUND(EXTRACT(EPOCH FROM vsc.created_at - v.created_at))::integer) AS percentiles,
+       extract(isoyear from v.created_at)::integer AS year,
+       extract(week from v.created_at)::integer AS week
+FROM visits AS v
+INNER JOIN visit_state_changes AS vsc ON v.id = vsc.visit_id AND vsc.visit_state IN ('booked', 'rejected')
+INNER JOIN prisons ON prisons.id = v.prison_id
+GROUP BY prison_name,
+         week,
+         year;

--- a/db/views/distribution_by_prisons_v02.sql
+++ b/db/views/distribution_by_prisons_v02.sql
@@ -1,0 +1,7 @@
+SELECT prisons.name AS prison_name,
+       PERCENTILE_DISC(ARRAY[0.95, 0.50])
+         WITHIN GROUP (ORDER BY ROUND(EXTRACT(EPOCH FROM vsc.created_at - v.created_at))::integer) AS percentiles
+FROM visits AS v
+INNER JOIN visit_state_changes AS vsc ON v.id = vsc.visit_id AND vsc.visit_state IN ('booked', 'rejected')
+INNER JOIN prisons ON prisons.id = v.prison_id
+GROUP BY prison_name;

--- a/db/views/distributions_v02.sql
+++ b/db/views/distributions_v02.sql
@@ -1,0 +1,4 @@
+SELECT percentile_disc(ARRAY[0.95,0.50])
+         WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM vsc.created_at - v.created_at)) AS percentiles
+FROM visits AS v
+INNER JOIN visit_state_changes AS vsc ON v.id = vsc.visit_id AND vsc.visit_state IN ('booked', 'rejected');

--- a/spec/metrics/percentiles_spec.rb
+++ b/spec/metrics/percentiles_spec.rb
@@ -6,39 +6,26 @@ RSpec.describe Percentiles do
     include_examples 'create and process visits timed by seconds'
 
     describe Percentiles::Distribution do
-      it 'returns the 99% 95% 90% 75% 50% 25% times' do
+      it 'returns the 95% 50% times' do
         expect(described_class.fetch_and_format).to be ==
           {
-            99 => 55,
             95 => 55,
-            90 => 34,
-            75 => 21,
-            50 => 5,
-            25 => 2
+            50 => 5
           }
       end
     end
-
     describe Percentiles::DistributionByPrison do
-      it 'returns the 99% 95% 90% 75% 50% 25% times' do
+      it 'returns the 95% 50% times' do
         expect(described_class.fetch_and_format).to be ==
           { 'Lunar Penal Colony' =>
             {
-              99 => 55,
               95 => 55,
-              90 => 34,
-              75 => 21,
-              50 => 5,
-              25 => 2
+              50 => 5
             },
             'Martian Penal Colony' =>
             {
-              99 => 55,
               95 => 55,
-              90 => 34,
-              75 => 21,
-              50 => 5,
-              25 => 2
+              50 => 5
             }
         }
       end
@@ -61,28 +48,16 @@ RSpec.describe Percentiles do
               { 5 =>
                 {
                   95 => 777_600,
-                  99 => 777_600,
-                  90 => 777_600,
-                  75 => 777_600,
-                  50 => 432_000,
-                  25 => 259_200
+                  50 => 432_000
                 },
                 6 =>
                 {
-                  99 => 777_600,
                   95 => 777_600,
-                  90 => 777_600,
-                  75 => 777_600,
-                  50 => 432_000,
-                  25 => 259_200
+                  50 => 432_000
                 },
                 7 => {
-                  99 => 777_600,
                   95 => 777_600,
-                  90 => 777_600,
-                  50 => 432_000,
-                  75 => 777_600,
-                  25 => 259_200
+                  50 => 432_000
                 }
               }
             }
@@ -102,29 +77,17 @@ RSpec.describe Percentiles do
                 2016 =>
                 { 5 =>
                   {
-                    99 => 777_600,
                     95 => 777_600,
-                    90 => 777_600,
-                    75 => 777_600,
-                    50 => 432_000,
-                    25 => 259_200
+                    50 => 432_000
                   },
                   6 =>
                   {
-                    99 => 777_600,
                     95 => 777_600,
-                    90 => 777_600,
-                    75 => 777_600,
-                    50 => 432_000,
-                    25 => 259_200
+                    50 => 432_000
                   },
                   7 => {
-                    99 => 777_600,
                     95 => 777_600,
-                    90 => 777_600,
-                    75 => 777_600,
-                    50 => 432_000,
-                    25 => 259_200
+                    50 => 432_000
                   }
                 }
               }
@@ -137,7 +100,7 @@ RSpec.describe Percentiles do
           luna_visits_with_dates
         end
 
-        it 'calculates distribution and groups by prison, nested calendar date and visit state' do
+        it 'calculates distribution and groups by prison, nested calendar date' do
           expect(described_class.fetch_and_format).to be ==
             { 'Lunar Penal Colony' =>
               {
@@ -146,29 +109,17 @@ RSpec.describe Percentiles do
                   {
                     1 =>
                     {
-                      99 => 777_600,
                       95 => 777_600,
-                      90 => 777_600,
-                      75 => 777_600,
-                      50 => 432_000,
-                      25 => 259_200
+                      50 => 432_000
                     },
                     8 =>
                     {
-                      99 => 777_600,
                       95 => 777_600,
-                      90 => 777_600,
-                      75 => 777_600,
-                      50 => 432_000,
-                      25 => 259_200
+                      50 => 432_000
                     },
                     15 => {
-                      99 => 777_600,
                       95 => 777_600,
-                      90 => 777_600,
-                      75 => 777_600,
-                      50 => 432_000,
-                      25 => 259_200
+                      50 => 432_000
                     }
                   }
                 }
@@ -182,7 +133,7 @@ RSpec.describe Percentiles do
             luna_visits_with_dates
           end
 
-          it 'counts visits and groups by year, calendar week and visit state' do
+          it 'counts visits and groups by calendar date' do
             expect(described_class.fetch_and_format(:concatenate)).to be ==
               { 'all' =>
                 {
@@ -191,29 +142,17 @@ RSpec.describe Percentiles do
                     {
                       1 =>
                       {
-                        99 => 777_600,
                         95 => 777_600,
-                        90 => 777_600,
-                        75 => 777_600,
-                        50 => 432_000,
-                        25 => 259_200
+                        50 => 432_000
                       },
                       8 =>
                       {
-                        99 => 777_600,
                         95 => 777_600,
-                        90 => 777_600,
-                        75 => 777_600,
-                        50 => 432_000,
-                        25 => 259_200
+                        50 => 432_000
                       },
                       15 => {
-                        99 => 777_600,
                         95 => 777_600,
-                        90 => 777_600,
-                        75 => 777_600,
-                        50 => 432_000,
-                        25 => 259_200
+                        50 => 432_000
                       }
                     }
                   }


### PR DESCRIPTION
Removes the 99, 75, 25 percentiles which are unused.

I've tried removing the views and inlining the query but came up with 2 issues.

First one was that by using `ActiveRecord.connection.execute` it didn't decode
the array value in the result.

Second one was that we filter the query by prison and week, this is easy to do
with views by using `where` but becomes more complex when using raw SQL queries.