### PR TITLE
Consolidate way we parse feature flag env vars

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -87,24 +87,24 @@ module PrisonVisits
       config.database_configuration[Rails.env]['pool'] || 5
 
     config.nomis_staff_prisoner_check_enabled =
-      ENV['NOMIS_STAFF_PRISONER_CHECK_ENABLED'].try(:downcase) == 'true'
+      ENV['NOMIS_STAFF_PRISONER_CHECK_ENABLED']&.downcase == 'true'
 
     config.nomis_public_prisoner_check_enabled =
-      ENV['NOMIS_PUBLIC_PRISONER_CHECK_ENABLED'].try(:downcase) == 'true'
+      ENV['NOMIS_PUBLIC_PRISONER_CHECK_ENABLED']&.downcase == 'true'
 
     # Prisoner availability depends on the prisoner check flag because to check
     # the availability we need to call the api used in the prisoner check to get
     # the offender id.
     config.nomis_staff_prisoner_availability_enabled =
       config.nomis_staff_prisoner_check_enabled &&
-      ENV['NOMIS_STAFF_PRISONER_AVAILABILITY_ENABLED'].try(:downcase) == 'true'
+      ENV['NOMIS_STAFF_PRISONER_AVAILABILITY_ENABLED']&.downcase == 'true'
 
     config.nomis_public_prisoner_availability_enabled =
       config.nomis_public_prisoner_check_enabled &&
-      ENV['NOMIS_PUBLIC_PRISONER_AVAILABILITY_ENABLED'].try(:downcase) == 'true'
+      ENV['NOMIS_PUBLIC_PRISONER_AVAILABILITY_ENABLED']&.downcase == 'true'
 
     config.nomis_staff_slot_availability_enabled =
-      ENV['NOMIS_STAFF_SLOT_AVAILABILITY_ENABLED'].try(:downcase) == 'true'
+      ENV['NOMIS_STAFF_SLOT_AVAILABILITY_ENABLED']&.downcase == 'true'
 
     config.staff_prisons_with_slot_availability =
       ENV['STAFF_PRISONS_WITH_SLOT_AVAILABILITY']&.split(',')&.map(&:strip) || []
@@ -116,7 +116,7 @@ module PrisonVisits
       ENV['STAFF_PRISONS_WITH_NOMIS_CONTACT_LIST']&.split(',')&.map(&:strip) || []
 
     config.nomis_staff_book_to_nomis_enabled =
-      ENV['NOMIS_STAFF_BOOK_TO_NOMIS_ENABLED'].try(:downcase) == 'true'
+      ENV['NOMIS_STAFF_BOOK_TO_NOMIS_ENABLED']&.downcase == 'true'
 
     config.staff_prisons_with_book_to_nomis =
       ENV['STAFF_PRISONS_WITH_BOOK_TO_NOMIS']&.split(',')&.map(&:strip) || []


### PR DESCRIPTION
Before we were using a mix of try and safe operator, this changes to use the
safe operator only.