### PR TITLE
Refactor env variables config parsing

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -22,19 +22,4 @@ Rails.application.configure do
   # credentials to avoid the possibility of leaking sensitive credentials or
   # returned data into VCR test output files.
   config.nomis_api_host = 'http://151.237.239.116:4888'
-  config.nomis_api_token = nil
-  config.nomis_api_key = nil
-
-  # Set feature flags to nil to prevent them being set by local .env
-  # and to ensure tests pass wherever they are run from.
-  config.nomis_staff_prisoner_check_enabled = nil
-  config.nomis_public_prisoner_check_enabled = nil
-  config.nomis_staff_prisoner_availability_enabled = nil
-  config.nomis_public_prisoner_availability_enabled = nil
-  config.nomis_staff_slot_availability_enabled = nil
-  config.staff_prisons_with_slot_availability = nil
-  config.public_prisons_with_slot_availability = nil
-  config.staff_prisons_with_nomis_contact_list = nil
-  config.nomis_staff_book_to_nomis_enabled = nil
-  config.staff_prisons_with_book_to_nomis = nil
 end


### PR DESCRIPTION
Prevents having to define `nil` configuration in `test` environment.

This was a problem because when we had a new environment variable for
configuration that we didn't want to leak into the tests we had to remember
to explicitly set it in `config/environments/test.rb` which was easy to forget.