### PR TITLE
Allow staff to check multiple cancellation reasons

### DIFF
--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -5,7 +5,7 @@ class Prison::VisitsController < ApplicationController
 
   before_action :authorize_prison_request
   before_action :authenticate_user
-  before_action :cancellation_reason_set, only: :cancel
+  before_action :cancellation_reasons_set, only: :cancel
   before_action :visit_is_processable, only: :update
   before_action :set_visit_processing_time_cookie, only: :show
   after_action  :track_visit_process, only: :update
@@ -75,11 +75,11 @@ private
       CancellationResponse.new(
         visit: memoised_visit,
         user: current_user,
-        reason: params[:cancellation_reason])
+        reasons: params[:cancellation_reasons])
   end
 
-  def cancellation_reason_set
-    if params[:cancellation_reason].blank?
+  def cancellation_reasons_set
+    if params[:cancellation_reasons].blank?
       flash[:notice] = t('no_cancellation_reason', scope: %i[prison flash])
       redirect_to action: :show
     end

--- a/app/models/cancellation.rb
+++ b/app/models/cancellation.rb
@@ -22,7 +22,11 @@ class Cancellation < ActiveRecord::Base
 
   validate :validate_reasons
   validates :reasons, presence: true
-  validates :reason, inclusion: { in: REASONS }
+
+  # TODO: Remove after column has been dropped.
+  def self.columns
+    super.reject { |r| r == 'reason' }
+  end
 
 private
 

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -28,7 +28,7 @@ class Visit < ActiveRecord::Base
   alias_attribute :first_date, :slot_option_0
 
   delegate :reasons, to: :rejection, prefix: true
-  delegate :reason, to: :cancellation, prefix: true
+  delegate :reasons, to: :cancellation, prefix: true
   delegate :allowance_will_renew?, :allowance_renews_on,
     to: :rejection
 

--- a/app/services/booking_responder/cancel.rb
+++ b/app/services/booking_responder/cancel.rb
@@ -4,8 +4,7 @@ class BookingResponder
       super do
         visit.cancel!
         Cancellation.create!(visit: visit,
-                             reason: staff_response.reason,
-                             reasons: [staff_response.reason],
+                             reasons: staff_response.reasons,
                              nomis_cancelled: true)
 
         BookingResponse.successful

--- a/app/services/cancellation_response.rb
+++ b/app/services/cancellation_response.rb
@@ -1,14 +1,14 @@
 class CancellationResponse
-  attr_reader :visit, :user, :reason
+  attr_reader :visit, :user, :reasons
 
-  def initialize(visit:, user:, reason:)
+  def initialize(visit:, user:, reasons:)
     @visit = visit
     @user = user
-    @reason = reason
+    @reasons = reasons
   end
 
   def can_cancel?
-    @visit.can_cancel?
+    visit.can_cancel?
   end
 
   def cancel!

--- a/app/views/api/visits/show.json.jbuilder
+++ b/app/views/api/visits/show.json.jbuilder
@@ -7,7 +7,6 @@ json.visit do
   json.contact_email_address @visit.contact_email_address
   json.slots @visit.slots.map(&:iso8601)
   json.slot_granted @visit.slot_granted&.iso8601
-  json.cancellation_reason @visit.cancellation&.reason
   json.cancellation_reasons @visit.cancellation&.reasons
   json.cancelled_at @visit.cancellation&.created_at&.iso8601
   json.can_cancel VisitorCancellationResponse.new(visit: @visit).visitor_can_cancel?

--- a/app/views/prison/visits/_cancel_visit.html.erb
+++ b/app/views/prison/visits/_cancel_visit.html.erb
@@ -1,67 +1,27 @@
-<h3 class="heading-medium"><%= t(".title") %></h3>
+<%= form_tag cancel_prison_visit_path(@visit, locale: 'en'), class: 'form' do -%>
+  <h3 class="heading-medium"><%= t(".title") %></h3>
 
-<div class="grid-row">
-  <fieldset>
-    <div class="column-one-half">
-      <div class="multiple-choice">
-        <%= radio_button_tag 'cancellation_reason', :prisoner_vos, false %>
-        <label for="cancellation_reason_prisoner_vos">
-          <%= t(".prisoner_vos") %>
-        </label>
+  <div class="grid-row">
+    <fieldset>
+      <div class="column-one-half">
+        <% %i[prisoner_vos prisoner_released child_protection_issues slot_unavailable visitor_banned].each do |reason| %>
+          <div class="multiple-choice">
+            <%= check_box_tag 'cancellation_reasons[]', reason, false, id: reason %>
+            <%= label_tag reason, t(".#{reason}") %>
+          </div>
+        <% end %>
       </div>
-      <div class="multiple-choice">
-        <%= radio_button_tag 'cancellation_reason', :prisoner_released, false %>
-        <label for="cancellation_reason_prisoner_released">
-          <%= t(".prisoner_released") %>
-        </label>
+      <div class="column-one-half">
+        <% %i[prisoner_moved prisoner_non_association booked_in_error capacity_issues].each do |reason| %>
+          <div class="multiple-choice">
+            <%= check_box_tag 'cancellation_reasons[]', reason, false, id: reason %>
+            <%= label_tag reason, t(".#{reason}") %>
+          </div>
+        <% end %>
       </div>
-      <div class="multiple-choice">
-        <%= radio_button_tag 'cancellation_reason', :child_protection_issues, false %>
-        <label for="cancellation_reason_child_protection_issues">
-          <%= t(".child_protection_issues") %>
-        </label>
-      </div>
-      <div class="multiple-choice">
-        <%= radio_button_tag 'cancellation_reason', :slot_unavailable, false %>
-        <label for="cancellation_reason_slot_unavailable">
-          <%= t(".slot_unavailable") %>
-        </label>
-      </div>
-      <div class="multiple-choice">
-        <%= radio_button_tag 'cancellation_reason', :visitor_banned, false %>
-        <label for="cancellation_reason_visitor_banned">
-          <%= t(".visitor_banned") %>
-        </label>
-      </div>
-    </div>
-    <div class="column-one-half">
-      <div class="multiple-choice">
-        <%= radio_button_tag 'cancellation_reason', :prisoner_moved, false %>
-        <label for="cancellation_reason_prisoner_moved">
-          <%= t(".prisoner_moved") %>
-        </label>
-      </div>
-      <div class="multiple-choice">
-        <%= radio_button_tag 'cancellation_reason', :prisoner_non_association, false %>
-        <label for="cancellation_reason_prisoner_non_association">
-          <%= t(".prisoner_non_association") %>
-        </label>
-      </div>
-      <div class="multiple-choice">
-        <%= radio_button_tag 'cancellation_reason', :booked_in_error, false %>
-        <label for="cancellation_reason_booked_in_error">
-          <%= t(".booked_in_error") %>
-        </label>
-      </div>
-      <div class="multiple-choice">
-        <%= radio_button_tag 'cancellation_reason', :capacity_issues, false %>
-        <label for="cancellation_reason_capacity_issues">
-          <%= t(".capacity_issues") %>
-        </label>
-      </div>
-    </div>
-  </fieldset>
-</div>
-<div class='form-group push-top'>
-  <%= submit_tag t('cancel_visit', scope: :shared), class: 'button button-secondary' %>
-</div>
+    </fieldset>
+  </div>
+  <div class='form-group push-top'>
+    <%= submit_tag t('cancel_visit', scope: :shared), class: 'button button-secondary' %>
+  </div>
+<% end %>

--- a/app/views/prison/visits/_processed.html.erb
+++ b/app/views/prison/visits/_processed.html.erb
@@ -51,9 +51,13 @@
     <div class="column-two-thirds push-top">
       <div class="panel panel-border-narrow">
         <div class="text-secondary">
-          <%= @visit.processing_state.capitalize %> reason
+          <%= t('.cancelled_reason', count: @visit.cancellation_reasons.size) %>
         </div>
-        <small class="font-xsmall"><%= t(@visit.cancellation_reason, scope: :shared) %></small>
+        <ul class="list list-bullet">
+          <% @visit.cancellation_reasons.each do |reason| %>
+            <li><%= t(reason, scope: :shared) %></li>
+          <% end %>
+        </ul>
       </div>
     </div>
   <% end %>
@@ -62,33 +66,30 @@
 <hr>
 <%= render 'prison/visits/processed_prisoner_details', visit: @visit %>
 
-<%= form_tag cancel_prison_visit_path(@visit, locale: 'en'), class: 'form' do -%>
+<hr>
 
-  <hr>
-
-  <h2 class="bold-medium push-top"><%= t('.visit_date') %></h2>
-  <div class="grid-row push-top">
-    <% @visit.slots.each_with_index do |slot, i| %>
-    <div class="column-one-third">
-      <div class="date-box date-box--number">
-        <div class="date-box__label <%= 'selected' if @visit.slot_granted == slot.object %>">
-          <span class="date-box__number"><%= i+1 %></span>
-          <span class="date-box__day"><%= format_date_day(slot) %></span>
-          <br><%= format_date_of_birth(slot) %> <br><%= format_slot_times(slot) %>
-        </div>
+<h2 class="bold-medium push-top"><%= t('.visit_date') %></h2>
+<div class="grid-row push-top">
+  <% @visit.slots.each_with_index do |slot, i| %>
+  <div class="column-one-third">
+    <div class="date-box date-box--number">
+      <div class="date-box__label <%= 'selected' if @visit.slot_granted == slot.object %>">
+        <span class="date-box__number"><%= i+1 %></span>
+        <span class="date-box__day"><%= format_date_day(slot) %></span>
+        <br><%= format_date_of_birth(slot) %> <br><%= format_slot_times(slot) %>
       </div>
     </div>
-    <% end %>
   </div>
-
-  <%= render 'prison/visits/visitor_detail' %>
-
-  <% if @visit.can_cancel? %>
-    <%= render 'prison/visits/cancel_visit' %>
-    <hr>
   <% end %>
+</div>
 
-<% end %> <!-- end form tag -->
+<%= render 'prison/visits/visitor_detail' %>
+
+<% if @visit.can_cancel? %>
+  <%= render 'prison/visits/cancel_visit' %>
+  <hr>
+<% end %>
+
 
 <div class="grid-row push-top">
   <div class="column-two-thirds">

--- a/app/views/visitor_mailer/_multiple_cancellation_reasons.html.erb
+++ b/app/views/visitor_mailer/_multiple_cancellation_reasons.html.erb
@@ -10,3 +10,4 @@
 <ul class="list list-bullet">
   <%= render @cancellation.formatted_reasons %>
 </ul>
+<p><%= t('arrange_html', scope: %i(visitor_mailer cancelled)) %></p>

--- a/app/views/visitor_mailer/_single_cancellation_reason.html.erb
+++ b/app/views/visitor_mailer/_single_cancellation_reason.html.erb
@@ -7,5 +7,5 @@
   %>
 </p>
 
-<%= @cancellation.formatted_reasons.first.explanation %>
-
+<p><%= t('cant_visit', scope: %i(visitor_mailer cancelled)) %> <%= @cancellation.formatted_reasons.first.explanation %></p>
+<p><%= t('arrange_html', scope: %i(visitor_mailer cancelled)) %></p>

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -202,6 +202,9 @@ en:
         no_messages: There are currently no messages.
         body: Please type your message
         visit_history: Visit history
+        cancelled_reason:
+          one: Cancellation reason
+          other: Cancellation reasons
       timeline:
         requested: Requested
         booked: Booked
@@ -356,6 +359,12 @@ en:
     visitor_name: Visitor name
     warning: Warning
     no_adult: There must be at least one adult visitor
+    prisoner_released: Prisoner released
+    booked_in_error: Booked in error
+    prisoner_vos: Prisoner had no visiting allowance
+    prisoner_non_association: Prisoner had no association
+    capacity_issues: Capacity issues
+    child_protection_issues: Child protection issues
     no_allowance: Prisoner had no visiting allowance.
     no_allowance_true: Prisoner has no visiting allowance. Allowance renews on %{vo_date}
     no_allowance_false: Prisoner had no visiting allowance. Allowance renewed on %{vo_date}

--- a/config/locales/en/pvb2-mailers.yml
+++ b/config/locales/en/pvb2-mailers.yml
@@ -179,42 +179,27 @@ en:
         We're sorry to let you know we have cancelled your visit to %{prisoner} at %{prison} on %{date}.
       cant_visit: You can't visit because
       slot_unavailable_html: >-
-        <p>We’re sorry but the date and time you chose is no longer available.</p>
-
-        <p>To arrange another visit, go to <a href="%{service_url}">www.gov.uk/prison-visits</a> and choose new dates.</p>
+        the dates and times you chose are no longer available.
       visitor_banned_html: >-
-        <p>We have cancelled your visit because you have been banned from visiting this prison.</p>
-
-        <p>We have sent you a letter explaining why we took this decision and giving you further details.</p>
+        you have been banned from visiting this prison. We’ve sent you a letter with further details.
       booked_in_error_html: >-
-        <p>Unfortunately, we made a mistake booking this visit.</p>
-
-        <p>To arrange another visit, go to <a href="%{service_url}">www.gov.uk/prison-visits</a> and choose new dates.</p>
+        we made a mistake booking this visit.
       capacity_issues_html: >-
-        <p>We’re sorry but there are too many visitors scheduled for that time and we do not have enough space to sit everyone safely.</p>
-
-        <p>To arrange another visit, go to <a href="%{service_url}">www.gov.uk/prison-visits</a> and choose new dates.</p>
+        the visit hall is fully booked for the dates and times you chose.
       prisoner_moved_html: >-
-        <p>We cancelled your visit because they have left this prison.</p>
-
-        <p>If they haven’t been in touch recently, visit <a href="%{service_url}">www.gov.uk/find-prisoner</a>.This service will help you find them.</p>
+        they have left this prison. If you don’t know where they are, you can visit <a href="%{service_url}">www.gov.uk/find-prisoner</a>.
       restricted_reason_html: >-
-        <p>We have cancelled your visit due to restrictions around this prisoner.</p>
-
-        <p>You may be able to visit them at a later date.</p>
+        there are restrictions around this prisoner. You may be able to visit them at a later date.
       prisoner_released_html: >-
-        <p>We cancelled your visit because they were released from prison.</p>
-
-        <p>We’re not able to share any contact details so hope that they get in touch with you soon.</p>
+        they have been released from prison. We can’t share any contact details but we hope they get in touch with you soon.
       prisoner_vos_html: >-
-        <p>There is a limit to how many visits a prisoner can have each month.</p>
-
-        <p>%{prisoner} will have reached this limit by the date you’ve chosen but you can try to visit them again after their allowance is re-set.</p>
-
-        <p>To arrange another visit, go to <a href="%{service_url}">www.gov.uk/prison-visits</a>.</p>
+        there is a limit to how many visits a prisoner can have each month. %{prisoner} will have reached this limit by the date you’ve chosen,
+        but you can arrange another visit after their visit allowance is renewed.
       any_questions_html:
         If you have any questions, visit the <a href="%{url}">prison website</a> or call the prison on <strong>%{phone_no}</strong>.
       visit_id: "Visit ID:"
+      arrange_html: >-
+        You can arrange another visit on <a href="%{service_url}">www.gov.uk/prison-visits</a>.
     visit_info:
       what_to_bring_title: What to bring when you visit
       id_requirements_html: |

--- a/db/migrate/20171004152259_change_cancellation_reasons_nullable.rb
+++ b/db/migrate/20171004152259_change_cancellation_reasons_nullable.rb
@@ -1,0 +1,6 @@
+class ChangeCancellationReasonsNullable < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :cancellations, :reason, true
+    change_column_null :cancellations, :reasons, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170929084924) do
+ActiveRecord::Schema.define(version: 20171004152259) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,11 +18,11 @@ ActiveRecord::Schema.define(version: 20170929084924) do
 
   create_table "cancellations", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.uuid "visit_id", null: false
-    t.string "reason", null: false
+    t.string "reason"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean "nomis_cancelled", default: false, null: false
-    t.string "reasons", default: [], array: true
+    t.string "reasons", default: [], null: false, array: true
     t.index ["visit_id"], name: "index_cancellations_on_visit_id", unique: true
   end
 

--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -120,14 +120,6 @@ namespace :pvb do
 
     AdminMailer.slot_availability(prison_data).deliver_now!
   end
-
-  desc 'Backfill Cancellation#reasons'
-  task backfill_cancellation_reasons: :environment do
-    Cancellation.where(reasons: []).in_batches(of: 1000) do |relation|
-      relation.update_all('reasons = cancellations.reason || ARRAY[]::varchar[]')
-      sleep(1)
-    end
-  end
 end
 
 class SlotAvailabilityCounter

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -114,7 +114,7 @@ namespace :pvb do
         CancellationResponse.new(
           visit: visit,
           user: nil,
-          reason: Cancellation::REASONS.sample).cancel!
+          reasons: [Cancellation::REASONS.sample]).cancel!
       else
         VisitorCancellationResponse.new(visit: visit).cancel!
       end

--- a/spec/controllers/prison/visits_controller_spec.rb
+++ b/spec/controllers/prison/visits_controller_spec.rb
@@ -125,12 +125,12 @@ RSpec.describe Prison::VisitsController, type: :controller do
   describe '#cancel' do
     let(:visit) { FactoryGirl.create(:booked_visit) }
     let(:mailing) { double(Mail::Message, deliver_later: nil) }
-    let(:cancellation_reason) { 'slot_unavailable' }
+    let(:cancellation_reasons) { ['slot_unavailable'] }
 
     subject do
       delete :cancel, params: {
         id: visit.id,
-        cancellation_reason: cancellation_reason,
+        cancellation_reasons: cancellation_reasons,
         locale: 'en'
       }
     end
@@ -160,8 +160,8 @@ RSpec.describe Prison::VisitsController, type: :controller do
         end
       end
 
-      context 'when there is no cancellation reason' do
-        let(:cancellation_reason) { nil }
+      context 'when there is no cancellation reasons' do
+        let(:cancellation_reasons) { [] }
 
         it 'redirect to the visit show page setting the no cancellation reason flash message' do
           is_expected.to redirect_to(prison_visit_path(visit))

--- a/spec/decorators/cancellation_decorator_spec.rb
+++ b/spec/decorators/cancellation_decorator_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CancellationDecorator do
         expect(
           subject.formatted_reasons.map(&:explanation)
         ).to eq([
-          "<p>We have cancelled your visit due to restrictions around this prisoner.<\/p>\n<p\>You may be able to visit them at a later date.<\/p>"
+          "there are restrictions around this prisoner. You may be able to visit them at a later date."
         ])
       end
     end
@@ -30,7 +30,7 @@ RSpec.describe CancellationDecorator do
         expect(
           subject.formatted_reasons.map(&:explanation)
         ).to eq([
-          "<p>We have cancelled your visit due to restrictions around this prisoner.<\/p>\n<p>You may be able to visit them at a later date.</p>"
+          "there are restrictions around this prisoner. You may be able to visit them at a later date."
         ])
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe CancellationDecorator do
         expect(
           subject.formatted_reasons.map(&:explanation)
         ).to eq([
-          "<p>We have cancelled your visit because you have been banned from visiting this prison.<\/p>\n<p>We have sent you a letter explaining why we took this decision and giving you further details.</p>"
+          "you have been banned from visiting this prison. We’ve sent you a letter with further details."
         ])
       end
     end
@@ -57,7 +57,7 @@ RSpec.describe CancellationDecorator do
 
       it 'has a restricted and another restricted reasons' do
         expect(subject.formatted_reasons.map(&:explanation)).
-          to contain_exactly("<p>We have cancelled your visit due to restrictions around this prisoner.<\/p>\n<p>You may be able to visit them at a later date.<\/p>")
+          to contain_exactly("there are restrictions around this prisoner. You may be able to visit them at a later date.")
       end
     end
   end

--- a/spec/factories/cancellations.rb
+++ b/spec/factories/cancellations.rb
@@ -1,7 +1,6 @@
 FactoryGirl.define do
   factory :cancellation do
     association :visit, processing_state: 'cancelled'
-    reason 'prisoner_moved'
     reasons ['prisoner_moved']
   end
 end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -125,10 +125,6 @@ RSpec.feature 'Using the dashboard' do
     end
 
     it 'sends a message and cancels the visit' do
-      allow(StaffNomisChecker).
-        to receive(:new).and_return(
-          double(StaffNomisChecker, prisoner_existance_status: StaffNomisChecker::VALID, location_verified?: true))
-
       fill_in 'Search', with: vst.prisoner_number
       find('.button.search').click
       click_link 'View'
@@ -140,7 +136,7 @@ RSpec.feature 'Using the dashboard' do
 
       expect(page).to have_css('.message', text: 'Sandals not allowed')
 
-      choose 'Prisoner has moved prisons'
+      check 'Prisoner has moved prisons'
       click_button 'Cancel visit', match: :first
 
       visit prison_visit_path(vst, locale: 'en')

--- a/spec/features/process_a_request_cancel_spec.rb
+++ b/spec/features/process_a_request_cancel_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+require 'shared_process_setup_context'
+
+RSpec.feature 'Processing a request', js: true do
+  include ActiveJobHelper
+
+  include_context 'process request setup'
+
+  describe 'cancelling' do
+    before do
+      vst.assign_attributes(slot_granted: vst.slot_option_0)
+      BookingResponder.new(vst).respond!
+
+      visit prison_visit_path(vst, locale: 'en')
+    end
+
+    scenario 'cancelling a booked visit with more than one reason' do
+      check 'Visit slot no longer available'
+      check 'Visitor is banned'
+      click_button 'Cancel visit'
+      expect(page).to have_css('.tag--heading', text: /Cancelled/)
+      expect(page).to have_css('.panel', text: /None of the dates and times chosen were available/)
+      expect(page).to have_css('.panel', text: /A visitor has been banned/)
+    end
+  end
+end

--- a/spec/mailers/visitor_mailer/cancelled_spec.rb
+++ b/spec/mailers/visitor_mailer/cancelled_spec.rb
@@ -60,19 +60,19 @@ RSpec.describe VisitorMailer, '.cancelled' do
   context 'when there are capacity issues' do
     let(:reason) { 'capacity_issues' }
 
-    it { expect(mail.html_part.body).to match(/too many visitors/) }
+    it { expect(mail.html_part.body).to match(/fully booked/) }
   end
 
   context 'when there are child protection issues' do
     let(:reason) { 'child_protection_issues' }
 
-    it { expect(mail.html_part.body).to match(/due to restrictions/) }
+    it { expect(mail.html_part.body).to match(/there are restrictions/) }
   end
 
   context 'when non association issues' do
     let(:reason) { 'prisoner_non_association' }
 
-    it { expect(mail.html_part.body).to match(/due to restrictions/) }
+    it { expect(mail.html_part.body).to match(/there are restrictions/) }
   end
 
   context 'when booked in error' do
@@ -84,7 +84,7 @@ RSpec.describe VisitorMailer, '.cancelled' do
   context 'when cancelled by more than one reason' do
     let(:reasons) { %w[child_protection_issues visitor_banned] }
 
-    it { expect(mail.html_part.body).to match(/due to restrictions/) }
+    it { expect(mail.html_part.body).to match(/there are restrictions/) }
     it { expect(mail.html_part.body).to match(/banned from visiting/) }
   end
 end

--- a/spec/models/cancellation_spec.rb
+++ b/spec/models/cancellation_spec.rb
@@ -17,13 +17,6 @@ RSpec.describe Cancellation, model: true do
       }.to raise_exception(ActiveRecord::InvalidForeignKey)
     end
 
-    it 'checks the reason code is allowed' do
-      cancellation = FactoryGirl.build_stubbed(:cancellation)
-      cancellation.reason = 'random'
-      expect(cancellation).to be_invalid
-      expect(cancellation.errors[:reason]).to be_present
-    end
-
     describe '#reasons' do
       context 'with rejection reasons' do
         before do

--- a/spec/services/booking_responder/cancel_spec.rb
+++ b/spec/services/booking_responder/cancel_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe BookingResponder::Cancel do
   subject(:instance) { described_class.new(cancellation_response) }
 
   let(:cancellation_response) do
-    CancellationResponse.new(visit: visit, user: user, reason: reason)
+    CancellationResponse.new(visit: visit, user: user, reasons: [reason])
   end
   let(:visit) { FactoryGirl.create(:booked_visit) }
   let(:reason) { 'booked_in_error' }
@@ -16,7 +16,6 @@ RSpec.describe BookingResponder::Cancel do
 
     visit.reload
     expect(visit).to be_cancelled
-    expect(visit.cancellation.reason).to eq(reason)
     expect(visit.cancellation.reasons).to eq([reason])
     expect(visit.cancellation.nomis_cancelled).to eq(true)
   end

--- a/spec/services/cancellation_response_spec.rb
+++ b/spec/services/cancellation_response_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CancellationResponse do
   subject(:instance) do
-    described_class.new(visit: visit, user: user, reason: reason)
+    described_class.new(visit: visit, user: user, reasons: [reason])
   end
 
   let(:user) { nil }

--- a/spec/services/visit_timeline_spec.rb
+++ b/spec/services/visit_timeline_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe VisitTimeline do
         CancellationResponse.new(
           visit: visit,
           user: nil,
-          reason: 'booked_in_error').tap(&:cancel!)
+          reasons: ['booked_in_error']).tap(&:cancel!)
 
         VisitStateChange.
           find_by!(visit_state: 'cancelled').

--- a/spec/support/helpers/staff_response_helper.rb
+++ b/spec/support/helpers/staff_response_helper.rb
@@ -7,12 +7,12 @@ module StaffResponseHelper
     visit
   end
 
-  def cancel_visit(visit, reason = Cancellation::VISITOR_CANCELLED)
+  def cancel_visit(visit, reasons = [Cancellation::VISITOR_CANCELLED])
     accept_visit(visit, visit.slots.first)
     CancellationResponse.new(
       visit: visit,
       user:   create(:user),
-      reason: reason
+      reasons: reasons
     ).cancel!
     visit
   end


### PR DESCRIPTION
Changes radio input to checkboxes to let staff select multiple
cancellation reasons.

It also adds a few missing translation for cancellation reasons.

After this PR is deployed the 'reason' column can be dropped.