### PR TITLE
Normalise noms_id on offenders

### DIFF
--- a/app/services/nomis/offender.rb
+++ b/app/services/nomis/offender.rb
@@ -2,7 +2,10 @@ class Nomis::Offender
   include NonPersistedModel
 
   attribute :id
-  attribute :noms_id
+  attribute :noms_id,
+    String,
+    coercer: ->(number) { number&.upcase&.strip }
+
   validates_presence_of :id, :noms_id
 
   def api_call_successful?

--- a/spec/services/nomis/offender_spec.rb
+++ b/spec/services/nomis/offender_spec.rb
@@ -3,4 +3,14 @@ require "rails_helper"
 RSpec.describe Nomis::Offender, type: :model do
   it { is_expected.to validate_presence_of :id }
   it { is_expected.to validate_presence_of :noms_id }
+
+  context 'with an unormalised noms_id' do
+    before do
+      subject.noms_id = 'A1234bc '
+    end
+
+    it 'normalises the noms_id' do
+      expect(subject.noms_id).to eq('A1234BC')
+    end
+  end
 end


### PR DESCRIPTION
The offenders noms_id is used to call the location api which expects the value
to be normalised.