### PR TITLE
[STAGE-1] - Prevent prisons API to return ALI

### DIFF
--- a/app/controllers/api/prisons_controller.rb
+++ b/app/controllers/api/prisons_controller.rb
@@ -1,7 +1,10 @@
 module Api
   class PrisonsController < ApiController
     def index
-      @prisons = Prison.order(name: :asc).all
+      # temporarily filter out ALI so no new visit
+      # requests are sent to ALI
+      albany = Estate.find_by!(nomis_id: 'ALI')
+      @prisons = Prison.where.not(estate_id: albany.id).order(name: :asc).all
     end
 
     def show

--- a/app/controllers/api/prisons_controller.rb
+++ b/app/controllers/api/prisons_controller.rb
@@ -3,8 +3,10 @@ module Api
     def index
       # temporarily filter out ALI so no new visit
       # requests are sent to ALI
-      albany = Estate.find_by!(nomis_id: 'ALI')
-      @prisons = Prison.where.not(estate_id: albany.id).order(name: :asc).all
+      @prisons = Prison.joins(:estate).
+                   where.not(
+                     estates: { nomis_id: 'ALI' }
+                   ).order(name: :asc).all
     end
 
     def show

--- a/db/seeds/prisons/IWI-isle-of-wight-parkhurst.yml
+++ b/db/seeds/prisons/IWI-isle-of-wight-parkhurst.yml
@@ -1,5 +1,5 @@
 ---
-name: Isle of Wight - Parkhurst
+name: Isle of Wight
 nomis_id: IWI
 address: |-
   Clissold Road

--- a/spec/controllers/api/prisons_controller_spec.rb
+++ b/spec/controllers/api/prisons_controller_spec.rb
@@ -27,7 +27,19 @@ RSpec.describe Api::PrisonsController do
     )
   }
 
+  let!(:ali_prison) {
+    create(
+      :prison,
+      enabled: false,
+      estate: ali_estate,
+      name: 'Isle Of Wight - Albany',
+      postcode: 'XL1 1AA',
+      translations: { 'cy' => { 'name' => 'Some Welsh' } }
+    )
+  }
+
   let(:estate) { create(:estate, nomis_id: 'LNX', name: 'Moon') }
+  let(:ali_estate) { create(:estate, nomis_id: 'ALI', name: 'Isle Of Wight - Albany') }
 
   render_views
 


### PR DESCRIPTION
**CHANGES:**
* prevent `ALI` prison to be returned for no new visit booking requests are made to `ALI`
* rename Parkhust in to just `Isle of Wight` but keep sso_organisation_name the same. This will effectively have merged Isle of Wight prisons for visitors.

**NOTES:**
This is the first step of a 4 stages deploy process