### PR TITLE
Fix Analytics

### DIFF
--- a/app.json
+++ b/app.json
@@ -112,6 +112,9 @@
     },
     "ZENDESK_USERNAME": {
       "required": true
+    },
+    "GA_TRACKING_ID": {
+      "required": true
     }
   },
   "formation": {

--- a/app/assets/javascripts/modules/moj.AsyncGA.js
+++ b/app/assets/javascripts/modules/moj.AsyncGA.js
@@ -5,19 +5,27 @@
   moj.Modules.AsyncGA = {
     el: '.js-AsyncGA',
     init: function() {
+      GOVUK.Analytics.load();
 
+      // Use document.domain in dev, preview and staging so that tracking works
+      // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
+      var cookieDomain = (document.domain === 'www.gov.uk') ? '.www.gov.uk' : document.domain;
       var gaTrackingId = $(this.el).data('ga-tracking-id');
-      var hitTypePage  = $(this.el).data('hit-type-page');
 
-      window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-      window.ga('create', gaTrackingId, 'service.gov.uk');
+      // Configure profiles and make interface public
+      // for custom dimensions, virtual pageviews and events
+      GOVUK.analytics = new GOVUK.Analytics({
+        universalId: gaTrackingId,
+        cookieDomain: cookieDomain
+      });
 
-      if (hitTypePage) {
-        window.ga('send', 'pageview', location.pathname + '#' + hitTypePage);
+      this.hitTypePage  = $(this.el).data('hit-type-page');
+      if (this.hitTypePage) {
+        GOVUK.analytics.trackPageview(location.pathname + '#' + this.hitTypePage);
       } else {
-        window.ga('send', 'pageview');
+        GOVUK.analytics.trackPageview();
       }
-    }
+    },
   };
 
 }());

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
     <%= stylesheet_link_tag('application-ie8', media: 'all') %>
   <![endif]-->
 <% end %>
+<%= content_tag :div, nil, class: "js-AsyncGA", data: ga_tracking_data %>
 
 <% yield :metrics %>
 
@@ -95,14 +96,7 @@
 <% end %>
 
 <% content_for :body_end do %>
-  <%= content_tag :div, nil, class: "js-AsyncGA", data: ga_tracking_data %>
   <%= content_tag :div, nil, class: "js-Sentry", data: { sentry_js_dsn: config_item(:sentry_js_dsn) } %>
-  <%= hashed_javascript_tag do %>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-  <% end %>
   <%= javascript_include_tag('application') %>
   <%= yield :metrics %>
 <% end %>


### PR DESCRIPTION
**CHANGES:**
An update to `govuk_frontend_toolkit` hijacked all google event tracker queue and preventing events being sent to google analytics

Here is the page explaining how this now works
https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md