### PR TITLE
Order prisoner's contact list alphabetically

### DIFF
--- a/app/services/nomis/contact.rb
+++ b/app/services/nomis/contact.rb
@@ -1,6 +1,7 @@
 module Nomis
   class Contact
     include NonPersistedModel
+    include Comparable
 
     attribute :id, Integer
     attribute :given_name
@@ -23,6 +24,10 @@ module Nomis
 
     def banned_until
       restrictions.find(&:banned?)&.expiry_date
+    end
+
+    def <=>(other)
+      [surname, given_name] <=> [other.surname, other.given_name]
     end
   end
 end

--- a/app/services/nomis/contact_list.rb
+++ b/app/services/nomis/contact_list.rb
@@ -5,7 +5,10 @@ module Nomis
 
     delegate :each, to: :contacts
 
-    attribute :contacts, Array[Contact]
+    attribute :contacts,
+      Array[Contact],
+      coercer: ->(contacts) { contacts.map { |s| Contact.new(s) }.sort }
+
     attribute :api_call_successful, Boolean, default: true
 
     def approved

--- a/spec/services/nomis/contact_list_spec.rb
+++ b/spec/services/nomis/contact_list_spec.rb
@@ -2,19 +2,19 @@ require 'rails_helper'
 
 RSpec.describe Nomis::ContactList do
   let(:approved_active) do
-    Nomis::Contact.new(id: 1, active: true, approved_visitor: true)
+    Nomis::Contact.new(id: 1, active: true, surname: "Janklin", given_name: "Dave", approved_visitor: true)
   end
 
   let(:disapproved_active) do
-    Nomis::Contact.new(id: 2, active: true, approved_visitor: false)
+    Nomis::Contact.new(id: 2, active: true, surname: "Buster", given_name: "Kristen", approved_visitor: false)
   end
 
   let(:approved_inactive) do
-    Nomis::Contact.new(id: 3, active: false, approved_visitor: true)
+    Nomis::Contact.new(id: 3, active: false, surname: "Zoomer", given_name: "Pete", approved_visitor: true)
   end
 
   let(:disapproved_inactive) do
-    Nomis::Contact.new(id: 4, active: false, approved_visitor: false)
+    Nomis::Contact.new(id: 4, active: false, surname: "Buster", given_name: "Kate", approved_visitor: false)
   end
 
   subject(:instance) do
@@ -32,5 +32,10 @@ RSpec.describe Nomis::ContactList do
       expect(subject.map(&:id)).to include(approved_active.id)
       expect(subject.map(&:id)).to include(approved_inactive.id)
     end
+  end
+
+  it 'returns an alphabetically ordered list of contacts, by surname and then first name' do
+    contacts = subject.map{ |k, _| [k[:surname], k[:given_name]] }
+    expect(contacts).to eq [%w[Buster Kate], %w[Buster Kristen], %w[Janklin Dave], %w[Zoomer Pete]]
   end
 end

--- a/spec/services/nomis/contact_spec.rb
+++ b/spec/services/nomis/contact_spec.rb
@@ -100,4 +100,24 @@ RSpec.describe Nomis::Contact do
       it { is_expected.to eq(nil) }
     end
   end
+
+  describe '#<=>' do
+    it 'returns 1 when first contact is greater than the second' do
+      first_contact = described_class.new(surname: "Jones", given_name: "Grace")
+      second_contact = described_class.new(surname: "Jones", given_name: "Billy")
+      expect(first_contact <=> second_contact).to eq(1)
+    end
+
+    it 'returns -1 when the first contact is lesser than the second' do
+      first_contact = described_class.new(surname: "Franklin", given_name: "Adam")
+      second_contact = described_class.new(surname: "Poppins", given_name: "Jeff")
+      expect(first_contact <=> second_contact).to eq(-1)
+    end
+
+    it 'returns 0 when the first contact matches the second' do
+      first_contact = described_class.new(surname: "Smith", given_name: "John")
+      second_contact = described_class.new(surname: "Smith", given_name: "John")
+      expect(first_contact <=> second_contact).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
User feedback indicated that having the contact list ordered
alphabetically would save booking staff time when matching the name(s).
This refactor sorts the contact list, first by surname and then by
given name.