### PR TITLE
Remove did_you_mean gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem 'rails', '~> 5.1'
 
 gem 'activerecord-safer_migrations'
 gem 'base32-crockford', require: 'base32/crockford'
-gem 'did_you_mean', require: 'did_you_mean/jaro_winkler'
 gem 'draper'
 gem 'connection_pool'
 gem 'excon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,6 @@ GEM
     database_cleaner (1.6.1)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    did_you_mean (1.1.0)
     diff-lcs (1.3)
     docile (1.1.5)
     draper (3.0.0)
@@ -385,7 +384,6 @@ DEPENDENCIES
   capybara
   connection_pool
   database_cleaner
-  did_you_mean
   draper
   excon
   factory_girl_rails

--- a/app/models/contact_list_matcher.rb
+++ b/app/models/contact_list_matcher.rb
@@ -1,5 +1,3 @@
-require 'did_you_mean'
-
 class ContactListMatcher
   NEAREST_MATCH_THRESHOLD = 0.90
   EXACT_MATCH_THRESHOLD   = 1


### PR DESCRIPTION
Remove this gem to prevent any unintended conflicts with future updates.
Will continue to use the version that ships with ruby.