### PR TITLE
Visitor ban rejection email issue

### DIFF
--- a/app/models/staff_response.rb
+++ b/app/models/staff_response.rb
@@ -103,8 +103,10 @@ privileged_allowance_expires_on])
   end
 
   def check_principal_visitor
-    if principal_visitor.banned? || principal_visitor.not_on_list? ||
-           principal_visitor.age < ADULT_AGE
+    if principal_visitor.banned?
+      rejection.reasons << Rejection::BANNED
+      visit.slot_granted = nil
+    elsif principal_visitor.not_on_list?
       rejection.reasons << Rejection::NOT_ON_THE_LIST
       visit.slot_granted = nil
     end

--- a/spec/models/staff_response_spec.rb
+++ b/spec/models/staff_response_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe StaffResponse, type: :model do
         it { is_expected.to be_valid }
 
         it 'has a rejection for visitor banned' do
-          expect(subject.visit.rejection.reasons).to eq([Rejection::NOT_ON_THE_LIST, Rejection::BANNED])
+          expect(subject.visit.rejection.reasons).to eq([Rejection::BANNED])
         end
       end
     end


### PR DESCRIPTION
Issue where if the lead visitor is banned then the rejection email sent
to them included the incorrect copy i.e. the copy where someone is not
on the list.  Implement amendment so email only includes details about
the visitor ban.