### PR TITLE
Multiple cancellation reasons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,9 @@ ruby '2.4.2'
 
 gem 'rails', '~> 5.1'
 
-gem 'connection_pool'
+gem 'activerecord-safer_migrations'
 gem 'base32-crockford', require: 'base32/crockford'
+gem 'connection_pool'
 gem 'excon'
 gem 'highline', require: false
 gem 'jbuilder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,8 @@ GEM
       activemodel (= 5.1.4)
       activesupport (= 5.1.4)
       arel (~> 8.0)
+    activerecord-safer_migrations (2.0.0)
+      activerecord (>= 4.0)
     activesupport (5.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
@@ -374,6 +376,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-safer_migrations
   awesome_print
   base32-crockford
   brakeman

--- a/app/models/cancellation.rb
+++ b/app/models/cancellation.rb
@@ -17,5 +17,22 @@ class Cancellation < ActiveRecord::Base
 
   belongs_to :visit
 
+  validate :validate_reasons
+  validates :reasons, presence: true
   validates :reason, inclusion: { in: REASONS }
+
+private
+
+  def validate_reasons
+    reasons.each do |r|
+      next if REASONS.include?(r)
+      errors.add(
+        :reasons,
+        I18n.t(
+          'activerecord.errors.models.cancellation.invalid_reason',
+          reason: r
+        )
+      )
+    end
+  end
 end

--- a/app/services/booking_responder/cancel.rb
+++ b/app/services/booking_responder/cancel.rb
@@ -5,6 +5,7 @@ class BookingResponder
         visit.cancel!
         Cancellation.create!(visit: visit,
                              reason: staff_response.reason,
+                             reasons: [staff_response.reason],
                              nomis_cancelled: true)
 
         BookingResponse.successful

--- a/app/services/booking_responder/visitor_cancel.rb
+++ b/app/services/booking_responder/visitor_cancel.rb
@@ -4,6 +4,7 @@ class BookingResponder
       super do
         visit.cancel!
         Cancellation.create!(visit: visit,
+                             reasons: [Cancellation::VISITOR_CANCELLED],
                              reason: Cancellation::VISITOR_CANCELLED,
                              nomis_cancelled: false)
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -34,6 +34,8 @@ en:
       models:
         rejection:
           invalid_reason: "%{reason} is not in the list"
+        cancellation:
+          invalid_reason: "%{reason} is not in the list"
         prison:
           duplicate_unbookable_date: An unbookable date may not be duplicated
           unbookable_and_anomalous_conflict: An unbookable date may not also be anomalous

--- a/db/migrate/20170929084924_add_reasons_to_cancellations.rb
+++ b/db/migrate/20170929084924_add_reasons_to_cancellations.rb
@@ -1,0 +1,5 @@
+class AddReasonsToCancellations < ActiveRecord::Migration[5.1]
+  def change
+    add_column :cancellations, :reasons, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170706150304) do
+ActiveRecord::Schema.define(version: 20170929084924) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20170706150304) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "nomis_cancelled", default: false, null: false
+    t.string "reasons", default: [], array: true
     t.index ["visit_id"], name: "index_cancellations_on_visit_id", unique: true
   end
 

--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -120,6 +120,14 @@ namespace :pvb do
 
     AdminMailer.slot_availability(prison_data).deliver_now!
   end
+
+  desc 'Backfill Cancellation#reasons'
+  task backfill_cancellation_reasons: :enviornment do
+    Cancellation.where(reasons: []).in_batches(of: 1000) do |relation|
+      relation.update_all('reasons = cancellations.reason || ARRAY[]::varchar[]')
+      sleep(1)
+    end
+  end
 end
 
 class SlotAvailabilityCounter

--- a/spec/factories/cancellations.rb
+++ b/spec/factories/cancellations.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :cancellation do
     association :visit, processing_state: 'cancelled'
     reason 'prisoner_moved'
+    reasons ['prisoner_moved']
   end
 end

--- a/spec/models/cancellation_spec.rb
+++ b/spec/models/cancellation_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Cancellation, model: true do
+  subject { FactoryGirl.build(:cancellation) }
+
   describe 'validation' do
     it 'enforces no more than one per visit' do
       cancellation = FactoryGirl.create(:cancellation)
@@ -20,6 +22,33 @@ RSpec.describe Cancellation, model: true do
       cancellation.reason = 'random'
       expect(cancellation).to be_invalid
       expect(cancellation.errors[:reason]).to be_present
+    end
+
+    describe '#reasons' do
+      context 'with rejection reasons' do
+        before do
+          subject.reasons = reasons
+        end
+
+        context 'and the reason does not exists' do
+          let(:reasons) { ['invalid_reason'] }
+
+          it 'for an invalid reason' do
+            expect(subject).not_to be_valid
+            expect(subject.errors.full_messages_for(:reasons)).to eq(
+              ['Reasons invalid_reason is not in the list']
+            )
+          end
+        end
+
+        context 'and the reason exists' do
+          let(:reasons) do
+            described_class::REASONS[0..rand(described_class::REASONS.length - 1)]
+          end
+
+          it { is_expected.to be_valid }
+        end
+      end
     end
   end
 end

--- a/spec/services/booking_responder/cancel_spec.rb
+++ b/spec/services/booking_responder/cancel_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe BookingResponder::Cancel do
     visit.reload
     expect(visit).to be_cancelled
     expect(visit.cancellation.reason).to eq(reason)
+    expect(visit.cancellation.reasons).to eq([reason])
     expect(visit.cancellation.nomis_cancelled).to eq(true)
   end
 end


### PR DESCRIPTION
Starts storing the cancellation reason as an array of reasons in the database and adds a task to migrate old cancellations to the new format.

Next steps are to update emails and public to make use of multiple cancellation reasons and then update the form so that users can specify multiple cancellations reasons.