### PR TITLE
Generate random human friendly visit ids

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ ruby '2.3.0'
 gem 'rails', '~> 4.2.3'
 
 gem 'connection_pool'
-gem 'base32-crockford', require: false
+gem 'base32-crockford', require: 'base32/crockford'
 gem 'excon'
 gem 'highline', require: false
 gem 'jbuilder'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby '2.3.0'
 gem 'rails', '~> 4.2.3'
 
 gem 'connection_pool'
+gem 'base32-crockford', require: false
 gem 'excon'
 gem 'highline', require: false
 gem 'jbuilder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
+    base32-crockford (0.1.0)
     brakeman (3.5.0)
     builder (3.2.3)
     byebug (9.0.6)
@@ -333,6 +334,7 @@ PLATFORMS
 
 DEPENDENCIES
   awesome_print
+  base32-crockford
   brakeman
   byebug
   capybara

--- a/app/controllers/api/visits_controller.rb
+++ b/app/controllers/api/visits_controller.rb
@@ -1,3 +1,5 @@
+require 'human_readable_id'
+
 module Api
   class VisitsController < ApiController
     # When this app not longer handles all the booking steps it will probably be
@@ -76,7 +78,15 @@ module Api
     end
 
     def visit
-      @_visit ||= Visit.find(params[:id])
+      # TODO: Delete the PK (id) lookup after people stop clicking on emails
+      # using the guids ids.
+      @_visit ||= begin
+                    if HumanReadableId.human_readable?(params[:id])
+                      Visit.find_by!(human_id: params[:id])
+                    else
+                      Visit.find(params[:id])
+                    end
+                  end
     end
 
     def fail_if_invalid(param, step)

--- a/app/models/booking_response.rb
+++ b/app/models/booking_response.rb
@@ -24,7 +24,8 @@ class BookingResponse
         :slot_granted,
         :slot_option_0,
         :slot_option_1,
-        :slot_option_2
+        :slot_option_2,
+        :human_id
       ],
       methods: [
         :principal_visitor_id

--- a/app/services/booking_request_creator.rb
+++ b/app/services/booking_request_creator.rb
@@ -1,3 +1,5 @@
+require 'human_readable_id'
+
 class BookingRequestCreator
   def create!(prisoner_step, visitors_step, slots_step, locale)
     create_visit(prisoner_step, visitors_step, slots_step, locale).tap { |visit|
@@ -10,8 +12,9 @@ private
   def create_visit(prisoner_step, visitors_step, slots_step, locale)
     ActiveRecord::Base.transaction do
       visit = build_visit(prisoner_step, visitors_step, slots_step, locale)
-
       visit.save!
+      human_id = HumanReadableId.update_unique_id(Visit, visit.id, :human_id)
+      visit.human_id = human_id
       create_visitors(visitors_step, visit)
       visit
     end

--- a/app/views/api/visits/show.json.jbuilder
+++ b/app/views/api/visits/show.json.jbuilder
@@ -1,5 +1,6 @@
 json.visit do
   json.id @visit.id
+  json.human_id @visit.human_id
   json.processing_state @visit.processing_state
   json.prison_id @visit.prison.id
   json.confirm_by @visit.confirm_by

--- a/db/migrate/20170220141246_add_human_id_to_visits.rb
+++ b/db/migrate/20170220141246_add_human_id_to_visits.rb
@@ -1,0 +1,5 @@
+class AddHumanIdToVisits < ActiveRecord::Migration
+  def change
+    add_column :visits, :human_id, :string
+  end
+end

--- a/db/migrate/20170220141458_add_human_id_unique_index_to_visits.rb
+++ b/db/migrate/20170220141458_add_human_id_unique_index_to_visits.rb
@@ -1,0 +1,7 @@
+class AddHumanIdUniqueIndexToVisits < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_index :visits, :human_id, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170213110434) do
+ActiveRecord::Schema.define(version: 20170220141458) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -164,8 +164,10 @@ ActiveRecord::Schema.define(version: 20170213110434) do
     t.boolean  "closed"
     t.uuid     "prisoner_id",                                             null: false
     t.string   "locale",                  limit: 2,                       null: false
+    t.string   "human_id"
   end
 
+  add_index "visits", ["human_id"], name: "index_visits_on_human_id", unique: true, using: :btree
   add_index "visits", ["prison_id"], name: "index_visits_on_prison_id", using: :btree
 
   add_foreign_key "cancellations", "visits"

--- a/lib/human_readable_id.rb
+++ b/lib/human_readable_id.rb
@@ -1,0 +1,21 @@
+class HumanReadableId
+  MAX_NUMBER = Base32::Crockford.decode('ZZZZZZZZ') # Largest 8 digit number
+
+  def self.update_unique_id(klass, primary_key, column)
+    ActiveRecord::Base.transaction(requires_new: true) do
+      generate_id do |candidate_id|
+        klass.
+          where(id: primary_key, column => nil).
+          update_all(column => candidate_id)
+        candidate_id
+      end
+    end
+  rescue ActiveRecord::RecordNotUnique
+    retry
+  end
+
+  def self.generate_id
+    random_number = SecureRandom.random_number(MAX_NUMBER)
+    yield Base32::Crockford.encode(random_number, length: 8)
+  end
+end

--- a/lib/human_readable_id.rb
+++ b/lib/human_readable_id.rb
@@ -1,5 +1,6 @@
 class HumanReadableId
-  MAX_NUMBER = Base32::Crockford.decode('ZZZZZZZZ') # Largest 8 digit number
+  ID_LENGTH = 8
+  MAX_NUMBER = Base32::Crockford.decode('Z' * ID_LENGTH) # Largest 8 digit number
 
   def self.update_unique_id(klass, primary_key, column)
     ActiveRecord::Base.transaction(requires_new: true) do
@@ -16,6 +17,10 @@ class HumanReadableId
 
   def self.generate_id
     random_number = SecureRandom.random_number(MAX_NUMBER)
-    yield Base32::Crockford.encode(random_number, length: 8)
+    yield Base32::Crockford.encode(random_number, length: ID_LENGTH)
+  end
+
+  def self.human_readable?(id)
+    id.size <= ID_LENGTH
   end
 end

--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -207,6 +207,21 @@ namespace :pvb do
     STDOUT.puts "Bad range: #{SlotAvailabilityCounter.bad_range}"
     STDOUT.puts "Unchecked: #{SlotAvailabilityCounter.hard_failures}"
   end
+
+  desc 'Populate visits friendly id'
+  task populate_visits_human_id: :environment do
+    require 'human_readable_id'
+
+    query = Visit.where(human_id: nil).limit(1000)
+    batch = query.pluck(:id)
+    while batch.any?
+      batch.each do |id|
+        HumanReadableId.update_unique_id(Visit, id, :human_id)
+      end
+
+      batch = query.pluck(:id)
+    end
+  end
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Lint/AssignmentInCondition
   # rubocop:enable Metrics/AbcSize

--- a/spec/controllers/api/visits_controller_spec.rb
+++ b/spec/controllers/api/visits_controller_spec.rb
@@ -113,14 +113,14 @@ RSpec.describe Api::VisitsController do
   end
 
   describe 'show' do
-    let(:params) {
+    let(:params) do
       {
         format: :json,
-        id: visit.id
+        id: visit.human_id
       }
-    }
+    end
 
-    specify do expect(get :show, params).to render_template(:show) end
+    it { expect(get :show, params).to render_template(:show) }
 
     it 'returns visit status' do
       get :show, params
@@ -174,13 +174,24 @@ RSpec.describe Api::VisitsController do
       expect(response).to have_http_status(:not_found)
       expect(parsed_body['message']).to eq('Not found')
     end
+
+    context 'with a guid' do
+      let(:params) do
+        {
+          format: :json,
+          id: visit.id
+        }
+      end
+
+      it { expect(get :show, params).to render_template(:show) }
+    end
   end
 
   describe 'destroy' do
     let(:params) {
       {
         format: :json,
-        id: visit.id
+        id: visit.human_id
       }
     }
 

--- a/spec/factories/visits.rb
+++ b/spec/factories/visits.rb
@@ -9,6 +9,10 @@ FactoryGirl.define do
 
     contact_phone_no '07900112233'
 
+    sequence :human_id do |n|
+      n.to_s
+    end
+
     slot_option_0 do |v|
       v.prison.available_slots.first
     end

--- a/spec/lib/human_readable_id_spec.rb
+++ b/spec/lib/human_readable_id_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+require 'human_readable_id'
+
+RSpec.describe HumanReadableId do
+  describe '.update_unique_id' do
+    subject { described_class.update_unique_id(Visit, visit.id, :human_id) }
+
+    let(:visit) { FactoryGirl.create(:visit, human_id: nil) }
+
+    it 'generates and updates the record with a new id' do
+      expect { subject }.to change { visit.reload.human_id }
+    end
+
+    context 'when an id has already been saved to the DB' do
+      before do
+        described_class.update_unique_id(Visit, visit.id, :human_id)
+      end
+
+      it 'does not override the previous id' do
+        expect { subject }.not_to change { visit.reload.human_id }
+      end
+    end
+
+    context 'when a duplicate id is generated' do
+      let(:other_visit) { FactoryGirl.create(:visit, human_id: nil) }
+
+      before do
+        described_class.update_unique_id(Visit, other_visit.id, :human_id)
+
+        expect(Base32::Crockford).
+          to receive(:encode).
+          and_return(other_visit.reload.human_id, 'unique_id')
+      end
+
+      it 'retries until a unique id is found' do
+        expect { subject }.
+          to change { visit.reload.human_id }.
+          to('unique_id')
+      end
+    end
+  end
+end

--- a/spec/services/booking_request_creator_spec.rb
+++ b/spec/services/booking_request_creator_spec.rb
@@ -48,9 +48,10 @@ RSpec.describe BookingRequestCreator do
   end
 
   context 'creating records' do
-    it 'creates a Visit record with the specified locale' do
+    it 'creates a Visit record with the specified locale and a human_id' do
       visit = subject.create!(prisoner_step, visitors_step, slots_step, :cy)
       expect(visit.locale).to eq('cy')
+      expect(visit.human_id).not_to be_nil
     end
 
     it 'creates a Visitor record' do


### PR DESCRIPTION
Generate a random [Crockford::Base32](http://www.crockford.com/wrmg/base32.html) id when a visit is created and use the new id in the API.

It also adds a task to populate old visits.

This PR does not use the id to the emails as there could be a small window during deploy when sidekiq could send emails with a nil id.