### PR TITLE
Update the expected book to NOMIS error response

### DIFF
--- a/app/services/create_nomis_visit.rb
+++ b/app/services/create_nomis_visit.rb
@@ -35,7 +35,7 @@ private
   end
 
   def already_booked_in_nomis?
-    booking.error_message == ALREADY_BOOKED_IN_NOMIS
+    booking.error_messages.include?(ALREADY_BOOKED_IN_NOMIS)
   end
 
   def offender_id

--- a/app/services/nomis/booking.rb
+++ b/app/services/nomis/booking.rb
@@ -3,15 +3,20 @@ module Nomis
     include NonPersistedModel
 
     attribute :visit_id, Integer
-    attribute :error_message, String
+    attribute :error_messages, Array[String]
 
     def self.build(response)
-      if response.key?('error')
-
-        new(error_message: response['error']['message'])
-      else
+      if response.key?('visit_id')
         new(visit_id: response['visit_id'])
+      elsif response.key?('error')
+        new(error_messages: [response['error']['message']])
+      else
+        new(error_messages: parse_multiple_errors(response))
       end
+    end
+
+    def self.parse_multiple_errors(response)
+      response.fetch('errors').map { |error| error.fetch('message') }
     end
   end
 end

--- a/spec/fixtures/vcr_cassettes/book_visit_validation_error.yml
+++ b/spec/fixtures/vcr_cassettes/book_visit_validation_error.yml
@@ -34,7 +34,7 @@ http_interactions:
       - close
     body:
       encoding: ASCII-8BIT
-      string: '{"error":{"message":"Overlapping visit"}}'
-    http_version: 
+      string: '{"errors":[{"message":"Overlapping visit"}]}'
+    http_version:
   recorded_at: Thu, 11 May 2017 12:27:34 GMT
 recorded_with: VCR 3.0.3

--- a/spec/services/create_nomis_visit_spec.rb
+++ b/spec/services/create_nomis_visit_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe CreateNomisVisit do
 
     describe 'duplicate post' do
       let(:error_message) { 'Duplicate post' }
-      let(:booking) { Nomis::Booking.new(error_message: error_message) }
+      let(:booking) { Nomis::Booking.new(error_messages: [error_message]) }
 
       it { expect(subject.execute).not_to be_success }
       it { expect(subject.execute).to have_attributes(message: BookingResponse::ALREADY_BOOKED_IN_NOMIS_ERROR) }

--- a/spec/services/nomis/api_spec.rb
+++ b/spec/services/nomis/api_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe Nomis::Api do
 
     context 'validation error', vcr: { cassette_name: 'book_visit_validation_error' } do
       it 'records the error message' do
-        expect(subject.error_message).to eq('Overlapping visit')
+        expect(subject.error_messages).to eq(['Overlapping visit'])
       end
 
       it 'instruments the outcome of the call' do
@@ -275,7 +275,7 @@ RSpec.describe Nomis::Api do
 
     context 'duplicate post', vcr: { cassette_name: 'book_visit_duplicate_error' } do
       it 'records the error message' do
-        expect(subject.error_message).to eq('Duplicate post')
+        expect(subject.error_messages).to eq(['Duplicate post'])
       end
     end
   end

--- a/spec/services/nomis/booking_spec.rb
+++ b/spec/services/nomis/booking_spec.rb
@@ -2,13 +2,26 @@ require 'rails_helper'
 
 RSpec.describe Nomis::Booking do
   describe '.build' do
-    describe 'with an error response' do
+    describe 'with a single error message' do
       let(:error_message) { 'error message' }
       let(:response) { { 'error' => { 'message' => error_message } } }
 
       it 'parses the error message' do
         expect(described_class.build(response)).
-          to have_attributes(visit_id: nil, error_message: error_message)
+          to have_attributes(visit_id: nil, error_messages: [error_message])
+      end
+    end
+
+    describe 'with a multiple error messages' do
+      let(:error_message1) { 'error message1' }
+      let(:error_message2) { 'error message2' }
+      let(:response) do
+        { 'errors' => [{ 'message' => error_message1 }, { 'message' => error_message2 }] }
+      end
+
+      it 'parses the error message' do
+        expect(described_class.build(response)).
+          to have_attributes(visit_id: nil, error_messages: [error_message1, error_message2])
       end
     end
 
@@ -18,7 +31,7 @@ RSpec.describe Nomis::Booking do
 
       it 'parses the visit id' do
         expect(described_class.build(response)).
-          to have_attributes(visit_id: visit_id, error_message: nil)
+          to have_attributes(visit_id: visit_id, error_messages: [])
       end
     end
   end


### PR DESCRIPTION
Previously book to NOMIS api returned a single string for validation
errors, but now returns an array of errors.