### PR TITLE
reduce firefox dependencies install to one line

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,9 +11,7 @@ test:
 
 dependencies:
   post:
-    - sudo apt-get update
-    - sudo apt-get install libpango1.0-0
-    - sudo apt-get install firefox
+    - sudo apt-get update && sudo  apt-get install -y libpango1.0-0 firefox
     - sudo ln -sf /usr/lib/firefox/firefox /usr/bin/firefox
     - mkdir drivers
     - wget https://github.com/mozilla/geckodriver/releases/download/v0.18.0/geckodriver-v0.18.0-linux64.tar.gz && tar -zxvf geckodriver-v0.18.0-linux64.tar.gz:

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ test:
 
 dependencies:
   post:
-    - sudo apt-get update && sudo  apt-get install -y libpango1.0-0 firefox
+    - sudo  apt-get install -y libpango1.0-0 firefox
     - sudo ln -sf /usr/lib/firefox/firefox /usr/bin/firefox
     - mkdir drivers
     - wget https://github.com/mozilla/geckodriver/releases/download/v0.18.0/geckodriver-v0.18.0-linux64.tar.gz && tar -zxvf geckodriver-v0.18.0-linux64.tar.gz:

--- a/circle.yml
+++ b/circle.yml
@@ -11,6 +11,7 @@ test:
 
 dependencies:
   post:
+    - sudo apt-get update
     - sudo  apt-get install -y libpango1.0-0 firefox
     - sudo ln -sf /usr/lib/firefox/firefox /usr/bin/firefox
     - mkdir drivers


### PR DESCRIPTION
**CHANGES:**

Make circle run faster by updating packages and installing libpango,  firefox packages in one go