### PR TITLE
Refactor test config env

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,9 +25,16 @@ Rails.application.configure do
   config.nomis_api_token = nil
   config.nomis_api_key = nil
 
-  config.nomis_staff_prisoner_check_enabled = true
-  config.nomis_public_prisoner_check_enabled = true
-
-  config.nomis_staff_prisoner_availability_enabled = true
-  config.nomis_public_prisoner_availability_enabled = true
+  # Set feature flags to nil to prevent them being set by local .env
+  # and to ensure tests pass wherever they are run from.
+  config.nomis_staff_prisoner_check_enabled = nil
+  config.nomis_public_prisoner_check_enabled = nil
+  config.nomis_staff_prisoner_availability_enabled = nil
+  config.nomis_public_prisoner_availability_enabled = nil
+  config.nomis_staff_slot_availability_enabled = nil
+  config.staff_prisons_with_slot_availability = nil
+  config.public_prisons_with_slot_availability = nil
+  config.staff_prisons_with_nomis_contact_list = nil
+  config.nomis_staff_book_to_nomis_enabled = nil
+  config.staff_prisons_with_book_to_nomis = nil
 end

--- a/spec/controllers/api/validations_controller_spec.rb
+++ b/spec/controllers/api/validations_controller_spec.rb
@@ -116,6 +116,9 @@ RSpec.describe Api::ValidationsController do
     end
 
     context 'when the prisoner does not exist' do
+      before do
+        switch_on :nomis_public_prisoner_check_enabled
+      end
       let(:offender) { Nomis::NullOffender.new(api_call_successful: true) }
 
       it 'returns a validation error' do

--- a/spec/decorators/concrete_slot_decorator_spec.rb
+++ b/spec/decorators/concrete_slot_decorator_spec.rb
@@ -40,46 +40,52 @@ RSpec.describe ConcreteSlotDecorator do
     end
 
     describe 'prisoner availability' do
-      context 'when a prisoner is available' do
-        it 'renders the checkbox without errors ' do
-          expect(html_fragment).to have_css('label.date-box__label')
-          expect(html_fragment).to have_css('span.date-box__number', text: '1')
-          expect(html_fragment).to have_css('span.date-box__day',    text: date.strftime('%A'))
-          expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %B %Y')} 14:00–15:30")
-          expect(html_fragment).not_to have_css("input[disabled='disabled']")
-        end
-      end
-
-      context 'when a prisoner is not available' do
-        context 'with a date in the future' do
-          let(:slot_errors) { ['prisoner_banned'] }
-
-          it 'renders the checkbox with errors' do
-            expect(html_fragment).to have_css('label.date-box__label.date-box--error')
-            expect(html_fragment).to have_css('span.date-box__number', text: '1')
-            expect(html_fragment).to have_css('span.date-box__day',    text: date.strftime('%A'))
-            expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %B %Y')} 14:00–15:30")
-            expect(html_fragment).to have_css('span.tag--error', text: 'Visits banned')
-          end
+      context 'when the api is enabled' do
+        before do
+          switch_on :nomis_staff_prisoner_availability_enabled
         end
 
-        context 'for a date in the past' do
-          let(:date) { Date.yesterday }
-
-          it 'renders the checkbox neither verified or errors' do
+        context 'when a prisoner is available' do
+          it 'renders the checkbox without errors ' do
             expect(html_fragment).to have_css('label.date-box__label')
             expect(html_fragment).to have_css('span.date-box__number', text: '1')
             expect(html_fragment).to have_css('span.date-box__day',    text: date.strftime('%A'))
             expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %B %Y')} 14:00–15:30")
-            expect(html_fragment).not_to have_css('span.tag--error')
-            expect(html_fragment).not_to have_css('span.tag--verified')
+            expect(html_fragment).not_to have_css("input[disabled='disabled']")
+          end
+        end
+
+        context 'when a prisoner is not available' do
+          context 'with a date in the future' do
+            let(:slot_errors) { ['prisoner_banned'] }
+
+            it 'renders the checkbox with errors' do
+              expect(html_fragment).to have_css('label.date-box__label.date-box--error')
+              expect(html_fragment).to have_css('span.date-box__number', text: '1')
+              expect(html_fragment).to have_css('span.date-box__day',    text: date.strftime('%A'))
+              expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %B %Y')} 14:00–15:30")
+              expect(html_fragment).to have_css('span.tag--error', text: 'Visits banned')
+            end
+          end
+
+          context 'for a date in the past' do
+            let(:date) { Date.yesterday }
+
+            it 'renders the checkbox neither verified or errors' do
+              expect(html_fragment).to have_css('label.date-box__label')
+              expect(html_fragment).to have_css('span.date-box__number', text: '1')
+              expect(html_fragment).to have_css('span.date-box__day',    text: date.strftime('%A'))
+              expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %B %Y')} 14:00–15:30")
+              expect(html_fragment).not_to have_css('span.tag--error')
+              expect(html_fragment).not_to have_css('span.tag--verified')
+            end
           end
         end
       end
 
       context 'when the api is disabled' do
         before do
-          switch_on :nomis_staff_prisoner_availability_enabled
+          switch_off :nomis_staff_prisoner_availability_enabled
         end
 
         it 'renders the checkbox without errors' do

--- a/spec/features/process_a_request_accept_with_contact_list_spec.rb
+++ b/spec/features/process_a_request_accept_with_contact_list_spec.rb
@@ -23,12 +23,14 @@ RSpec.feature 'Processing a request - Acceptance with the contact list enabled',
 
   before do
     switch_feature_flag_with(:staff_prisons_with_nomis_contact_list, [prison.name])
-
     vst.update!(slot_option_0: '2017-06-27T14:00/16:00')
   end
 
   context 'with book to nomis enabled' do
     before do
+      switch_on :nomis_staff_prisoner_check_enabled
+      switch_on :nomis_staff_prisoner_availability_enabled
+
       switch_on :nomis_staff_book_to_nomis_enabled
       switch_feature_flag_with(:staff_prisons_with_book_to_nomis, [prison.name])
 
@@ -37,6 +39,7 @@ RSpec.feature 'Processing a request - Acceptance with the contact list enabled',
     end
 
     scenario 'accepting a booking', vcr: { cassette_name: 'book_to_nomis' } do
+      switch_feature_flag_with(:staff_prisons_with_nomis_contact_list, [prison.name])
       visit prison_visit_path(vst, locale: 'en')
 
       expect(page).to have_css('h1', text: 'Visit details')
@@ -96,6 +99,9 @@ RSpec.feature 'Processing a request - Acceptance with the contact list enabled',
   context 'without book to nomis enabled' do
     before do
       switch_off :nomis_staff_book_to_nomis_enabled
+
+      switch_on :nomis_staff_prisoner_check_enabled
+      switch_on :nomis_staff_prisoner_availability_enabled
     end
 
     scenario 'accepting a booking', vcr: { cassette_name: 'process_happy_path_with_contact_list' } do

--- a/spec/features/process_a_request_accept_without_contact_list_spec.rb
+++ b/spec/features/process_a_request_accept_without_contact_list_spec.rb
@@ -22,6 +22,10 @@ RSpec.feature 'Processing a request - Acceptance without the contact list enable
     end
 
     context "validating prisoner informations - sad paths" do
+      before do
+        switch_on :nomis_staff_prisoner_check_enabled
+      end
+
       context "and the prisoner's informations are not valid", vcr: { cassette_name: 'lookup_active_offender-nomatch' } do
         let(:slot_zero) { ConcreteSlot.new(2016, 5, 1, 10, 30, 11, 30) }
         let(:slot_one) { ConcreteSlot.new(2016, 5, 21, 10, 30, 11, 30) }
@@ -43,6 +47,9 @@ RSpec.feature 'Processing a request - Acceptance without the contact list enable
     end
 
     scenario 'accepting a booking' do
+      switch_on :nomis_staff_prisoner_check_enabled
+      switch_on :nomis_staff_prisoner_availability_enabled
+
       visit prison_visit_path(vst, locale: 'en')
       click_button 'Process'
 

--- a/spec/features/process_a_request_unprocessable_spec.rb
+++ b/spec/features/process_a_request_unprocessable_spec.rb
@@ -59,6 +59,8 @@ RSpec.feature 'Processing a request', js: true do
     end
 
     before do
+      switch_on :nomis_staff_prisoner_availability_enabled
+      switch_on :nomis_staff_prisoner_check_enabled
       switch_feature_flag_with(:staff_prisons_with_nomis_contact_list, [vst.prison_name])
 
       switch_on :nomis_staff_book_to_nomis_enabled
@@ -74,7 +76,6 @@ RSpec.feature 'Processing a request', js: true do
       visit prison_visit_path(vst, locale: 'en')
 
       choose_date
-
       within "#visitor_#{visitor.id}" do
         select 'IRMA ITSU - 03/04/1975', from: 'Match to contact list'
       end

--- a/spec/models/api_slot_availability_spec.rb
+++ b/spec/models/api_slot_availability_spec.rb
@@ -104,6 +104,10 @@ RSpec.describe ApiSlotAvailability, type: :model do
     end
 
     describe 'restricting by prisoner availability' do
+      before do
+        switch_on :nomis_public_prisoner_availability_enabled
+      end
+
       it 'can intersect available slots with prisoner availability' do
         offender = Nomis::Offender.new(id: 123)
         prisoner_availability = Nomis::PrisonerAvailability.new(

--- a/spec/services/slot_availability_spec.rb
+++ b/spec/services/slot_availability_spec.rb
@@ -61,7 +61,10 @@ RSpec.describe SlotAvailability do
       end
 
       describe 'with nomis public prisoner check enabled' do
-        before do mock_nomis_with(:lookup_active_offender, offender) end
+        before do
+          switch_on :nomis_public_prisoner_availability_enabled
+          mock_nomis_with(:lookup_active_offender, offender)
+        end
 
         describe 'when the offender is valid' do
           before do
@@ -127,10 +130,6 @@ RSpec.describe SlotAvailability do
       end
 
       describe 'without nomis public prisoner check enabled' do
-        before do
-          switch_off(:nomis_public_prisoner_availability_enabled)
-        end
-
         it 'applies the prison availability' do
           expect(subject.slots).to eq(
             "2017-02-07T09:00/10:00" => [],
@@ -150,8 +149,13 @@ RSpec.describe SlotAvailability do
     end
 
     describe 'with a prison not in the trial' do
+      before do
+        switch_feature_flag_with(:public_prisons_with_slot_availability, [])
+      end
+
       describe 'and prisoner availability enabled' do
         before do
+          switch_on :nomis_public_prisoner_availability_enabled
           mock_nomis_with(:lookup_active_offender, offender)
           mock_nomis_with(:offender_visiting_availability, prisoner_availability)
         end

--- a/spec/services/staff_nomis_checker_spec.rb
+++ b/spec/services/staff_nomis_checker_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe StaffNomisChecker do
 
   describe 'When the API is enabled' do
     describe '#prisoner_existance_status' do
-      describe 'api is configured and the check is disabled for staff' do
+      describe 'api is enabled and the check is disabled for staff' do
         before do
           switch_off(:nomis_staff_prisoner_check_enabled)
         end
@@ -43,6 +43,7 @@ RSpec.describe StaffNomisChecker do
 
       describe 'when the nomis api is live' do
         before do
+          switch_on :nomis_staff_prisoner_check_enabled
           mock_nomis_with(:lookup_active_offender, offender)
         end
 
@@ -152,6 +153,7 @@ RSpec.describe StaffNomisChecker do
         end
 
         before do
+          switch_on(:nomis_staff_prisoner_availability_enabled)
           mock_nomis_with(:lookup_active_offender, offender)
           mock_service_with(PrisonerAvailabilityValidation, prisoner_availability_validation)
         end
@@ -224,6 +226,7 @@ RSpec.describe StaffNomisChecker do
         let(:offender) { Nomis::NullOffender.new }
 
         before do
+          switch_on(:nomis_staff_prisoner_availability_enabled)
           mock_nomis_with(:lookup_active_offender, offender)
         end
 


### PR DESCRIPTION
Prevent the feature flags in the test environment to be configured
by the local .env settings.  This should mean that the tests should
pass regardless of where they run.