### PR TITLE
Fix link directory setup

### DIFF
--- a/config/initializers/link_directory.rb
+++ b/config/initializers/link_directory.rb
@@ -9,5 +9,5 @@ public_service_url = if Rails.env.production?
 
 Rails.configuration.link_directory = LinkDirectory.new(
   prison_finder: 'http://www.justice.gov.uk/contacts/prison-finder{/prison}',
-  public_service: "#{public_service_url}/{path}"
+  public_service: public_service_url
 )


### PR DESCRIPTION
The setup in the initializer was setting the publice service as a URI Template
value, however the implementation of LinkDirectory expects it to be url.

The consequences of this was that links to the public visit page in the emails
had a double '/' in the path ie http://example.com//en/visits/123, and urls
generated for the public service through `LinkDirectory#public_service` would
have had the path duplicated.