### PR TITLE
Fix excon instrumentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'virtus'
 gem 'zendesk_api'
 gem 'pvb-instrumentation',
   git: 'https://github.com/ministryofjustice/pvb-instrumentation.git',
-  tag: 'v0.1.1'
+  tag: 'v0.1.2'
 # gem 'pvb-instrumentation', path: '../pvb-instrumentation'
 
 gem 'secure_headers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/ministryofjustice/pvb-instrumentation.git
-  revision: 08efd49e795ff4ac9845059fd3da23ab8331a02d
-  tag: v0.1.1
+  revision: c31d1358e8404ce2cc6dc4ed11c1477ebe366def
+  tag: v0.1.2
   specs:
-    pvb-instrumentation (0.1.1)
+    pvb-instrumentation (0.1.2)
       activesupport (~> 4.2)
       request_store (~> 1.3.2)
 

--- a/lib/excon/middleware/custom_instrumentor.rb
+++ b/lib/excon/middleware/custom_instrumentor.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+#
+# :nocov:
+# rubocop:disable Metrics/LineLength
+# rubocop:disable Metrics/MethodLength
+module Excon
+  module Middleware
+    class CustomInstrumentor < Excon::Middleware::Base
+      def error_call(datum)
+        if datum.key?(:instrumentor)
+          datum[:instrumentor].instrument("#{datum[:instrumentor_name]}.error", error: datum[:error]) do
+            @stack.error_call(datum)
+          end
+        else
+          @stack.error_call(datum)
+        end
+      end
+
+      def request_call(datum)
+        if datum.key?(:instrumentor)
+          if datum[:retries_remaining] < datum[:retry_limit]
+            event_name = "#{datum[:instrumentor_name]}.retry"
+          else
+            event_name = "#{datum[:instrumentor_name]}.request"
+          end
+          datum[:instrumentor].instrument(event_name, datum) do
+            @stack.request_call(datum)
+          end
+        else
+          @stack.request_call(datum)
+        end
+      end
+
+      # Changed from `datum[:response]` to `datum` since the response is not
+      # available when calling the instrumentation.
+      def response_call(datum)
+        if datum.key?(:instrumentor)
+          datum[:instrumentor].instrument("#{datum[:instrumentor_name]}.response", datum) do
+            @stack.response_call(datum)
+          end
+        else
+          @stack.response_call(datum)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe ApplicationController, type: :controller do
       WebMock.stub_request(:get, /\w/).to_return(status: 500)
       post :create
       expect(PVB::Instrumentation.custom_log_items[:api_request_count]).to eq(1)
-      expect(PVB::Instrumentation.custom_log_items[:api_error_count]).to eq(1)
+      expect(PVB::Instrumentation.custom_log_items[:api_retry_count]).to eq(1)
+      expect(PVB::Instrumentation.custom_log_items[:api_error_count]).to eq(2)
     end
   end
 


### PR DESCRIPTION
- Fix an issue with the instrumentation gem where retries time was overriding the total api time
- Fix the excon middleware stack to instrument the response time correctly (before it wasn't being instrumented.