### PR TITLE
Stop writing to 'reason' on the cancel API

### DIFF
--- a/app/models/cancellation.rb
+++ b/app/models/cancellation.rb
@@ -25,7 +25,7 @@ class Cancellation < ActiveRecord::Base
 
   # TODO: Remove after column has been dropped.
   def self.columns
-    super.reject { |r| r == 'reason' }
+    super.reject { |r| r.name == 'reason' }
   end
 
 private

--- a/app/services/booking_responder/visitor_cancel.rb
+++ b/app/services/booking_responder/visitor_cancel.rb
@@ -5,7 +5,6 @@ class BookingResponder
         visit.cancel!
         Cancellation.create!(visit: visit,
                              reasons: [Cancellation::VISITOR_CANCELLED],
-                             reason: Cancellation::VISITOR_CANCELLED,
                              nomis_cancelled: false)
 
         BookingResponse.successful

--- a/spec/services/booking_responder/visitor_cancel_spec.rb
+++ b/spec/services/booking_responder/visitor_cancel_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe BookingResponder::VisitorCancel do
 
     visit.reload
     expect(visit).to be_cancelled
-    expect(visit.cancellation.reason).to eq(reason)
+    expect(visit.cancellation.reasons).to eq([reason])
     expect(visit.cancellation.nomis_cancelled).to eq(false)
   end
 end


### PR DESCRIPTION
This was missed previously because the column wasn't ignored properly.

There shouldn't be anything else that uses the reason column now.