### PR TITLE
Fix email validation bug

### DIFF
--- a/app/services/email_checker.rb
+++ b/app/services/email_checker.rb
@@ -26,8 +26,8 @@ private
 
   def format_error
     return :unparseable unless parsed
-    return :domain_dot if domain_dot_error?
     return :malformed unless well_formed_address?
+    return :domain_dot if domain_dot_error?
   end
 
   def mx_records_error
@@ -45,7 +45,7 @@ private
   end
 
   def domain_dot_error?
-    domain&.start_with?('.')
+    domain.start_with?('.') || domain.match(/\.{2,}/)
   end
 
   def well_formed_address?

--- a/spec/services/email_checker_spec.rb
+++ b/spec/services/email_checker_spec.rb
@@ -50,6 +50,12 @@ RSpec.describe EmailChecker do
 
       it_behaves_like 'an invalid address', 'unparseable'
     end
+
+    context 'with additional dot included in the domain' do
+      let(:address) { 'user@test.example..com' }
+
+      it_behaves_like 'an invalid address', 'domain_dot'
+    end
   end
 
   context 'with valid address' do


### PR DESCRIPTION
The issue here is that older browsers are not compatible with the newer
HMTL input type "email", which alerts users when they have entered an
invalid email address (e.g. "user@example..com") when using the feedback
submission form.  This means that in older browsers form submissions
are allowed to go ahead regardless of an invalid email format, but then
result in an error in Sentry.  Therefore the #domain_dot_error method
has been extended to check for two or more consecutive dots in the
domain; if found an error is raised.