### PR TITLE
Fixes percentiles BST bug

### DIFF
--- a/db/migrate/20170327084830_update_percentiles_by_prison_and_calendar_dates_to_version_2.rb
+++ b/db/migrate/20170327084830_update_percentiles_by_prison_and_calendar_dates_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdatePercentilesByPrisonAndCalendarDatesToVersion2 < ActiveRecord::Migration
+  def change
+    update_view :percentiles_by_prison_and_calendar_dates, version: 2, revert_to_version: 1, materialized: true
+  end
+end

--- a/db/views/percentiles_by_prison_and_calendar_dates_v02.sql
+++ b/db/views/percentiles_by_prison_and_calendar_dates_v02.sql
@@ -1,0 +1,11 @@
+SELECT prisons.name                                                    AS prison_name,
+       prisons.id                                                      AS prison_id,
+       (v.created_at::TIMESTAMPTZ AT TIME ZONE 'Europe/London')::date  AS date,
+       PERCENTILE_DISC(ARRAY[0.95, 0.5]) WITHIN GROUP (ORDER BY ROUND(EXTRACT(EPOCH FROM vsc.created_at - v.created_at))::integer) AS percentiles
+FROM visits AS v
+INNER JOIN (SELECT MAX(created_at) AS created_at, visit_id, visit_state FROM visit_state_changes GROUP BY visit_id, visit_state) AS vsc ON v.id = vsc.visit_id
+INNER JOIN prisons ON prisons.id = v.prison_id
+WHERE vsc.visit_state IN ('booked', 'rejected')
+GROUP BY prison_name,
+         prisons.id,
+         date;

--- a/spec/models/percentiles_by_prison_and_calendar_date_spec.rb
+++ b/spec/models/percentiles_by_prison_and_calendar_date_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe PercentilesByPrisonAndCalendarDate, type: :model do
   subject { described_class.first }
 
   before do
-    travel_to(processed_within_a_day_visits.first.created_at. + 6.hours) do
+    travel_to(processed_within_a_day_visits.first.created_at + 6.hours) do
       processed_within_a_day_visits.each do |visit|
         accept_visit(visit, visit.slots.first)
       end


### PR DESCRIPTION
The view used to calculate the percentiles wasn't taking into account the
daylight savings so visits created just after midnight.