### PR TITLE
Fix Google Analytics

### DIFF
--- a/config/initializers/secure_headers.rb.rb
+++ b/config/initializers/secure_headers.rb.rb
@@ -2,7 +2,7 @@ SecureHeaders::Configuration.default do |config|
   config.csp = {
     default_src: ["'self'"],
     font_src: ["'self'", 'data:'],
-    img_src: ["'self'", 'data:'],
+    img_src: ["'self'", 'data:', 'www.google-analytics.com'],
     style_src: ["'self'", 'www.gstatic.com'],
     connect_src: ["'self'"],
     script_src: [


### PR DESCRIPTION
**CHANGES:**

Secure Content Policies broke google analytics tracking which requests a an pixel in order to collect metrics. This PR allows `img_src` to download images from `google-analytics.com`