### PR TITLE
Update selenium-webdriver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ group :test do
   gem 'ffaker'
   gem 'launchy'
   gem 'rspec-collection_matchers'
-  gem 'selenium-webdriver', '2.53.4'
+  gem 'selenium-webdriver'
   gem 'simplecov'
   gem 'simplecov-rcov'
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,10 +292,9 @@ GEM
       railties (>= 4.0.0)
     secure_headers (3.6.5)
       useragent
-    selenium-webdriver (2.53.4)
+    selenium-webdriver (3.4.4)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
-      websocket (~> 1.0)
     sentry-raven (2.6.0)
       faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (3.1.2)
@@ -355,7 +354,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    websocket (1.2.4)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -418,7 +416,7 @@ DEPENDENCIES
   sass-rails
   scenic
   secure_headers
-  selenium-webdriver (= 2.53.4)
+  selenium-webdriver
   sentry-raven
   shoulda-matchers
   sidekiq
@@ -438,4 +436,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.1
+   1.15.2

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,19 @@ machine:
   ruby:
     version:
       2.4.1
+  environment:
+    PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/drivers"
 
 test:
   override:
     - bundle exec rake
+
+dependencies:
+  post:
+    - sudo apt-get update
+    - sudo apt-get install libpango1.0-0
+    - sudo apt-get install firefox
+    - sudo ln -sf /usr/lib/firefox/firefox /usr/bin/firefox
+    - mkdir drivers
+    - wget https://github.com/mozilla/geckodriver/releases/download/v0.18.0/geckodriver-v0.18.0-linux64.tar.gz && tar -zxvf geckodriver-v0.18.0-linux64.tar.gz:
+        pwd: drivers


### PR DESCRIPTION
To version 3.4.4

This means it works with the latest version of Firefox (v54).

In local machines `geckodriver` needs to be installed `brew install geckodriver` and update Firefox 