### PR TITLE
Cancellation reasons api and email

### DIFF
--- a/app/decorators/cancellation_decorator.rb
+++ b/app/decorators/cancellation_decorator.rb
@@ -1,0 +1,46 @@
+class CancellationDecorator < Draper::Decorator
+  delegate_all
+
+  RESTRICTON_REASONS = [
+    Cancellation::CHILD_PROTECTION_ISSUES,
+    Cancellation::PRISONER_NON_ASSOCIATION
+  ].freeze
+
+  def formatted_reasons
+    result = []
+
+    if object.reasons.any? { |r| r.in? RESTRICTON_REASONS }
+      result << translated_restricted_reason
+    end
+
+    non_restricted_reasons = object.reasons - RESTRICTON_REASONS
+
+    non_restricted_reasons.each do |reason|
+      explanations = *translated_explanations_for(reason)
+      result += explanations
+    end
+    result
+  end
+
+private
+
+  def translated_explanations_for(reason)
+    Cancellation::Reason.new(explanation: reason_explanation(reason))
+  end
+
+  def reason_explanation(reason)
+    h.t(
+      "#{reason}_html",
+      prison: object.visit.prison_name,
+      prisoner: object.visit.prisoner_full_name,
+      visitor_name: object.visit.visitor_full_name,
+      service_url: h.link_directory.public_service,
+      scope: %i[visitor_mailer cancelled]
+    )
+  end
+
+  def translated_restricted_reason
+    explanation = h.t('restricted_reason_html', scope: %i[visitor_mailer cancelled])
+    Cancellation::Reason.new(explanation: explanation)
+  end
+end

--- a/app/mailers/visitor_mailer.rb
+++ b/app/mailers/visitor_mailer.rb
@@ -46,6 +46,8 @@ class VisitorMailer < ActionMailer::Base
 
   def cancelled(visit)
     I18n.locale = visit.locale
+
+    @cancellation = visit.cancellation.decorate
     mail_visitor visit,
       prison_name: visit.prison_name,
       date: format_date_without_year(visit.date)

--- a/app/models/cancellation.rb
+++ b/app/models/cancellation.rb
@@ -1,16 +1,19 @@
 class Cancellation < ActiveRecord::Base
-  VISITOR_CANCELLED = 'visitor_cancelled'
+  VISITOR_CANCELLED = 'visitor_cancelled'.freeze
+  CHILD_PROTECTION_ISSUES = 'child_protection_issues'.freeze
+  PRISONER_NON_ASSOCIATION = 'prisoner_non_association'.freeze
+  VISITOR_BANNED = 'visitor_banned'.freeze
 
-  STAFF_REASONS = %w[
-    booked_in_error
-    capacity_issues
-    child_protection_issues
-    prisoner_moved
-    prisoner_non_association
-    prisoner_released
-    prisoner_vos
-    slot_unavailable
-    visitor_banned
+  STAFF_REASONS = [
+    'booked_in_error',
+    'capacity_issues',
+    CHILD_PROTECTION_ISSUES,
+    'prisoner_moved',
+    PRISONER_NON_ASSOCIATION,
+    'prisoner_released',
+    'prisoner_vos',
+    'slot_unavailable',
+    VISITOR_BANNED
   ]
 
   REASONS = STAFF_REASONS + [VISITOR_CANCELLED]

--- a/app/models/cancellation/reason.rb
+++ b/app/models/cancellation/reason.rb
@@ -1,0 +1,6 @@
+class Cancellation < ActiveRecord::Base
+  class Reason
+    include ActiveModel::Model
+    attr_accessor :explanation
+  end
+end

--- a/app/views/api/visits/show.json.jbuilder
+++ b/app/views/api/visits/show.json.jbuilder
@@ -8,6 +8,7 @@ json.visit do
   json.slots @visit.slots.map(&:iso8601)
   json.slot_granted @visit.slot_granted&.iso8601
   json.cancellation_reason @visit.cancellation&.reason
+  json.cancellation_reasons @visit.cancellation&.reasons
   json.cancelled_at @visit.cancellation&.created_at&.iso8601
   json.can_cancel VisitorCancellationResponse.new(visit: @visit).visitor_can_cancel?
   json.can_withdraw VisitorWithdrawalResponse.new(visit: @visit).visitor_can_withdraw?

--- a/app/views/cancellation/reasons/_reason.html.erb
+++ b/app/views/cancellation/reasons/_reason.html.erb
@@ -1,0 +1,4 @@
+<li>
+  <%= reason.explanation %>
+</li>
+

--- a/app/views/visitor_mailer/_multiple_cancellation_reasons.html.erb
+++ b/app/views/visitor_mailer/_multiple_cancellation_reasons.html.erb
@@ -1,0 +1,12 @@
+<p>
+  <%= t('intro',
+       date: format_slot_for_public(@visit.slot_granted),
+       prison: @visit.prison.name,
+       prisoner: @visit.prisoner_full_name,
+       scope: %i(visitor_mailer cancelled))
+  %>
+</p>
+<p><%= t('cant_visit', scope: %i(visitor_mailer cancelled)) %>:</p>
+<ul class="list list-bullet">
+  <%= render @cancellation.formatted_reasons %>
+</ul>

--- a/app/views/visitor_mailer/_single_cancellation_reason.html.erb
+++ b/app/views/visitor_mailer/_single_cancellation_reason.html.erb
@@ -1,0 +1,11 @@
+<p>
+  <%= t('intro',
+       date: format_slot_for_public(@visit.slot_granted),
+       prison: @visit.prison.name,
+       prisoner: @visit.prisoner_full_name,
+       scope: %i(visitor_mailer cancelled))
+  %>
+</p>
+
+<%= @cancellation.formatted_reasons.first.explanation %>
+

--- a/app/views/visitor_mailer/cancelled.html.erb
+++ b/app/views/visitor_mailer/cancelled.html.erb
@@ -1,21 +1,9 @@
 <p><%= t('.salutation', name: @visit.visitor_first_name) %></p>
 
-<% case @visit.cancellation_reason %>
-<% when 'visitor_banned' %>
-  <%= t('.visitor_banned_html',
-        date: format_slot_for_public(@visit.slot_granted),
-        prison: @visit.prison.name,
-        prisoner: @visit.prisoner_full_name,
-        visitor_name: @visit.visitor_full_name) %>
-  <% else %>
-    <p>
-    <%= t('.intro',
-          date: format_slot_for_public(@visit.slot_granted),
-          prison: @visit.prison.name,
-          prisoner: @visit.prisoner_full_name) %>
-    </p>
-
-    <%= t(".#{@visit.cancellation_reason}_html", service_url: link_directory.public_service, prisoner: @visit.prisoner_full_name) %>
+<% if @cancellation.reasons.one? %>
+  <%= render 'single_cancellation_reason', reason: @cancellation.reasons.first %>
+<% else %>
+  <%= render 'multiple_cancellation_reasons' %>
 <% end %>
 
 <p><%= t('.any_questions_html',

--- a/config/locales/en/pvb2-mailers.yml
+++ b/config/locales/en/pvb2-mailers.yml
@@ -177,6 +177,7 @@ en:
       salutation: Dear %{name},
       intro:
         We're sorry to let you know we have cancelled your visit to %{prisoner} at %{prison} on %{date}.
+      cant_visit: You can't visit because
       slot_unavailable_html: >-
         <p>We’re sorry but the date and time you chose is no longer available.</p>
 
@@ -193,13 +194,11 @@ en:
         <p>We’re sorry but there are too many visitors scheduled for that time and we do not have enough space to sit everyone safely.</p>
 
         <p>To arrange another visit, go to <a href="%{service_url}">www.gov.uk/prison-visits</a> and choose new dates.</p>
-      child_protection_issues_html:
-        <p>We have cancelled your visit due to restrictions around this prisoner.</p>
       prisoner_moved_html: >-
         <p>We cancelled your visit because they have left this prison.</p>
 
         <p>If they haven’t been in touch recently, visit <a href="%{service_url}">www.gov.uk/find-prisoner</a>.This service will help you find them.</p>
-      prisoner_non_association_html: >-
+      restricted_reason_html: >-
         <p>We have cancelled your visit due to restrictions around this prisoner.</p>
 
         <p>You may be able to visit them at a later date.</p>

--- a/spec/decorators/cancellation_decorator_spec.rb
+++ b/spec/decorators/cancellation_decorator_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe CancellationDecorator do
+  let!(:visit) { create(:cancelled_visit) }
+  let(:cancellation) { create(:cancellation, visit: visit) }
+
+  subject { described_class.decorate(cancellation) }
+
+  describe '#formatted_reasons' do
+    before do
+      cancellation.reasons = reasons
+    end
+
+    context 'containing child protection' do
+      let(:reasons) { [Cancellation::CHILD_PROTECTION_ISSUES] }
+
+      it 'has the correct explanation' do
+        expect(
+          subject.formatted_reasons.map(&:explanation)
+        ).to eq([
+          "<p>We have cancelled your visit due to restrictions around this prisoner.<\/p>\n<p\>You may be able to visit them at a later date.<\/p>"
+        ])
+      end
+    end
+
+    context 'containing prisoner non association' do
+      let(:reasons) { [Cancellation::PRISONER_NON_ASSOCIATION] }
+
+      it 'has the correct explanation' do
+        expect(
+          subject.formatted_reasons.map(&:explanation)
+        ).to eq([
+          "<p>We have cancelled your visit due to restrictions around this prisoner.<\/p>\n<p>You may be able to visit them at a later date.</p>"
+        ])
+      end
+    end
+
+    context 'containing visitor banned' do
+      let(:reasons) { [Cancellation::VISITOR_BANNED] }
+
+      it 'has the correct explanation' do
+        expect(
+          subject.formatted_reasons.map(&:explanation)
+        ).to eq([
+          "<p>We have cancelled your visit because you have been banned from visiting this prison.<\/p>\n<p>We have sent you a letter explaining why we took this decision and giving you further details.</p>"
+        ])
+      end
+    end
+
+    context 'containing both a no association and another non-restriction reason' do
+      let(:reasons) do
+        [
+          Cancellation::PRISONER_NON_ASSOCIATION,
+          Cancellation::CHILD_PROTECTION_ISSUES
+        ]
+      end
+
+      it 'has a restricted and another restricted reasons' do
+        expect(subject.formatted_reasons.map(&:explanation)).
+          to contain_exactly("<p>We have cancelled your visit due to restrictions around this prisoner.<\/p>\n<p>You may be able to visit them at a later date.<\/p>")
+      end
+    end
+  end
+end

--- a/spec/mailers/visitor_mailer/cancelled_spec.rb
+++ b/spec/mailers/visitor_mailer/cancelled_spec.rb
@@ -5,10 +5,11 @@ RSpec.describe VisitorMailer, '.cancelled' do
   let(:visit) { create(:cancelled_visit) }
   let(:mail) { described_class.cancelled(visit) }
   let(:reason) { 'slot_unavailable' }
+  let(:reasons) { [reason] }
 
   before do
     ActionMailer::Base.deliveries.clear
-    FactoryGirl.create(:cancellation, visit: visit, reason: reason)
+    FactoryGirl.create(:cancellation, visit: visit, reason: reason, reasons: reasons)
   end
 
   around do |example|
@@ -78,5 +79,12 @@ RSpec.describe VisitorMailer, '.cancelled' do
     let(:reason) { 'booked_in_error' }
 
     it { expect(mail.html_part.body).to match(/mistake booking this/) }
+  end
+
+  context 'when cancelled by more than one reason' do
+    let(:reasons) { %w[child_protection_issues visitor_banned] }
+
+    it { expect(mail.html_part.body).to match(/due to restrictions/) }
+    it { expect(mail.html_part.body).to match(/banned from visiting/) }
   end
 end


### PR DESCRIPTION
Makes cancellation emails compatible with multiple reasons and adds the reason to the api.

It also refactors the single cancellation view to always show the intro.