### PR TITLE
Allow visits to be saved to Nomis in processor

### DIFF
--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -157,6 +157,10 @@ class Visit < ActiveRecord::Base
     @additional_visitors ||= visitors.reject { |v| v == principal_visitor }
   end
 
+  def allowed_additional_visitors
+    additional_visitors.select(&:allowed?)
+  end
+
 private
 
   def not_allowed_visitor_ids

--- a/app/services/booking_responder/accept.rb
+++ b/app/services/booking_responder/accept.rb
@@ -5,8 +5,28 @@ class BookingResponder
         visit.rejection = nil
         visit.accept!
 
-        BookingResponse.new(success: true)
+        if options[:persist_to_nomis]
+          book_to_nomis
+        else
+          BookingResponse.successful
+        end
       end
+    end
+
+  private
+
+    def book_to_nomis
+      booking_response = nomis_visit_creator.execute
+
+      if booking_response.success?
+        visit.update(nomis_id: nomis_visit_creator.nomis_visit_id)
+      end
+
+      booking_response
+    end
+
+    def nomis_visit_creator
+      @nomis_visit_creator ||= CreateNomisVisit.new(visit)
     end
   end
 end

--- a/app/services/booking_responder/booking_request_processor.rb
+++ b/app/services/booking_responder/booking_request_processor.rb
@@ -1,12 +1,16 @@
 class BookingResponder
   class BookingRequestProcessor
-    def initialize(staff_response)
+    attr_reader :options
+
+    def initialize(staff_response, options = {})
       self.staff_response = staff_response
+      self.options = options
     end
 
     def process_request(message_for_visitor = nil)
       ActiveRecord::Base.transaction do
         self.booking_response = yield if block_given?
+        raise ActiveRecord::Rollback unless booking_response.success?
 
         if message_for_visitor
           create_message(message_for_visitor, visit.last_visit_state)
@@ -21,6 +25,7 @@ class BookingResponder
   private
 
     attr_accessor :staff_response, :booking_response
+    attr_writer :options
 
     delegate :visit, to: :staff_response
     delegate :rejection, to: :visit

--- a/app/services/booking_responder/cancel.rb
+++ b/app/services/booking_responder/cancel.rb
@@ -7,7 +7,7 @@ class BookingResponder
                              reason: staff_response.reason,
                              nomis_cancelled: true)
 
-        BookingResponse.new(success: true)
+        BookingResponse.successful
       end
     end
   end

--- a/app/services/booking_responder/reject.rb
+++ b/app/services/booking_responder/reject.rb
@@ -8,7 +8,7 @@ class BookingResponder
         clean_up_allowance_renews_on
         visit.reject!
 
-        BookingResponse.new(success: true)
+        BookingResponse.successful
       end
     end
 

--- a/app/services/booking_responder/visitor_cancel.rb
+++ b/app/services/booking_responder/visitor_cancel.rb
@@ -7,7 +7,7 @@ class BookingResponder
                              reason: Cancellation::VISITOR_CANCELLED,
                              nomis_cancelled: false)
 
-        BookingResponse.new(success: true)
+        BookingResponse.successful
       end
     end
   end

--- a/app/services/booking_responder/visitor_withdrawal.rb
+++ b/app/services/booking_responder/visitor_withdrawal.rb
@@ -4,7 +4,7 @@ class BookingResponder
       super do
         visit.withdraw!
 
-        BookingResponse.new(success: true)
+        BookingResponse.successful
       end
     end
   end

--- a/app/services/booking_response.rb
+++ b/app/services/booking_response.rb
@@ -1,9 +1,45 @@
 class BookingResponse
-  def initialize(success:)
-    @success = success
+  ALREADY_PROCESSED_ERROR = 'already_processed'.freeze
+  PROCESS_REQUIRED_ERROR = 'process_required'.freeze
+  NOMIS_VALIDATION_ERROR = 'nomis_validation_error'.freeze
+  NOMIS_API_ERROR = 'nomis_api_error'.freeze
+  SUCCESS = 'success'.freeze
+
+  attr_reader :message
+
+  def self.successful
+    new(SUCCESS)
+  end
+
+  def self.process_required
+    new(PROCESS_REQUIRED_ERROR)
+  end
+
+  def self.nomis_validation_error
+    new(NOMIS_VALIDATION_ERROR)
+  end
+
+  def self.nomis_api_error
+    new(NOMIS_API_ERROR)
+  end
+
+  def self.already_processed
+    new(ALREADY_PROCESSED_ERROR)
+  end
+
+  def initialize(message)
+    self.message = message
   end
 
   def success?
-    @success
+    message == SUCCESS
   end
+
+  def already_processed?
+    message == ALREADY_PROCESSED_ERROR
+  end
+
+private
+
+  attr_writer :message
 end

--- a/app/services/create_nomis_visit.rb
+++ b/app/services/create_nomis_visit.rb
@@ -1,0 +1,54 @@
+class CreateNomisVisit
+  ALREADY_PROCESSED = 'Duplicate post'.freeze
+
+  def initialize(visit)
+    self.visit = visit
+    self.api_error = false
+  end
+
+  def execute
+    call_api
+    build_booking_response
+  end
+
+  def nomis_visit_id
+    booking.visit_id
+  end
+
+private
+
+  attr_accessor :visit, :booking, :api_error
+
+  def call_api
+    self.booking = Nomis::Api.
+      instance.
+      book_visit(offender_id: offender_id, params: booking_params)
+  rescue Nomis::APIError
+    self.api_error = true
+  end
+
+  def build_booking_response
+    return BookingResponse.nomis_api_error if api_error
+    return BookingResponse.successful if booking.visit_id
+    return BookingResponse.already_processed if already_processed?
+    BookingResponse.nomis_validation_error
+  end
+
+  def already_processed?
+    booking.error_message == ALREADY_PROCESSED
+  end
+
+  def offender_id
+    visit.prisoner.nomis_offender_id
+  end
+
+  def booking_params
+    {
+      lead_contact: visit.principal_visitor.nomis_id,
+      other_visitors: visit.allowed_additional_visitors.map(&:nomis_id),
+      slot: visit.slot_granted.to_s,
+      override_restrictions: false,
+      client_unique_ref: visit.id
+    }
+  end
+end

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -343,4 +343,30 @@ RSpec.describe Visit, type: :model do
       end
     end
   end
+
+  describe '#allowed_additional_visitors' do
+    let(:visitor1) { FactoryGirl.build_stubbed(:visitor) }
+    let(:visitor2) { FactoryGirl.build_stubbed(:visitor) }
+    let(:visitor3) { FactoryGirl.build_stubbed(:visitor, banned: true) }
+
+    describe 'when there is one visitor' do
+      before do
+        subject.visitors = [visitor1]
+      end
+
+      it 'returns an empty list' do
+        expect(subject.allowed_additional_visitors).to be_empty
+      end
+    end
+
+    describe 'when there is more than one visitor' do
+      before do
+        subject.visitors = [visitor1, visitor2, visitor3]
+      end
+
+      it 'returns a list without the principal visitor' do
+        expect(subject.allowed_additional_visitors).to eq([visitor2])
+      end
+    end
+  end
 end

--- a/spec/services/booking_responder/accept_spec.rb
+++ b/spec/services/booking_responder/accept_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe BookingResponder::Accept do
   let!(:banned_visitors) do
     create_list(:visitor, 2, visit: visit)
   end
+
   let(:staff_response) { StaffResponse.new(visit: visit) }
 
   before do
@@ -17,27 +18,67 @@ RSpec.describe BookingResponder::Accept do
       uv.not_on_list = true
       params[:visitors_attributes][params[:visitors_attributes].size] = uv.attributes.slice('id', 'banned', 'not_on_list')
     end
-    banned_visitors.map do |bv|
+    banned_visitors.each do |bv|
       bv.banned = true
       params[:visitors_attributes][params[:visitors_attributes].size] = bv.attributes.slice('id', 'banned', 'not_on_list')
     end
   end
 
-  subject { described_class.new(staff_response) }
+  subject { described_class.new(staff_response, persist_to_nomis: persist_to_nomis) }
 
-  describe 'with a message' do
-    before do
-      visit.assign_attributes(params)
-      expect(staff_response).to be_valid
-    end
-
-    it 'process the request' do
+  shared_examples_for 'process the request' do
+    it 'updates the visit' do
       subject.process_request
       expect(visit.reference_no).to eq(params[:reference_no])
       expect(visit.slot_granted.to_s).to eq(params[:slot_granted])
       expect(visit).to be_booked
       expect(visit.banned_visitors).to eq(banned_visitors)
       expect(visit.unlisted_visitors).to eq(unlisted_visitors)
+    end
+  end
+
+  before do
+    visit.assign_attributes(params)
+  end
+
+  describe 'with not booking to nomis' do
+    let(:persist_to_nomis) { false }
+
+    it_behaves_like 'process the request'
+  end
+
+  describe 'with book to nomis enabled' do
+    let(:persist_to_nomis) { true }
+    let(:nomis_visit_creator) { instance_double(CreateNomisVisit, nomis_visit_id: 12_345) }
+
+    before do
+      mock_service_with(CreateNomisVisit, nomis_visit_creator)
+    end
+
+    describe 'with book to nomis successfully' do
+      before do
+        expect(nomis_visit_creator).to receive(:execute).and_return(BookingResponse.successful)
+      end
+
+      it 'book the visit to nomis and update the nomis id' do
+        expect {
+          subject.process_request
+        }.to change { visit.reload.nomis_id }.to(nomis_visit_creator.nomis_visit_id)
+      end
+
+      it_behaves_like 'process the request'
+    end
+
+    describe 'with book to nomis with errors' do
+      before do
+        expect(nomis_visit_creator).to receive(:execute).and_return(BookingResponse.nomis_api_error)
+      end
+
+      it 'book the visit to nomis and update the nomis id' do
+        expect { subject.process_request }.not_to change { visit.reload.nomis_id }
+      end
+
+      it_behaves_like 'process the request'
     end
   end
 end

--- a/spec/services/booking_responder/booking_request_processor_spec.rb
+++ b/spec/services/booking_responder/booking_request_processor_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe BookingResponder::BookingRequestProcessor do
   include_context 'staff response setup'
 
   let(:staff_response) { StaffResponse.new(visit: visit, user: create(:user)) }
-  let(:message)          { build(:message, body: 'A staff message') }
+  let(:message)        { build(:message, body: 'A staff message') }
 
   before do
     visit.assign_attributes(params)
@@ -13,17 +13,53 @@ RSpec.describe BookingResponder::BookingRequestProcessor do
 
   subject { described_class.new(staff_response) }
 
-  it '#process_request' do
-    expect {
-      subject.process_request message do
-        visit.accept!
+  describe '#process_request' do
+    context 'happy path' do
+      let(:process_request) do
+        subject.process_request(message) do
+          visit.rejection = nil
+          visit.accept!
+          BookingResponse.successful
+        end
       end
-    }.to change {
-      visit.reload.processing_state
-    }.from('requested').to('booked').and change {
-      visit.messages.find_by(body: message.body)
-    }.from(nil).to(message)
 
-    expect(visit.last_visit_state.processed_by).to eq(staff_response.user)
+      it 'persists the visit state change and message' do
+        expect {
+          process_request
+        }.to change {
+          visit.reload.processing_state
+        }.from('requested').to('booked').and change {
+          visit.messages.find_by(body: message.body)
+        }.from(nil).to(message)
+
+        expect(visit.last_visit_state.processed_by).to eq(staff_response.user)
+      end
+
+      it 'returns a sucessful booking response' do
+        expect(process_request).to be_success
+      end
+    end
+
+    context 'sad path' do
+      let(:process_request) do
+        subject.process_request(message) do
+          visit.rejection = nil
+          visit.accept!
+          BookingResponse.new(errors: ['timeout'])
+        end
+      end
+
+      it 'does not persist the visit state change and message' do
+        expect { process_request }.
+          not_to change { visit.reload.processing_state }
+
+        expect(visit.messages.count).to eq(0)
+        expect(visit.last_visit_state).to be_nil
+      end
+
+      it 'returns a sucesful booking response' do
+        expect(process_request).not_to be_success
+      end
+    end
   end
 end

--- a/spec/services/booking_response_spec.rb
+++ b/spec/services/booking_response_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe BookingResponse do
+  describe '.successful' do
+    subject { described_class.successful }
+
+    it { is_expected.to be_success }
+    it { expect(subject.message).to eq(described_class::SUCCESS) }
+  end
+
+  describe '.process_required' do
+    subject { described_class.process_required }
+
+    it { expect(subject.message).to eq(described_class::PROCESS_REQUIRED_ERROR) }
+  end
+
+  describe '.nomis_api_error' do
+    subject { described_class.nomis_api_error }
+
+    it { expect(subject.message).to eq(described_class::NOMIS_API_ERROR) }
+  end
+
+  describe '.already_processed' do
+    subject { described_class.already_processed }
+
+    it { expect(subject.message).to eq(described_class::ALREADY_PROCESSED_ERROR) }
+    it { expect(subject).to be_already_processed }
+  end
+
+  describe '.nomis_validation_error' do
+    subject { described_class.nomis_validation_error }
+
+    it { expect(subject.message).to eq(described_class::NOMIS_VALIDATION_ERROR) }
+  end
+end

--- a/spec/services/create_nomis_visit_spec.rb
+++ b/spec/services/create_nomis_visit_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe CreateNomisVisit do
+  let(:prisoner) { FactoryGirl.build_stubbed(:prisoner, nomis_offender_id: 12_345) }
+  let(:lead_visitor) { FactoryGirl.build_stubbed(:visitor, nomis_id: 1234, sort_index: 0) }
+  let(:additional_visitor) { FactoryGirl.build_stubbed(:visitor, nomis_id: 2345, sort_index: 1) }
+  let(:banned_visitor) { FactoryGirl.build_stubbed(:visitor, nomis_id: 2345, banned: true, sort_index: 2) }
+
+  let(:visit) do
+    FactoryGirl.build_stubbed(:booked_visit,
+      prisoner: prisoner,
+      visitors: [lead_visitor, additional_visitor, banned_visitor])
+  end
+
+  let(:booking) { Nomis::Booking.new(visit_id: 99_999) }
+
+  subject { described_class.new(visit) }
+
+  before do
+    allow(Nomis::Api.instance).to receive(:book_visit).and_return(booking)
+  end
+
+  describe '#execute' do
+    let(:booking_response) { subject.execute }
+
+    describe 'api call to Nomis' do
+      it 'with the correct parameters' do
+        expect(Nomis::Api.instance).
+          to receive(:book_visit).
+          with(offender_id: prisoner.nomis_offender_id,
+               params: {
+                 lead_contact: lead_visitor.nomis_id,
+                 other_visitors: [additional_visitor.nomis_id],
+                 slot: visit.slot_granted.to_s,
+                 override_restrictions: false,
+                 client_unique_ref: visit.id
+               }).and_return(Nomis::Booking.new)
+
+        subject.execute
+      end
+    end
+
+    describe 'successful booking' do
+      let(:booking) { Nomis::Booking.new(visit_id: 99_999) }
+
+      it { expect(subject.execute).to be_success }
+    end
+
+    describe 'validation errors' do
+      let(:error_message) { 'overlapping visit' }
+      let(:booking) { Nomis::Booking.new(error_message: error_message) }
+
+      it { expect(subject.execute).not_to be_success }
+      it { expect(subject.execute).to have_attributes(message: BookingResponse::NOMIS_VALIDATION_ERROR) }
+    end
+
+    describe 'api errors' do
+      before do
+        allow(Nomis::Api.instance).
+          to receive(:book_visit).and_raise(Nomis::APIError, 'timeout')
+      end
+
+      it { expect(subject.execute).not_to be_success }
+      it { expect(subject.execute).to have_attributes(message: BookingResponse::NOMIS_API_ERROR) }
+    end
+
+    describe 'duplicate post' do
+      let(:error_message) { 'Duplicate post' }
+      let(:booking) { Nomis::Booking.new(error_message: error_message) }
+
+      it { expect(subject.execute).not_to be_success }
+      it { expect(subject.execute).to have_attributes(message: BookingResponse::ALREADY_PROCESSED_ERROR) }
+    end
+  end
+
+  describe '#nomis_visit_id' do
+    let(:nomis_visit_id) { 99_999 }
+    let(:booking) { Nomis::Booking.new(visit_id: nomis_visit_id) }
+
+    before do
+      subject.execute
+    end
+
+    it { expect(subject.nomis_visit_id).to eq(nomis_visit_id) }
+  end
+end

--- a/spec/services/nomis/booking_spec.rb
+++ b/spec/services/nomis/booking_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Nomis::Booking do
       end
     end
 
-    describe 'with a succesful response' do
+    describe 'with a successful response' do
       let(:visit_id) { 12_345 }
       let(:response) { { 'visit_id' => visit_id } }
 


### PR DESCRIPTION
Updates the BookingRequestProcessor to save visits to Nomis if configured to do
so.

The visit is created inside the database transaction to try to minimise the
chances of errors leaving Nomis and PVB inconsistent.

For example if the api is called was to be called outside the transaction then
we could end up with the visit persisted to nomis and the transaction failing,
or if it was called afterwards then pvb could end up with the visit booked but
not in nomis.