### PR TITLE
Update StaffResponse/BookingResponder interaction

### DIFF
--- a/app/controllers/concerns/staff_response_context.rb
+++ b/app/controllers/concerns/staff_response_context.rb
@@ -25,6 +25,12 @@ private
     params[:id] || params[:visit_id]
   end
 
+  def booking_responder
+    visit = load_visit
+    visit.assign_attributes(visit_params)
+    BookingResponder.new(visit, user: current_user, message: message)
+  end
+
   # rubocop:disable Metrics/MethodLength
   def visit_params
     params.require(:visit).permit(

--- a/app/controllers/prison/email_previews_controller.rb
+++ b/app/controllers/prison/email_previews_controller.rb
@@ -33,6 +33,6 @@ private
 
   def visitor_mailer
     @visitor_mailer ||=
-      BookingResponder.new(staff_response, message).visitor_mailer
+      BookingResponder.new(staff_response.visit, message: message).visitor_mailer
   end
 end

--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -7,29 +7,20 @@ class Prison::VisitsController < ApplicationController
 
   def process_visit
     @visit = load_visit.decorate
-    @staff_response = StaffResponse.new(visit: @visit)
   end
 
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/AbcSize
   def update
-    @visit = load_visit
-    @visit.assign_attributes(visit_params)
-    @staff_response = StaffResponse.new(visit: @visit, user: current_user)
-
-    if @staff_response.valid?
-      BookingResponder.new(@staff_response, message).respond!
+    booking_response = booking_responder.respond!
+    if booking_response.success?
       flash[:notice] = t('process_thank_you', scope: [:prison, :flash])
       redirect_to prison_inbox_path
     else
       # Always decorate object last once they've been mutated
-      @visit = @visit.decorate
+      @visit = load_visit.decorate
       flash[:alert] = t('process_required', scope: [:prison, :flash])
       render :process_visit
     end
   end
-  # rubocop:enable Metrics/MethodLength
-  # rubocop:enable Metrics/AbcSize
 
   def nomis_cancelled
     load_visit.confirm_nomis_cancelled

--- a/app/services/booking_responder/accept.rb
+++ b/app/services/booking_responder/accept.rb
@@ -4,6 +4,8 @@ class BookingResponder
       super do
         visit.rejection = nil
         visit.accept!
+
+        BookingResponse.new(success: true)
       end
     end
   end

--- a/app/services/booking_responder/booking_request_processor.rb
+++ b/app/services/booking_responder/booking_request_processor.rb
@@ -1,23 +1,26 @@
 class BookingResponder
   class BookingRequestProcessor
     def initialize(staff_response)
-      @staff_response = staff_response
+      self.staff_response = staff_response
     end
 
     def process_request(message_for_visitor = nil)
       ActiveRecord::Base.transaction do
-        yield if block_given?
+        self.booking_response = yield if block_given?
+
         if message_for_visitor
           create_message(message_for_visitor, visit.last_visit_state)
         end
 
         record_visitor_or_user
       end
+
+      booking_response
     end
 
   private
 
-    attr_reader :staff_response
+    attr_accessor :staff_response, :booking_response
 
     delegate :visit, to: :staff_response
     delegate :rejection, to: :visit

--- a/app/services/booking_responder/cancel.rb
+++ b/app/services/booking_responder/cancel.rb
@@ -6,6 +6,8 @@ class BookingResponder
         Cancellation.create!(visit: visit,
                              reason: staff_response.reason,
                              nomis_cancelled: true)
+
+        BookingResponse.new(success: true)
       end
     end
   end

--- a/app/services/booking_responder/reject.rb
+++ b/app/services/booking_responder/reject.rb
@@ -7,6 +7,8 @@ class BookingResponder
         visit.reference_no = nil
         clean_up_allowance_renews_on
         visit.reject!
+
+        BookingResponse.new(success: true)
       end
     end
 

--- a/app/services/booking_responder/visitor_cancel.rb
+++ b/app/services/booking_responder/visitor_cancel.rb
@@ -6,6 +6,8 @@ class BookingResponder
         Cancellation.create!(visit: visit,
                              reason: Cancellation::VISITOR_CANCELLED,
                              nomis_cancelled: false)
+
+        BookingResponse.new(success: true)
       end
     end
   end

--- a/app/services/booking_responder/visitor_withdrawal.rb
+++ b/app/services/booking_responder/visitor_withdrawal.rb
@@ -1,7 +1,11 @@
 class BookingResponder
   class VisitorWithdrawal < BookingRequestProcessor
     def process_request
-      super { visit.withdraw! }
+      super do
+        visit.withdraw!
+
+        BookingResponse.new(success: true)
+      end
     end
   end
 end

--- a/app/services/booking_response.rb
+++ b/app/services/booking_response.rb
@@ -1,0 +1,9 @@
+class BookingResponse
+  def initialize(success:)
+    @success = success
+  end
+
+  def success?
+    @success
+  end
+end

--- a/app/views/prison/visits/process_visit.html.erb
+++ b/app/views/prison/visits/process_visit.html.erb
@@ -61,7 +61,7 @@
     <hr/>
     <%= f.submit t('.submit'), class: 'button button-primary' %>
     <div class="push-top">
-      <%= link_to t('.email_preview'), prison_visit_email_preview_path(@staff_response.visit), class: 'js-LinkPreview', target: '_blank' %>
+      <%= link_to t('.email_preview'), prison_visit_email_preview_path(@visit), class: 'js-LinkPreview', target: '_blank' %>
     </div>
   </div>
 

--- a/spec/factories/visits.rb
+++ b/spec/factories/visits.rb
@@ -86,9 +86,7 @@ FactoryGirl.define do
     factory :rejected_visit do
       rejection_attributes do { reasons: [Rejection::SLOT_UNAVAILABLE] } end
       after :create do |visit|
-        staff_request = StaffResponse.new(visit: visit)
-        staff_request.valid?
-        BookingResponder.new(staff_request).respond!
+        BookingResponder.new(visit).respond!
       end
     end
 

--- a/spec/metrics/shared_examples_for_metrics.rb
+++ b/spec/metrics/shared_examples_for_metrics.rb
@@ -10,29 +10,17 @@ RSpec.shared_examples 'create rejections without dates' do
     make_visits(mars)
   end
 
-  def reject_visit(staff_response)
-    staff_response.valid?
-    BookingResponder.new(staff_response).respond!
+  def reject_visit(visit)
+    BookingResponder.new(visit).respond!
   end
 
   def make_visits(prison)
     create_list(:booked_visit, 6, prison: prison)
 
-    reject_visit StaffResponse.new(
-      visit: create(:visit, prison: prison, rejection_attributes: { reasons: [Rejection::NO_ALLOWANCE] })
-
-    )
-
-    reject_visit StaffResponse.new(
-      visit: create(:visit, prison: prison, rejection_attributes: { reasons: [Rejection::NO_ALLOWANCE] })
-    )
-
-    reject_visit StaffResponse.new(
-      visit: create(:visit, prison: prison, rejection_attributes: { reasons: ['slot_unavailable'] })
-    )
-    reject_visit StaffResponse.new(
-      visit: create(:visit, prison: prison, rejection_attributes: { reasons: ['visitor_banned'] })
-    )
+    reject_visit create(:visit, prison: prison, rejection_attributes: { reasons: [Rejection::NO_ALLOWANCE] })
+    reject_visit create(:visit, prison: prison, rejection_attributes: { reasons: [Rejection::NO_ALLOWANCE] })
+    reject_visit create(:visit, prison: prison, rejection_attributes: { reasons: ['slot_unavailable'] })
+    reject_visit create(:visit, prison: prison, rejection_attributes: { reasons: ['visitor_banned'] })
   end
 end
 
@@ -50,51 +38,18 @@ RSpec.shared_examples 'create rejections with dates' do
     make_visits(mars)
   end
 
-  def reject_visit(staff_response)
-    BookingResponder.new(staff_response).respond!
+  def reject_visit(visit)
+    BookingResponder.new(visit).respond!
   end
 
   def make_visits(prison)
     create_list(:booked_visit, 5, created_at: Time.zone.local(2016, 2, 1), prison: prison)
 
-    reject_visit StaffResponse.new(
-      visit: create(:visit,
-        prison:     prison,
-        created_at: Time.zone.local(2016, 2, 1),
-        rejection_attributes: { reasons: [Rejection::NO_ALLOWANCE] }
-                   )
-    )
-
-    reject_visit StaffResponse.new(
-      visit: create(:visit,
-        prison:     prison,
-        created_at: Time.zone.local(2016, 2, 2),
-        rejection_attributes: { reasons: [Rejection::NO_ALLOWANCE] }
-                   )
-    )
-
-    reject_visit StaffResponse.new(
-      visit: create(:visit,
-        prison:     prison,
-        created_at: Time.zone.local(2016, 2, 3),
-        rejection_attributes: { reasons: ['slot_unavailable'] }
-                   )
-    )
-    reject_visit StaffResponse.new(
-      visit: create(:visit,
-        prison:     prison,
-        created_at: Time.zone.local(2016, 2, 4),
-        rejection_attributes: { reasons: ['visitor_banned'] }
-                   )
-    )
-
-    reject_visit StaffResponse.new(
-      visit: create(:visit,
-        prison:     prison,
-        created_at: Time.zone.local(2016, 2, 4),
-        rejection_attributes: { reasons: ['no_adult'] }
-                   )
-    )
+    reject_visit create(:visit, prison: prison, created_at: Time.zone.local(2016, 2, 1), rejection_attributes: { reasons: [Rejection::NO_ALLOWANCE] })
+    reject_visit create(:visit, prison: prison, created_at: Time.zone.local(2016, 2, 2), rejection_attributes: { reasons: [Rejection::NO_ALLOWANCE] })
+    reject_visit create(:visit, prison: prison, created_at: Time.zone.local(2016, 2, 3), rejection_attributes: { reasons: ['slot_unavailable'] })
+    reject_visit create(:visit, prison: prison, created_at: Time.zone.local(2016, 2, 4), rejection_attributes: { reasons: ['visitor_banned'] })
+    reject_visit create(:visit, prison: prison, created_at: Time.zone.local(2016, 2, 4), rejection_attributes: { reasons: ['no_adult'] })
   end
 end
 

--- a/spec/services/booking_responder_spec.rb
+++ b/spec/services/booking_responder_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe BookingResponder do
-  subject { described_class.new(staff_response, message) }
+  subject { described_class.new(visit, message: message) }
 
   let(:visit)            { create(:visit_with_three_slots) }
   let(:staff_response) { StaffResponse.new(visit: visit) }

--- a/spec/support/helpers/staff_response_helper.rb
+++ b/spec/support/helpers/staff_response_helper.rb
@@ -10,7 +10,7 @@ module StaffResponseHelper
   def cancel_visit(visit, reason = Cancellation::VISITOR_CANCELLED)
     accept_visit(visit, visit.slots.first)
     CancellationResponse.new(
-      visit:  visit,
+      visit: visit,
       user:   create(:user),
       reason: reason
     ).cancel!
@@ -18,10 +18,9 @@ module StaffResponseHelper
   end
 
   def reject_visit(visit, reasons = [Rejection::SLOT_UNAVAILABLE])
-    staff_response = StaffResponse.new(visit: visit)
-    staff_response.valid?
-    staff_response.visit.rejection.reasons += reasons
-    BookingResponder.new(staff_response).respond!
+    visit.rejection || visit.build_rejection
+    visit.rejection.reasons += reasons
+    BookingResponder.new(visit).respond!
   end
 
   def withdraw_visit(visit)


### PR DESCRIPTION
This change will let us recover from errors when visits get booked to Nomis.
There is no change in behaviour, just a refactor.

The previous interaction relied that StaffReponse would run the validations, and
it it was valid then BookingResponder would execute the action and always succeed.
This will no longer be the case when booking to nomis since the api might fail
on the execution path.

The main change is to introduce a BookingResponse object that represents the
result of executing the action (accepting, rejecting, etc). This object will be
used to abort the transaction, not send emails and render errors back to the
user when booking to nomis.