### PR TITLE
Do not enforce contact list on visit rejection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ tags
 .byebug_history
 dump.rdb
 .ruby-gemset
+config/database.yml

--- a/app/models/staff_response.rb
+++ b/app/models/staff_response.rb
@@ -149,6 +149,7 @@ privileged_allowance_expires_on])
 
   def visitors_selection
     return unless validate_visitors_nomis_ready?
+    return if rejection.valid?
 
     invalid_visitors = visit.visitors.select { |visitor|
       visitor.nomis_id.present? == visitor.not_on_list?

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -23,8 +23,8 @@ default: &default
 
 development:
   <<: *default
+  host: postgres
   database: pvb2_development
-
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
@@ -58,7 +58,7 @@ development:
 test:
   <<: *default
   database: pvb2_test
-
+  url: <%= ENV["DATABASE_URL"] %>
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
 # ever seen by anyone, they now have access to your database.

--- a/spec/models/staff_response_spec.rb
+++ b/spec/models/staff_response_spec.rb
@@ -73,9 +73,7 @@ RSpec.describe StaffResponse, type: :model do
     context 'when not processable' do
       let(:processing_state) { 'rejected' }
 
-      before do
-        is_expected.not_to be_valid
-      end
+      before { is_expected.not_to be_valid }
 
       specify { expect(subject.errors.full_messages).to eq(["Visit can't be processed"]) }
     end
@@ -98,30 +96,21 @@ RSpec.describe StaffResponse, type: :model do
     context 'when visitors need to be ready for nomis' do
       let(:validate_visitors_nomis_ready) { 'true' }
 
+      context 'with a rejected visit' do
+        before do
+          params[:rejection_attributes][:reasons] = [Rejection::NO_ALLOWANCE]
+          params['slot_granted'] = ''
+        end
+
+        it 'does not require to process the visitors' do
+          is_expected.to be_valid
+        end
+      end
+
       context 'and a visitor is on the list and not have a nomis id' do
         before do
           params[:visitors_attributes]['0'][:nomis_id] = nil
           params[:visitors_attributes]['0'][:not_on_list] = nil
-        end
-
-        it 'is invalid' do
-          is_expected.to be_invalid
-
-          expect(subject.errors.full_messages).
-            to include(
-              I18n.t('visitors_invalid',
-                scope: %i[activemodel errors models staff_response attributes base])
-               )
-
-          expect(subject.visit.visitors.first.errors[:base]).
-            to include("Process this visitor to continue")
-        end
-      end
-
-      context 'and a visitor is not on the list and has a nomis id' do
-        before do
-          params[:visitors_attributes]['0'][:nomis_id] = 12_345
-          params[:visitors_attributes]['0'][:not_on_list] = true
         end
 
         it 'is invalid' do


### PR DESCRIPTION
**CHANGES:**  

No longer require staff to process/match contact on the contact list when rejecting a booking