### PR TITLE
Store contact nomis id on visitor

### DIFF
--- a/app/assets/javascripts/modules/moj.matchVisitors.js
+++ b/app/assets/javascripts/modules/moj.matchVisitors.js
@@ -6,6 +6,7 @@
     init: function() {
       this.cacheEls();
       this.bindEvents();
+      this.onRender();
     },
 
     cacheEls: function() {
@@ -22,6 +23,28 @@
       this.$el.find('select').on('change', $.proxy(this.changeSelect, this));
       this.$el.find(this.notContactCheckbox).on('change', $.proxy(this.changeNotOnList, this));
       this.$el.find(this.bannedCheckbox).on('change', $.proxy(this.changeBanned, this));
+    },
+
+    onRender: function(){
+      var self = this;
+
+      $.each(this.$el.find('select'), function(i,obj){
+        var $obj = $(obj),
+          option = $obj.find('option:selected'),
+          contact = option.data('contact'),
+          val = $obj.val(),
+          parent = self.findParent(obj);
+
+        if(val == contact.uid && val != ''){
+          self.toggleSelectOptions($obj);
+          self.toggleCheckbox($obj, val == '');
+          option.prop('disabled', null);
+        }
+
+        self.processVisitor(parent, !val == '');
+      });
+
+      this.checkStatus();
     },
 
     changeSelect: function(e) {
@@ -159,11 +182,10 @@
 
     toggleSelectOptions: function(el) {
       var self = this,
-        options = this.$el.find('select').not(el).find('option').not(':first');
+        options = this.$el.find('select').not(el).find('option').not(':first').not(':selected');
 
       $.each(options, function(i, obj) {
         var contact = $(obj).data('contact');
-
         if ($.inArray(contact.uid.toString(), self.getVisitorIDs()) !== -1) {
           $(obj).prop('disabled', 'disabled');
         } else {

--- a/app/assets/javascripts/modules/moj.matchVisitors.js
+++ b/app/assets/javascripts/modules/moj.matchVisitors.js
@@ -27,7 +27,7 @@
     changeSelect: function(e) {
       var el = e.currentTarget,
         contactData = $(el).find(':selected').data('contact'),
-        adding = el.value == '0',
+        adding = el.value == '',
         parent = this.findParent(el);
 
       this.toggleSelectOptions(el);
@@ -67,7 +67,7 @@
       select = $(el).find('select option:selected').val();
       noContact = $(el).find(this.notContactCheckbox).is(':checked');
 
-      if (select == '0' && noContact == false) {
+      if (select == '' && noContact == false) {
         $(el).attr('data-processed', false);
       } else {
         $(el).attr('data-processed', true);
@@ -140,7 +140,7 @@
         listItemsArray = this.$el.find('select option:selected').map(function() {
           var parent = self.findParent(this);
 
-          if (this.value != 0 && !self.isVisitorBanned(parent)) {
+          if (this.value != '' && !self.isVisitorBanned(parent)) {
             return parent;
           }
         }).get();
@@ -150,7 +150,7 @@
     getVisitorIDs: function() {
       var self = this,
         visitorIDArray = $('select').map(function() {
-          if (this.value !== '0') {
+          if (this.value !== '') {
             return this.value
           }
         }).get();
@@ -164,7 +164,7 @@
       $.each(options, function(i, obj) {
         var contact = $(obj).data('contact');
 
-        if ($.inArray(contact.uid, self.getVisitorIDs()) !== -1) {
+        if ($.inArray(contact.uid.toString(), self.getVisitorIDs()) !== -1) {
           $(obj).prop('disabled', 'disabled');
         } else {
           $(obj).prop('disabled', null);

--- a/app/controllers/concerns/booking_response_context.rb
+++ b/app/controllers/concerns/booking_response_context.rb
@@ -38,6 +38,7 @@ private
       ],
       visitors_attributes:  [
         :id,
+        :nomis_id,
         :banned,
         :not_on_list,
         banned_until: [:day, :month, :year]

--- a/app/services/nomis/contact.rb
+++ b/app/services/nomis/contact.rb
@@ -2,7 +2,7 @@ module Nomis
   class Contact
     include NonPersistedModel
 
-    attribute :id
+    attribute :id, Integer
     attribute :given_name
     attribute :surname
     attribute :date_of_birth, Date

--- a/app/views/prison/visits/_visitor_contact.html.erb
+++ b/app/views/prison/visits/_visitor_contact.html.erb
@@ -24,19 +24,15 @@
     <div class="column">
       <% if !@visit.contact_list_unknown? && @visit.contact_list_enabled? %>
         <div class="form-group">
-          <label for="nomis_contacts_<%= dom_id(v) %>" class="form-label"><%= t('.nomis_list') %></label>
-          <select class="form-control js-contactList" name="nomis_contacts_<%= dom_id(v) %>" id="nomis_contacts_<%= dom_id(v) %>">
-          <option data-contact='{"uid": "0"}' value="0"><%= t('.please_select') %></option>
-          <% @visit.approved_contacts.each do |visitor| %>
-            <option data-contact='{
-                "uid":"<%= visitor.id %>",
-                "banned": "<%= visitor.banned? %>"
-                }'
-                value="<%= visitor.id %>">
-              <%= visitor.given_name %> <%= visitor.surname %> - <%= visitor.date_of_birth.to_s(:short_nomis) %>
-            </option>
+          <%= vf.label :nomis_id, t('.nomis_list'), class: 'form-label' %>
+          <%= vf.select :nomis_id, nil, {}, { class: 'form-control js-contactList' } do %>
+            <option data-contact='{"uid": ""}' value=""><%= t('.please_select') %></option>
+            <% @visit.approved_contacts.each do |contact| %>
+              <%= content_tag :option, value: contact.id, selected: contact.id == v.nomis_id, 'data-contact': { uid: contact.id, banned: contact.banned? }.to_json do -%>
+                <%= contact.given_name %> <%= contact.surname %> - <%= contact.date_of_birth.to_s(:short_nomis) %>
+              <% end -%>
+            <% end %>
           <% end %>
-          </select>
         </div>
       <% end %>
       <%= vf.label :not_on_list, class: 'form-group' do %>

--- a/db/migrate/20170509114346_add_visitors_nomis_id.rb
+++ b/db/migrate/20170509114346_add_visitors_nomis_id.rb
@@ -1,0 +1,5 @@
+class AddVisitorsNomisId < ActiveRecord::Migration
+  def change
+    add_column :visitors, :nomis_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170327084830) do
+ActiveRecord::Schema.define(version: 20170509114346) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -142,6 +142,7 @@ ActiveRecord::Schema.define(version: 20170327084830) do
     t.boolean  "banned",        default: false
     t.boolean  "not_on_list",   default: false
     t.date     "banned_until"
+    t.integer  "nomis_id"
   end
 
   add_index "visitors", ["visit_id", "sort_index"], name: "index_visitors_on_visit_id_and_sort_index", unique: true, using: :btree

--- a/spec/features/process_a_request_accept_spec.rb
+++ b/spec/features/process_a_request_accept_spec.rb
@@ -6,11 +6,78 @@ RSpec.feature 'Processing a request - Acceptance', js: true do
 
   include_context 'process request setup'
 
-  around do |ex|
-    travel_to(Date.new(2016, 12, 1)) { ex.run }
+  context 'with visitor contact list', vcr: { cassette_name: 'process_happy_path_with_contact_list' } do
+    # Leicester has contact list enabled in 'test'
+    let(:prison) do
+      FactoryGirl.create(:prison,
+        name: 'Leicester',
+        email_address: prison_email_address)
+    end
+    let(:prisoner_number) { 'A1484AE' }
+    let(:prisoner_dob) { '11-11-1971' }
+    let(:visitor) { vst.visitors.first }
+
+    around do |ex|
+      travel_to(Date.new(2017, 5, 10)) { ex.run }
+    end
+
+    before do
+      switch_feature_flag_with(:staff_prisons_with_nomis_contact_list, [prison.name])
+    end
+
+    scenario 'accepting a booking' do
+      visit prison_visit_process_path(vst, locale: 'en')
+      click_button 'Process'
+
+      # Renders the form again
+      expect(page).to have_text('Visit details')
+
+      expect(page).to have_content("The prisoner date of birth and number have been verified.")
+      expect(page).to have_css('.choose-date .tag--verified', text: 'Prisoner available')
+
+      choose_date
+
+      fill_in 'Reference number',   with: '12345678'
+      fill_in 'Message (optional)', with: 'A staff message'
+
+      within "#visitor_#{visitor.id}" do
+        select 'IRMA ITSU - 03/04/1975', from: 'Match to contact list'
+      end
+
+      preview_window = window_opened_by {
+        click_link 'Preview Email'
+      }
+
+      within_window preview_window do
+        expect(page).to have_css('p', text: /Dear #{vst.visitor_full_name}/)
+        expect(page).to have_css('p', text: 'A staff message')
+      end
+
+      click_button 'Process'
+
+      expect(page).to have_text('Thank you for processing the visit')
+
+      vst.reload
+      visitor.reload
+      expect(vst).to be_booked
+      expect(visitor.nomis_id).to eq(13_428)
+      expect(vst.reference_no).to eq('12345678')
+
+      expect(contact_email_address).
+        to receive_email.
+        with_subject(/Visit confirmed: your visit for \w+ \d+ \w+ has been confirmed/).
+        and_body(/Your visit to Leicester is now successfully confirmed/)
+
+      visit prison_visit_path(vst, locale: 'en')
+      expect(page).to have_css('span', text: 'by joe@example.com')
+    end
   end
 
   context 'accepting', vcr: { cassette_name: 'process_booking_happy_path' } do
+    around do |ex|
+      travel_to(Date.new(2016, 12, 1)) { ex.run }
+    end
+
     context "validating prisoner informations - sad paths" do
       context "and the prisoner's informations are not valid", vcr: { cassette_name: 'lookup_active_offender-nomatch' } do
         let(:slot_zero) { ConcreteSlot.new(2016, 5, 1, 10, 30, 11, 30) }

--- a/spec/features/process_a_request_accept_spec.rb
+++ b/spec/features/process_a_request_accept_spec.rb
@@ -85,14 +85,6 @@ RSpec.feature 'Processing a request - Acceptance', js: true do
 
         let(:prisoner_number) { 'Z9999ZZ' }
 
-        before do
-          vst.update!(
-            slot_option_0: slot_zero.iso8601,
-            slot_option_1: slot_one.iso8601,
-            slot_option_2: nil
-          )
-        end
-
         it 'informs staff prisoner details are invalid' do
           visit prison_visit_process_path(vst, locale: 'en')
           expect(page).to have_content("The prisoner date of birth and number do not match.")

--- a/spec/fixtures/vcr_cassettes/process_happy_path_with_contact_list.yml
+++ b/spec/fixtures/vcr_cassettes/process_happy_path_with_contact_list.yml
@@ -1,0 +1,207 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://151.237.239.116:4888/nomisapi/lookup/active_offender?date_of_birth=1971-11-11&noms_id=A1484AE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.55.0
+      Accept:
+      - application/json
+      Authorization:
+      - ''
+      X-Request-Id:
+      - f1bc5efe-1125-42a6-b1d9-2ae0ee795bbb
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server-Timing:
+      - total=2, db=2
+      Url-Template:
+      - "/lookup/active_offender"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 10 May 2017 15:38:46 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"found":true,"offender":{"id":1057307}}'
+    http_version: 
+  recorded_at: Wed, 10 May 2017 15:38:47 GMT
+- request:
+    method: get
+    uri: http://151.237.239.116:4888/nomisapi/offenders/1057307/visits/unavailability?dates=2017-05-16
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.55.0
+      Accept:
+      - application/json
+      Authorization:
+      - ''
+      X-Request-Id:
+      - f1bc5efe-1125-42a6-b1d9-2ae0ee795bbb
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server-Timing:
+      - total=47, db=45
+      Url-Template:
+      - "/offenders/{offender_id}/visits/unavailability"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 10 May 2017 15:38:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"2017-05-16":{"external_movement":false,"existing_visits":[],"out_of_vo":false,"banned":false}}'
+    http_version: 
+  recorded_at: Wed, 10 May 2017 15:38:48 GMT
+- request:
+    method: get
+    uri: http://151.237.239.116:4888/nomisapi/offenders/1057307/visits/contact_list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.55.0
+      Accept:
+      - application/json
+      Authorization:
+      - ''
+      X-Request-Id:
+      - f1bc5efe-1125-42a6-b1d9-2ae0ee795bbb
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server-Timing:
+      - total=5, db=3
+      Url-Template:
+      - "/offenders/{offender_id}/visits/contact_list"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 10 May 2017 15:38:47 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"contacts":[{"id":12588,"given_name":"BILLY","surname":"JONES","date_of_birth":"1970-01-01","gender":{"code":"M","desc":"Male"},"relationship_type":{"code":"FRI","desc":"Friend"},"contact_type":{"code":"S","desc":"Social\/
+        Family"},"approved_visitor":true,"active":true,"restrictions":[]},{"id":13428,"given_name":"IRMA","middle_names":"CHRISTINE","surname":"ITSU","date_of_birth":"1975-04-03","gender":{"code":"F","desc":"Female"},"relationship_type":{"code":"WIFE","desc":"Wife"},"contact_type":{"code":"S","desc":"Social\/
+        Family"},"approved_visitor":true,"active":true,"restrictions":[]},{"id":13429,"given_name":"ISAIAH","surname":"ITSU","date_of_birth":"1981-11-16","gender":{"code":"M","desc":"Male"},"relationship_type":{"code":"BRO","desc":"Brother"},"contact_type":{"code":"S","desc":"Social\/
+        Family"},"approved_visitor":true,"active":false,"restrictions":[]},{"id":13432,"given_name":"SHAY","surname":"DEE","date_of_birth":"1978-06-07","gender":{"code":"M","desc":"Male"},"relationship_type":{"code":"SOL","desc":"Solicitor"},"contact_type":{"code":"O","desc":"Official"},"approved_visitor":true,"active":false,"restrictions":[]}]}'
+    http_version: 
+  recorded_at: Wed, 10 May 2017 15:38:48 GMT
+- request:
+    method: get
+    uri: http://151.237.239.116:4888/nomisapi/lookup/active_offender?date_of_birth=1971-11-11&noms_id=A1484AE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.55.0
+      Accept:
+      - application/json
+      Authorization:
+      - ''
+      X-Request-Id:
+      - 65071694-0716-48b0-8fd5-76e2e89e1a3e
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server-Timing:
+      - total=2, db=1
+      Url-Template:
+      - "/lookup/active_offender"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 10 May 2017 15:38:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"found":true,"offender":{"id":1057307}}'
+    http_version: 
+  recorded_at: Wed, 10 May 2017 15:38:49 GMT
+- request:
+    method: get
+    uri: http://151.237.239.116:4888/nomisapi/offenders/1057307/visits/unavailability?dates=2017-05-16
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.55.0
+      Accept:
+      - application/json
+      Authorization:
+      - ''
+      X-Request-Id:
+      - 65071694-0716-48b0-8fd5-76e2e89e1a3e
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server-Timing:
+      - total=49, db=48
+      Url-Template:
+      - "/offenders/{offender_id}/visits/unavailability"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 10 May 2017 15:38:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"2017-05-16":{"external_movement":false,"existing_visits":[],"out_of_vo":false,"banned":false}}'
+    http_version: 
+  recorded_at: Wed, 10 May 2017 15:38:50 GMT
+- request:
+    method: get
+    uri: http://151.237.239.116:4888/nomisapi/offenders/1057307/visits/contact_list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.55.0
+      Accept:
+      - application/json
+      Authorization:
+      - ''
+      X-Request-Id:
+      - 65071694-0716-48b0-8fd5-76e2e89e1a3e
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Server-Timing:
+      - total=4, db=3
+      Url-Template:
+      - "/offenders/{offender_id}/visits/contact_list"
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 10 May 2017 15:38:49 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: '{"contacts":[{"id":12588,"given_name":"BILLY","surname":"JONES","date_of_birth":"1970-01-01","gender":{"code":"M","desc":"Male"},"relationship_type":{"code":"FRI","desc":"Friend"},"contact_type":{"code":"S","desc":"Social\/
+        Family"},"approved_visitor":true,"active":true,"restrictions":[]},{"id":13428,"given_name":"IRMA","middle_names":"CHRISTINE","surname":"ITSU","date_of_birth":"1975-04-03","gender":{"code":"F","desc":"Female"},"relationship_type":{"code":"WIFE","desc":"Wife"},"contact_type":{"code":"S","desc":"Social\/
+        Family"},"approved_visitor":true,"active":true,"restrictions":[]},{"id":13429,"given_name":"ISAIAH","surname":"ITSU","date_of_birth":"1981-11-16","gender":{"code":"M","desc":"Male"},"relationship_type":{"code":"BRO","desc":"Brother"},"contact_type":{"code":"S","desc":"Social\/
+        Family"},"approved_visitor":true,"active":false,"restrictions":[]},{"id":13432,"given_name":"SHAY","surname":"DEE","date_of_birth":"1978-06-07","gender":{"code":"M","desc":"Male"},"relationship_type":{"code":"SOL","desc":"Solicitor"},"contact_type":{"code":"O","desc":"Official"},"approved_visitor":true,"active":false,"restrictions":[]}]}'
+    http_version: 
+  recorded_at: Wed, 10 May 2017 15:38:50 GMT
+recorded_with: VCR 3.0.3

--- a/spec/javascripts/fixtures/visitor_details.html
+++ b/spec/javascripts/fixtures/visitor_details.html
@@ -21,9 +21,9 @@
         </div>
         <div class="column">
           <div class="form-group">
-            <label for="nomis_contacts_visitor_d0482cf9-7bea-4453-b3be-d6b45e3cc951" class="form-label">Match to contact list</label>
-            <select class="form-control js-contactList" name="nomis_contacts_visitor_d0482cf9-7bea-4453-b3be-d6b45e3cc951" id="nomis_contacts_visitor_d0482cf9-7bea-4453-b3be-d6b45e3cc951">
-              <option data-contact="{&quot;uid&quot;: &quot;0&quot;}" value="0">Please select a contact</option>
+            <label for="visit_visitors_attributes_0_nomis_id" class="form-label">Match to contact list</label>
+            <select class="form-control js-contactList" name="visit[visitors_attributes][0][nomis_id]" id="visit_visitors_attributes_0_nomis_id">
+              <option data-contact="{&quot;uid&quot;: &quot;0&quot;}" value="">Please select a contact</option>
               <option data-contact="{
                 &quot;uid&quot;:&quot;12588&quot;,
                 &quot;banned&quot;: &quot;true&quot;
@@ -64,9 +64,9 @@
         </div>
         <div class="column">
           <div class="form-group">
-            <label for="nomis_contacts_visitor_f1f7b645-c57f-4926-bfba-a29e4e45542e" class="form-label">Match to contact list</label>
-            <select class="form-control js-contactList" name="nomis_contacts_visitor_f1f7b645-c57f-4926-bfba-a29e4e45542e" id="nomis_contacts_visitor_f1f7b645-c57f-4926-bfba-a29e4e45542e">
-              <option data-contact="{&quot;uid&quot;: &quot;0&quot;}" value="0">Please select a contact</option>
+            <label for="visit_visitors_attributes_1_nomis_id" class="form-label">Match to contact list</label>
+            <select class="form-control js-contactList" name="visit[visitors_attributes][1][nomis_id]" id="visit_visitors_attributes_1_nomis_id">
+              <option data-contact="{&quot;uid&quot;: &quot;0&quot;}" value="">Please select a contact</option>
               <option data-contact="{
                 &quot;uid&quot;:&quot;12588&quot;,
                 &quot;banned&quot;: &quot;true&quot;
@@ -107,9 +107,9 @@
         </div>
         <div class="column">
           <div class="form-group">
-            <label for="nomis_contacts_visitor_8fe3312c-a83d-4785-b438-4b039f3c8640" class="form-label">Match to contact list</label>
-            <select class="form-control js-contactList" name="nomis_contacts_visitor_8fe3312c-a83d-4785-b438-4b039f3c8640" id="nomis_contacts_visitor_8fe3312c-a83d-4785-b438-4b039f3c8640">
-              <option data-contact="{&quot;uid&quot;: &quot;0&quot;}" value="0">Please select a contact</option>
+            <label for="visit_visitors_attributes_2_nomis_id" class="form-label">Match to contact list</label>
+            <select class="form-control js-contactList" name="visit[visitors_attributes][2][nomis_id]" id="visit_visitors_attributes_2_nomis_id">
+              <option data-contact="{&quot;uid&quot;: &quot;0&quot;}" value="">Please select a contact</option>
               <option data-contact="{
                 &quot;uid&quot;:&quot;12588&quot;,
                 &quot;banned&quot;: &quot;true&quot;

--- a/spec/javascripts/fixtures/visitor_details.html
+++ b/spec/javascripts/fixtures/visitor_details.html
@@ -1,6 +1,6 @@
 <div id="visitors-fixture" class="js-visitorList nomis-enabled">
   <ul class="visitor-contact-list push-top">
-    <li id="visitor_d0482cf9-7bea-4453-b3be-d6b45e3cc951" data-visitor="{&quot;first_name&quot;: &quot;Tom&quot;, &quot;last_name&quot;: &quot;Smith&quot;, &quot;dob&quot;: &quot;1970-01-01&quot;}" data-processed="true">
+    <li id="visitor_d0482cf9-7bea-4453-b3be-d6b45e3cc951" data-visitor="{&quot;first_name&quot;: &quot;Tom&quot;, &quot;last_name&quot;: &quot;Smith&quot;, &quot;dob&quot;: &quot;1970-01-01&quot;}" data-processed="false">
       <div class="error">
         <label class="" for="visit_visitors_attributes_0_banned">
         </label>    <label class="" for="visit_visitors_attributes_0_banned_until">
@@ -27,7 +27,7 @@
               <option data-contact="{
                 &quot;uid&quot;:&quot;12588&quot;,
                 &quot;banned&quot;: &quot;true&quot;
-                }" value="12588">
+                }" value="12588" selected>
                 BILLY JONES - 01/01/1970
               </option>
               <option data-contact="{

--- a/spec/javascripts/matchVisitors_spec.js
+++ b/spec/javascripts/matchVisitors_spec.js
@@ -43,7 +43,7 @@ describe('Match visitor to NOMIS', function() {
 
     beforeEach(function() {
       $('#visitors-fixture li:eq(0) select').val('12588').trigger('change');
-      $('#visitors-fixture li:eq(0) select').val('0').trigger('change');
+      $('#visitors-fixture li:eq(0) select').val('').trigger('change');
     });
 
     it('should enable all other select options with value 125888', function() {

--- a/spec/javascripts/matchVisitors_spec.js
+++ b/spec/javascripts/matchVisitors_spec.js
@@ -5,16 +5,52 @@ describe('Match visitor to NOMIS', function() {
     moj.Modules.MatchVisitors.init();
   });
 
+  describe('on initialization', function(){
+
+    beforeEach(function(){
+      spyOn(moj.Modules.MatchVisitors, 'cacheEls');
+      spyOn(moj.Modules.MatchVisitors, 'bindEvents');
+      spyOn(moj.Modules.MatchVisitors, 'onRender');
+      moj.Modules.MatchVisitors.init();
+    });
+
+    it('should call cacheEls, bindEvents and onRender', function(){
+      expect(moj.Modules.MatchVisitors.cacheEls).toHaveBeenCalled();
+      expect(moj.Modules.MatchVisitors.bindEvents).toHaveBeenCalled();
+      expect(moj.Modules.MatchVisitors.onRender).toHaveBeenCalled();
+    });
+
+    describe('when a visitor value is pre-selected', function(){
+
+      it('should disable all other select options with value 125888', function() {
+        expect($('#visitors-fixture li:eq(0) select option[value="12588"]')).not.toBeDisabled();
+        expect($('#visitors-fixture li:eq(1) select option[value="12588"]')).toBeDisabled();
+        expect($('#visitors-fixture li:eq(2) select option[value="12588"]')).toBeDisabled();
+      });
+
+      it('should disable the not on list checkbox', function() {
+        expect($('#visit_visitors_attributes_0_not_on_list')).toBeDisabled();
+      });
+
+      it('should process the visitor item', function() {
+        expect($('#visitors-fixture li:eq(0)').data('processed')).toBe(true);
+      });
+
+    });
+
+  });
+
   describe('On select of visitor ID 125888', function() {
 
     beforeEach(function() {
+      moj.Modules.MatchVisitors.init();
       $('#visitors-fixture li:eq(0) select').val('12588').trigger('change');
     });
 
     it('should disable all other select options with value 125888', function() {
-      expect($('#visitors-fixture li:eq(0) select option:eq(1)')).not.toBeDisabled();
-      expect($('#visitors-fixture li:eq(1) select option:eq(1)')).toBeDisabled();
-      expect($('#visitors-fixture li:eq(2) select option:eq(1)')).toBeDisabled();
+      expect($('#visitors-fixture li:eq(0) select option[value="12588"]')).not.toBeDisabled();
+      expect($('#visitors-fixture li:eq(1) select option[value="12588"]')).toBeDisabled();
+      expect($('#visitors-fixture li:eq(2) select option[value="12588"]')).toBeDisabled();
     });
 
     it('should disable the not on list checkbox', function() {
@@ -42,14 +78,15 @@ describe('Match visitor to NOMIS', function() {
   describe('On select and deselect of visitor ID 125888', function() {
 
     beforeEach(function() {
+      moj.Modules.MatchVisitors.init();
       $('#visitors-fixture li:eq(0) select').val('12588').trigger('change');
       $('#visitors-fixture li:eq(0) select').val('').trigger('change');
     });
 
     it('should enable all other select options with value 125888', function() {
-      expect($('#visitors-fixture li:eq(0) select option:eq(1)')).not.toBeDisabled();
-      expect($('#visitors-fixture li:eq(1) select option:eq(1)')).not.toBeDisabled();
-      expect($('#visitors-fixture li:eq(2) select option:eq(1)')).not.toBeDisabled();
+      expect($('#visitors-fixture li:eq(0) select option[value="12588"]')).not.toBeDisabled();
+      expect($('#visitors-fixture li:eq(1) select option[value="12588"]')).not.toBeDisabled();
+      expect($('#visitors-fixture li:eq(2) select option[value="12588"]')).not.toBeDisabled();
     });
 
     it('should enable the not on list checkbox', function() {

--- a/spec/shared_process_setup_context.rb
+++ b/spec/shared_process_setup_context.rb
@@ -28,11 +28,12 @@ RSpec.shared_context 'process request setup' do
         number: prisoner_number,
         first_name: 'Oscar',
         last_name: 'Wilde',
-        date_of_birth: Date.parse('1976-06-12')
+        date_of_birth: Date.parse(prisoner_dob)
       )
     )
   }
   let(:prisoner_number) { 'A1459AE' }
+  let(:prisoner_dob) { '1976-06-12' }
 
   let(:sso_response) do
     {


### PR DESCRIPTION
- Pre-requisit for booking the visit to nomis. We'll be needing the visitors nomis
id when using the API to book visits.

- Preserves the selected contact after a validation errors.

- It also introduces a new feature spec with the contact list enabled, the plan is
to extend this test to test the booking to nomis.