### PR TITLE
Add content to staff stats pages

### DIFF
--- a/app/views/metrics/_all_time_graphs.html.erb
+++ b/app/views/metrics/_all_time_graphs.html.erb
@@ -1,4 +1,14 @@
+<h4 class="heading-small push-top"><%= t('.percentiles_distribution_title') %>
+<p><%= t('.percentiles_distribution') %></p>
 <%= content_tag :div, '', { class: 'js-Metrics',              data: { percentiles: @graphs_presenter.percentiles_by_day } } %>
+<h4 class="heading-small push-top"><%= t('.processing_states_title') %>
+<p><%= t('.processing_states') %></p>
 <%= content_tag :div, '', { class: 'js-VisitsCounts',         data: { visit_counts: @graphs_presenter.visits_per_processing_state } } %>
+
+<h4 class="heading-small push-top"><%= t('.timely_overdue_visits_title') %>
+<p><%= t('.timely_overdue_visits') %></p>
 <%= content_tag :div, '', { class: 'js-TimelyVisitsCount',    data: { visit_counts: @graphs_presenter.timely_and_overdue } } %>
+
+<h4 class="heading-small push-top"><%= t('.rejection_reasons_title') %>
+<p><%= t('.rejection_reasons_percentages') %></p>
 <%= content_tag :div, '', { class: 'js-RejectionPercentages', data: { rejections_percentages: @graphs_presenter.rejection_percentages } } %>

--- a/app/views/metrics/_all_time_table.html.erb
+++ b/app/views/metrics/_all_time_table.html.erb
@@ -3,7 +3,9 @@
     <thead>
     <tr>
       <th></th>
-      <th colspan="5">Number of visits</th>
+      <th colspan="5">Number of visits
+      <br/>
+      <span class="font-xsmall">The table below shows a breakdown of all visits requested online for each prison.</span></th>
     </tr>
     </thead>
     <tbody>

--- a/app/views/metrics/digital_takeup.html.erb
+++ b/app/views/metrics/digital_takeup.html.erb
@@ -2,8 +2,7 @@
   Digital take-up
 </h1>
 
-<p>Find out how many visits are booked online or by telephone</p>
-
+<p>This graph shows the number of visits booked online or on the telephone for each prison for the week:</p>
 <% content_for :metrics do %>
   <%= javascript_include_tag '//www.gstatic.com/charts/loader.js' %>
   <%= javascript_include_tag 'metrics' %>

--- a/app/views/metrics/index.html.erb
+++ b/app/views/metrics/index.html.erb
@@ -4,11 +4,15 @@
 
 <%= render 'content_for_head' %>
 
-<h1>
-  All time
+<h1 class="heading-xlarge">
+  Visit booking stats
 </h1>
-<h3>
-  <%= link_to 'Download confirmed bookings CSV', action: 'confirmed_bookings', format: :csv  %>
-</h3>
+<p>This page shows visit processing statistics across all prisons.</p>
+<p class="push-bottom">Click and drag a section of each graph to zoom in, and right click to reset the graph. </p>
+
+<h4 class="heading-small">Weekly confirmed bookings</h4>
+<p>
+  <%= link_to 'Download latest confirmed bookings (CSV)', action: 'confirmed_bookings', format: :csv  %>
+</p>
 <%= render 'all_time_graphs' %>
 <%= render 'all_time_table' %>

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -243,15 +243,21 @@ en:
       duplicate_request:
         title: Other
         duplicate_visit_request: Duplicate visit request
-  staff_info:
-    telephone_script:
-      telephone_script_html: |
   sessions:
     create:
       cannot_sign_in: You cannot be signed in
   metrics:
     summary:
       processing_turnaround_time_for: "Processing Turnaround Time For %{prison_name}"
+    all_time_graphs:
+      percentiles_distribution_title: Percentiles distribution
+      percentiles_distribution: This graph shows the 95th percentile and median visit processing times for all prisons.
+      processing_states_title: Visits by processing states
+      processing_states: The graph below shows total processed visits for all prisons, broken down by processing state. 
+      timely_overdue_visits_title: Timely and overdue visits
+      timely_overdue_visits: The graph below shows the number of timely (processed within 3 days) and overdue visits for all prisons.
+      rejection_reasons_title: Rejection reasons
+      rejection_reasons_percentages: The graph below shows total rejected visits for all prisons, broken down by rejection reason. 
   shared:
     age: Age
     actions: Actions

--- a/spec/features/metrics_spec.rb
+++ b/spec/features/metrics_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature 'Metrics', js: true do
       end
 
       it 'downloads a csv', driver: :rack_test do
-        click_on 'Download confirmed bookings CSV'
+        click_on 'Download latest confirmed bookings (CSV)'
         expect(page.response_headers['Content-Type']).to eq('text/csv')
       end
     end


### PR DESCRIPTION
Content added to stats and digital take up pages to set context around the graphs.