### PR TITLE
Refactor visit decorator to take a nomis checker

### DIFF
--- a/app/controllers/concerns/staff_response_context.rb
+++ b/app/controllers/concerns/staff_response_context.rb
@@ -3,8 +3,17 @@ module StaffResponseContext
 
 private
 
-  def load_visit
-    @visit ||= scoped_visit
+  def memoised_visit
+    @_visit ||= scoped_visit
+  end
+
+  def decorate_visit(visit)
+    @_decorated_visit ||=
+      visit.decorate(context: { staff_nomis_checker: staff_nomis_checker })
+  end
+
+  def staff_nomis_checker
+    @staff_nomis_checker ||= StaffNomisChecker.new(memoised_visit)
   end
 
   def message
@@ -26,9 +35,9 @@ private
   end
 
   def booking_responder
-    visit = load_visit
-    visit.assign_attributes(visit_params)
-    BookingResponder.new(visit,
+    memoised_visit.assign_attributes(visit_params)
+
+    BookingResponder.new(memoised_visit,
       user: current_user,
       message: message,
       options: booking_responder_opts)

--- a/app/controllers/prison/email_previews_controller.rb
+++ b/app/controllers/prison/email_previews_controller.rb
@@ -25,10 +25,9 @@ private
 
   def staff_response
     @staff_response ||= begin
-      visit = load_visit
-      visit.assign_attributes(visit_params)
+      memoised_visit.assign_attributes(visit_params)
       StaffResponse.new(
-        visit: visit,
+        visit: memoised_visit,
         validate_visitors_nomis_ready: params[:validate_visitors_nomis_ready])
     end
   end

--- a/app/controllers/prison/messages_controller.rb
+++ b/app/controllers/prison/messages_controller.rb
@@ -1,17 +1,17 @@
 class Prison::MessagesController < ApplicationController
+  include StaffResponseContext
+
   before_action :authorize_prison_request
   before_action :authenticate_user
 
   def create
-    load_visit
     @message = Message.create_and_send_email(message_params)
 
     if @message.persisted?
       flash[:notice] = t('message_created', scope: %i[prison flash])
-      redirect_to prison_visit_path(@visit)
+      redirect_to prison_visit_path(memoised_visit)
     else
-      @visit = @visit.decorate
-
+      @visit = decorate_visit(memoised_visit)
       flash[:notice] = t('message_create_error', scope: %i[prison flash])
       render 'prison/visits/show'
     end
@@ -19,15 +19,8 @@ class Prison::MessagesController < ApplicationController
 
 private
 
-  def load_visit
-    @visit ||= Visit.joins(prison: :estate).
-               where(estates: { id: accessible_estates }).
-               find(params[:visit_id])
-  end
-  alias_method :visit, :load_visit
-
   def message_params
     params.require(:message).permit(:body).
-      merge(user: current_user, visit: visit)
+      merge(user: current_user, visit: memoised_visit)
   end
 end

--- a/app/decorators/visit_decorator.rb
+++ b/app/decorators/visit_decorator.rb
@@ -78,6 +78,6 @@ private
   end
 
   def nomis_checker
-    @nomis_checker ||= StaffNomisChecker.new(object)
+    context[:staff_nomis_checker]
   end
 end


### PR DESCRIPTION
The decorator now takes the staff nomis checker as an argument so that the same
nomis checker instance can be used by other objects if necessary.