### PR TITLE
DO NOT MERGE - Add print visit details to slot list

### DIFF
--- a/app/assets/stylesheets/_moj-overrides.scss
+++ b/app/assets/stylesheets/_moj-overrides.scss
@@ -61,6 +61,9 @@
       }
     }
   }
+  @include media(print){
+    display: none !important;
+  }
 }
 
 #wrapper {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -74,6 +74,7 @@
 @import "modules/visitor-list";
 
 // Candidates for re-usable components
+@import "print";
 @import "responsive";
 @import "components/moj.autocomplete";
 @import "components/govuk.chosen";

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,5 +1,5 @@
-@media print {
-  .indicator {
-    display: none;
+.print-only {
+  @media not print {
+    @include visually-hidden;
   }
 }

--- a/app/services/nomis/api.rb
+++ b/app/services/nomis/api.rb
@@ -131,7 +131,7 @@ module Nomis
         )
       end
     end
-  # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/MethodLength
 
     def cancel_visit(offender_id, booking_id, params:)
       response = @pool.with { |client|

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
 <% end %>
 
 <% content_for :proposition_header do %>
-  <div class="header-proposition">
+  <div class="header-proposition hidden--print">
     <div class="content">
       <nav id="proposition-menu" class="header__menu" role="navigation">
         <a href="/" id="proposition-name" class="header__menu__proposition-name"><%= t('app_title') %></a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,7 +53,7 @@
   <![endif]-->
 
   <main id="content">
-    <a target="_blank" href="https://www.surveymonkey.co.uk/r/36LDWKD" class="feedback-link"><%= t('.feedback') %></a>
+    <a target="_blank" href="https://www.surveymonkey.co.uk/r/36LDWKD" class="feedback-link hidden--print"><%= t('.feedback') %></a>
     <%= yield :banner %>
     <%= yield :navigation %>
     <% if content_for?(:header) %>

--- a/app/views/prison/dashboards/_print_details.html.erb
+++ b/app/views/prison/dashboards/_print_details.html.erb
@@ -2,31 +2,31 @@
 <div class="grid-row">
   <div class="column-one-half">
     <h3 class="heading-large">
-      <span class="heading-secondary">Prisoner</span>
+      <span class="heading-secondary"><%= t('prisoner', scope: :shared) %></span>
       <%= visit.prisoner_full_name %>
     </h3>
     <h3 class="heading-large">
-      <span class="heading-secondary">Prisoner number</span>
+      <span class="heading-secondary"><%= t('prisoner_number', scope: :shared) %></span>
       <%= visit.prisoner_number %>
     </h3>
   </div>
   <div class="column-one-half">
     <h3 class="heading-large">
-      <span class="heading-secondary">Cell location</span>
+      <span class="heading-secondary"><%= t('cell_location', scope: :shared) %></span>
       -
     </h3>
   </div>
 </div>
 <h3 class="heading-large">
-  <span class="heading-secondary">Visit date</span>
+  <span class="heading-secondary"><%= t('visit_date', scope: :shared) %></span>
   <%= format_visit_slot_date_for_staff(visit) %>
 </h3>
 <h3 class="heading-large">
-  <span class="heading-secondary">Visit time</span>
+  <span class="heading-secondary"><%= t('visit_time', scope: :shared) %></span>
   <%= format_visit_slot_times_for_staff(visit) %>
 </h3>
 <h3 class="heading-large">
-  <span class="heading-secondary">Visitor(s)</span>
+  <span class="heading-secondary"><%= t('visitors', scope: :shared) %></span>
   <% visit.allowed_visitors.each do |visitor| %>
     <%= visitor.full_name %><br>
   <% end %>

--- a/app/views/prison/dashboards/_print_details.html.erb
+++ b/app/views/prison/dashboards/_print_details.html.erb
@@ -1,0 +1,34 @@
+
+<div class="grid-row">
+  <div class="column-one-half">
+    <h3 class="heading-large">
+      <span class="heading-secondary">Prisoner</span>
+      <%= visit.prisoner_full_name %>
+    </h3>
+    <h3 class="heading-large">
+      <span class="heading-secondary">Prisoner number</span>
+      <%= visit.prisoner_number %>
+    </h3>
+  </div>
+  <div class="column-one-half">
+    <h3 class="heading-large">
+      <span class="heading-secondary">Cell location</span>
+      -
+    </h3>
+  </div>
+</div>
+<h3 class="heading-large">
+  <span class="heading-secondary">Visit date</span>
+  <%= format_visit_slot_date_for_staff(visit) %>
+</h3>
+<h3 class="heading-large">
+  <span class="heading-secondary">Visit time</span>
+  <%= format_visit_slot_times_for_staff(visit) %>
+</h3>
+<h3 class="heading-large">
+  <span class="heading-secondary">Visitor(s)</span>
+  <% visit.allowed_visitors.each do |visitor| %>
+    <%= visitor.full_name %><br>
+  <% end %>
+</h3>
+<p class="push-top">Visit ID: <%= visit.human_id %></p>

--- a/app/views/prison/dashboards/_print_visits.html.erb
+++ b/app/views/prison/dashboards/_print_visits.html.erb
@@ -1,4 +1,4 @@
-<h3 class="heading-medium hidden--print">Visit list</h3>
+<h3 class="heading-medium hidden--print"><%= t('.visit_list') %></h3>
 <% grouped_visits['booked'].each_with_index do |(slot, visits), index| %>
   <% unless index.zero? %>
     <div class="page-break"></div>

--- a/app/views/prison/dashboards/_print_visits.html.erb
+++ b/app/views/prison/dashboards/_print_visits.html.erb
@@ -6,32 +6,7 @@
   <%= render 'print_slot', slot: slot, visits: visits %>
   <% visits.each do |visit| %>
     <div class="page-break"></div>
-
-    <div class="grid-row">
-      <div class="column-one-half">
-        <h3 class="heading-large">
-          <span class="heading-secondary">Prisoner</span>
-          <%= visit.prisoner_full_name %>
-        </h3>
-      </div>
-      <div class="column-one-half">
-        <h3 class="heading-large">
-          <span class="heading-secondary">Cell location</span>
-          -
-        </h3>
-      </div>
-    </div>
-    <h3 class="heading-large">
-      <span class="heading-secondary">Visit date</span>
-      <%= format_date_without_year(@visit_date) %> - <%= format_slot_times(slot) %>
-    </h3>
-    <h3 class="heading-large">
-      <span class="heading-secondary">Visitor(s)</span>
-      <% visit.allowed_visitors.each do |visitor| %>
-        <%= visitor.full_name %><br>
-      <% end %>
-    </h3>
-    <p class="push-top">Visit ID: <%= visit.human_id %></p>
+    <%= render 'print_details', visit: visit %>
     <hr>
   <% end %>
 <% end -%>

--- a/app/views/prison/dashboards/_print_visits.html.erb
+++ b/app/views/prison/dashboards/_print_visits.html.erb
@@ -1,0 +1,37 @@
+<h3 class="heading-medium hidden--print">Visit list</h3>
+<% grouped_visits['booked'].each_with_index do |(slot, visits), index| %>
+  <% unless index.zero? %>
+    <div class="page-break"></div>
+  <% end %>
+  <%= render 'print_slot', slot: slot, visits: visits %>
+  <% visits.each do |visit| %>
+    <div class="page-break"></div>
+
+    <div class="grid-row">
+      <div class="column-one-half">
+        <h3 class="heading-large">
+          <span class="heading-secondary">Prisoner</span>
+          <%= visit.prisoner_full_name %>
+        </h3>
+      </div>
+      <div class="column-one-half">
+        <h3 class="heading-large">
+          <span class="heading-secondary">Cell location</span>
+          -
+        </h3>
+      </div>
+    </div>
+    <h3 class="heading-large">
+      <span class="heading-secondary">Visit date</span>
+      <%= format_date_without_year(@visit_date) %> - <%= format_slot_times(slot) %>
+    </h3>
+    <h3 class="heading-large">
+      <span class="heading-secondary">Visitor(s)</span>
+      <% visit.allowed_visitors.each do |visitor| %>
+        <%= visitor.full_name %><br>
+      <% end %>
+    </h3>
+    <p class="push-top">Visit ID: <%= visit.human_id %></p>
+    <hr>
+  <% end %>
+<% end -%>

--- a/app/views/prison/dashboards/_prison_switcher.html.erb
+++ b/app/views/prison/dashboards/_prison_switcher.html.erb
@@ -2,7 +2,7 @@
   <div class="column-full">
     <% content_for :prison_switcher do %>
       <% if sso_identity.accessible_estates.size > 1 -%>
-        <%= form_tag prison_switch_estates_path, enforce_utf8: false, class: 'form prison-switcher-form' do -%>
+        <%= form_tag prison_switch_estates_path, enforce_utf8: false, class: 'form prison-switcher-form hidden--print' do -%>
           <%= label_tag "estate_ids", class: "form-label" do -%>
             <%= t('.prison_switcher') %>
           <% end %>

--- a/app/views/prison/dashboards/print_visits.html.erb
+++ b/app/views/prison/dashboards/print_visits.html.erb
@@ -23,32 +23,34 @@
 
 <% if @visit_date %>
   <% if @data.any? %>
-    <%= link_to t('.download_csv_html'), prison_print_visits_path(visit_date: params[:visit_date] ,format: :csv) %>
-    <a class="push-left--half hidden--print print-link" href="#"><%= t('.print') %></a>
-
-    <% @data.each do |prison_name, grouped_visits| %>
-      <h2 class="heading-large"><%= prison_name %></h2>
-      <% if grouped_visits['booked'].nil? -%>
-        <p class="lede push-top"><%= t('.no_bookings') %></p>
-      <% else %>
-        <% grouped_visits['booked'].each_with_index do |(slot, visits), index| %>
-          <% unless index.zero? %>
-            <div class="page-break"></div>
-          <% end %>
-          <%= render 'print_slot', slot: slot, visits: visits %>
-        <% end -%>
-      <% end -%>
-
-      <% if grouped_visits['cancelled'].nil? -%>
-        <p class="lede push-top"><%= t('.no_cancellations') %></p>
-      <% else %>
+    <div class="js-print-visits">
+      <span class="hidden--print">
+        <%= link_to t('.download_csv_html'), prison_print_visits_path(visit_date: params[:visit_date] ,format: :csv) %>
+      </span>
+      <a class="push-left--half hidden--print print-link js-print-list" href="#"><%= t('.print') %></a>
+      <% @data.each do |prison_name, grouped_visits| %>
         <div class="page-break"></div>
-        <h3 class="heading-medium"><%= t('.cancelled_visits') %></h3>
-        <% grouped_visits['cancelled'].each_with_index do |(slot, visits), index| %>
-          <%= render 'print_cancelled_slot', slot: slot, visits: visits %>
+        <h2 class="heading-xlarge"><%= prison_name %></h2>
+        <% if grouped_visits['booked'].nil? -%>
+          <p class="lede push-top"><%= t('.no_bookings') %></p>
+        <% else %>
+          <%= render 'print_visits', grouped_visits: grouped_visits %>
+        <% end -%>
+
+        <% if grouped_visits['cancelled'].nil? -%>
+          <div class="hidden--print">
+            <div class="page-break"></div>
+            <h3 class="heading-medium"><%= t('.no_cancellations') %></h3>
+          </div>
+        <% else %>
+          <div class="page-break"></div>
+          <h3 class="heading-medium"><%= t('.cancelled_visits') %></h3>
+          <% grouped_visits['cancelled'].each_with_index do |(slot, visits), index| %>
+            <%= render 'print_cancelled_slot', slot: slot, visits: visits %>
+          <% end -%>
         <% end -%>
       <% end -%>
-    <% end -%>
+    </div>
   <% else %>
     <p class="lede"><%= t('.no_visits', date: @visit_date.to_s(:short_nomis)) %></p>
   <% end %>

--- a/app/views/prison/dashboards/print_visits.html.erb
+++ b/app/views/prison/dashboards/print_visits.html.erb
@@ -28,8 +28,10 @@
         <%= link_to t('.download_csv_html'), prison_print_visits_path(visit_date: params[:visit_date] ,format: :csv) %>
       </span>
       <a class="push-left--half hidden--print print-link js-print-list" href="#"><%= t('.print') %></a>
-      <% @data.each do |prison_name, grouped_visits| %>
-        <div class="page-break"></div>
+      <% @data.each_with_index do |(prison_name, grouped_visits), index| %>
+        <% unless index.zero? %>
+          <div class="page-break"></div>
+        <% end %>
         <h2 class="heading-xlarge"><%= prison_name %></h2>
         <% if grouped_visits['booked'].nil? -%>
           <p class="lede push-top"><%= t('.no_bookings') %></p>

--- a/app/views/prison/visits/_processed.html.erb
+++ b/app/views/prison/visits/_processed.html.erb
@@ -16,9 +16,6 @@
           <% if @visit.reference_no -%>
             <div class="text-secondary"><%= t('.ref') %>: <%= @visit.reference_no %></div>
           <% end %>
-          <% if @visit.booked? %>
-            <a class="print-link" href="#">Print visit</a>
-          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/prison/visits/_processed.html.erb
+++ b/app/views/prison/visits/_processed.html.erb
@@ -1,137 +1,144 @@
-<div class="grid-row push-top">
-  <div class="column-one-third">
-    <h1 class="bold-large"><%= t('.title') %></h1>
-  </div>
-  <div class="column-two-thirds">
-    <div class="grid-row">
-      <div class="column-one-third">
-        <div class="tag tag--requested tag--heading"><%= t('requested', scope: 'shared') %>: <br><%= @visit.created_at.to_date.to_s(:short_nomis) %> - <%= @visit.created_at.to_s(:time) %></div>
-      </div>
-      <div class="column-one-third">
-        <div class="tag tag--<%= @visit.processing_state %> tag--heading"><%= @visit.processing_state.capitalize %>: <br><%= @visit.processed_at.to_date.to_s(:short_nomis) %> - <%= @visit.processed_at.to_s(:time) %></div>
-      </div>
-      <div class="column-one-third">
-        <div class="text-secondary">ID: <%= @visit.human_id %></div>
-        <% if @visit.reference_no -%>
-          <div class="text-secondary"><%= t('.ref') %>: <%= @visit.reference_no %></div>
-        <% end %>
+<div class="hidden--print">
+  <div class="grid-row push-top">
+    <div class="column-one-third">
+      <h1 class="bold-large"><%= t('.title') %></h1>
+    </div>
+    <div class="column-two-thirds">
+      <div class="grid-row">
+        <div class="column-one-third">
+          <div class="tag tag--requested tag--heading"><%= t('requested', scope: 'shared') %>: <br><%= @visit.created_at.to_date.to_s(:short_nomis) %> - <%= @visit.created_at.to_s(:time) %></div>
+        </div>
+        <div class="column-one-third">
+          <div class="tag tag--<%= @visit.processing_state %> tag--heading"><%= @visit.processing_state.capitalize %>: <br><%= @visit.processed_at.to_date.to_s(:short_nomis) %> - <%= @visit.processed_at.to_s(:time) %></div>
+        </div>
+        <div class="column-one-third">
+          <div class="text-secondary">ID: <%= @visit.human_id %></div>
+          <% if @visit.reference_no -%>
+            <div class="text-secondary"><%= t('.ref') %>: <%= @visit.reference_no %></div>
+          <% end %>
+          <% if @visit.booked? %>
+            <a class="print-link" href="#">Print visit</a>
+          <% end %>
+        </div>
       </div>
     </div>
   </div>
-</div>
 
-<% if @visit.closed? && @visit.booked? %>
-  <p class="panel panel-border-narrow font-xsmall">
-    <%= t('.closed_visit') %>
-  </p>
-<% end %>
+  <% if @visit.closed? && @visit.booked? %>
+    <p class="panel panel-border-narrow font-xsmall">
+      <%= t('.closed_visit') %>
+    </p>
+  <% end %>
 
-<div class="grid-row">
-  <% if @visit.rejected? %>
-    <div class="column-two-thirds push-top">
-      <div class="push-top text-secondary push-bottom--half">
-        <i class="icon icon-information align-vertical--middle"></i> Rejected reason(s)
-      </div>
-      <ul class="list list-bullet">
-        <% @visit.rejection.reasons.each do |reason| %>
-            <% if reason == 'no_allowance' %>
-              <% if @visit.allowance_renews_on %>
-                <li><%= t("#{reason}_#{@visit.allowance_renews_on.future?}", vo_date: @visit.allowance_renews_on.to_s(:short_nomis), scope: :shared) %></li>
+  <div class="grid-row">
+    <% if @visit.rejected? %>
+      <div class="column-two-thirds push-top">
+        <div class="push-top text-secondary push-bottom--half">
+          <i class="icon icon-information align-vertical--middle"></i> Rejected reason(s)
+        </div>
+        <ul class="list list-bullet">
+          <% @visit.rejection.reasons.each do |reason| %>
+              <% if reason == 'no_allowance' %>
+                <% if @visit.allowance_renews_on %>
+                  <li><%= t("#{reason}_#{@visit.allowance_renews_on.future?}", vo_date: @visit.allowance_renews_on.to_s(:short_nomis), scope: :shared) %></li>
+                <% else %>
+                  <li><%= t(reason, scope: :shared) %></li>
+                <% end %>
               <% else %>
                 <li><%= t(reason, scope: :shared) %></li>
               <% end %>
-            <% else %>
-              <li><%= t(reason, scope: :shared) %></li>
-            <% end %>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-  <% if @visit.cancelled? %>
-    <div class="column-two-thirds push-top">
-      <div class="panel panel-border-narrow">
-        <div class="text-secondary">
-          <%= t('.cancelled_reason', count: @visit.cancellation_reasons.size) %>
-        </div>
-        <ul class="list list-bullet">
-          <% @visit.cancellation_reasons.each do |reason| %>
-            <li><%= t(reason, scope: :shared) %></li>
           <% end %>
         </ul>
       </div>
-    </div>
-  <% end %>
-</div>
+    <% end %>
+    <% if @visit.cancelled? %>
+      <div class="column-two-thirds push-top">
+        <div class="panel panel-border-narrow">
+          <div class="text-secondary">
+            <%= t('.cancelled_reason', count: @visit.cancellation_reasons.size) %>
+          </div>
+          <ul class="list list-bullet">
+            <% @visit.cancellation_reasons.each do |reason| %>
+              <li><%= t(reason, scope: :shared) %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    <% end %>
+  </div>
 
-<hr>
-<%= render 'prison/visits/processed_prisoner_details', visit: @visit %>
+  <hr>
+  <%= render 'prison/visits/processed_prisoner_details', visit: @visit %>
 
-<hr>
+  <hr>
 
-<h2 class="bold-medium push-top"><%= t('.visit_date') %></h2>
-<div class="grid-row push-top">
-  <% @visit.slots.each_with_index do |slot, i| %>
-  <div class="column-one-third">
-    <div class="date-box date-box--number">
-      <div class="date-box__label <%= 'selected' if @visit.slot_granted == slot.object %>">
-        <span class="date-box__number"><%= i+1 %></span>
-        <span class="date-box__day"><%= format_date_day(slot) %></span>
-        <br><%= format_date_of_birth(slot) %> <br><%= format_slot_times(slot) %>
+  <h2 class="bold-medium push-top"><%= t('.visit_date') %></h2>
+  <div class="grid-row push-top">
+    <% @visit.slots.each_with_index do |slot, i| %>
+    <div class="column-one-third">
+      <div class="date-box date-box--number">
+        <div class="date-box__label <%= 'selected' if @visit.slot_granted == slot.object %>">
+          <span class="date-box__number"><%= i+1 %></span>
+          <span class="date-box__day"><%= format_date_day(slot) %></span>
+          <br><%= format_date_of_birth(slot) %> <br><%= format_slot_times(slot) %>
+        </div>
       </div>
     </div>
-  </div>
-  <% end %>
-</div>
-
-<%= render 'prison/visits/visitor_detail' %>
-
-<% if @visit.can_cancel? %>
-  <%= render 'prison/visits/cancel_visit' %>
-  <hr>
-<% end %>
-
-
-<div class="grid-row push-top">
-  <div class="column-two-thirds">
-    <% if current_user %>
-      <% if @visit.booked? %>
-        <details class="push-top">
-          <summary><span class="summary"><%= t('.send_a_message') %></span></summary>
-          <div class="panel panel-border-narrow">
-            <h3 class="bold-medium"><%= t('.send_a_message') %></h3>
-            <%= form_for [:prison, @visit, @message], html: { class: 'js-SubmitOnce  form' } do |f| -%>
-              <%= single_field(f, :body, :text_area, class: 'form-control form-control-full-width', rows: 4) %>
-              <div class="">
-                <%= f.submit t('.send_email'), class: 'button' %>
-              </div>
-            <% end -%>
-          </div>
-        </details>
-      <% else -%>
-        <div class="panel panel-border-narrow"><%= t('.message_not_allowed') %></div>
-      <% end -%>
     <% end %>
-    <% if @visit.messages.any? -%>
-      <% @visit.messages.each do |message| %>
-        <div class='messages push-top'>
-          <div class="message">
-            <div class="message-top">
-              <span class="bold-small"><%= message.user.email %></span>
-              <span class="dash">—</span>
-              <span class="datetime"><%= time_ago_in_words(message.created_at) %></span>
-            </div>
-            <p class="message-content"><%= message.body %></p>
-          </div>
-        </div>
-      <% end %>
-    <% else %>
-      <p><%= t('.no_messages') %></p>
-    <% end -%>
   </div>
 
-  <div class="column-one-third">
-    <h3 class="bold-medium push-bottom"><%= t('.visit_history') %></h3>
-    <%= render 'prison/visits/timeline' %>
+  <%= render 'prison/visits/visitor_detail' %>
+
+  <% if @visit.can_cancel? %>
+    <%= render 'prison/visits/cancel_visit' %>
+    <hr>
+  <% end %>
+
+
+  <div class="grid-row push-top">
+    <div class="column-two-thirds">
+      <% if current_user %>
+        <% if @visit.booked? %>
+          <details class="push-top">
+            <summary><span class="summary"><%= t('.send_a_message') %></span></summary>
+            <div class="panel panel-border-narrow">
+              <h3 class="bold-medium"><%= t('.send_a_message') %></h3>
+              <%= form_for [:prison, @visit, @message], html: { class: 'js-SubmitOnce  form' } do |f| -%>
+                <%= single_field(f, :body, :text_area, class: 'form-control form-control-full-width', rows: 4) %>
+                <div class="">
+                  <%= f.submit t('.send_email'), class: 'button' %>
+                </div>
+              <% end -%>
+            </div>
+          </details>
+        <% else -%>
+          <div class="panel panel-border-narrow"><%= t('.message_not_allowed') %></div>
+        <% end -%>
+      <% end %>
+      <% if @visit.messages.any? -%>
+        <% @visit.messages.each do |message| %>
+          <div class='messages push-top'>
+            <div class="message">
+              <div class="message-top">
+                <span class="bold-small"><%= message.user.email %></span>
+                <span class="dash">—</span>
+                <span class="datetime"><%= time_ago_in_words(message.created_at) %></span>
+              </div>
+              <p class="message-content"><%= message.body %></p>
+            </div>
+          </div>
+        <% end %>
+      <% else %>
+        <p><%= t('.no_messages') %></p>
+      <% end -%>
+    </div>
+
+    <div class="column-one-third">
+      <h3 class="bold-medium push-bottom"><%= t('.visit_history') %></h3>
+      <%= render 'prison/visits/timeline' %>
+    </div>
   </div>
 </div>
-
+<div class="print-only">
+  <%= render 'prison/dashboards/print_details', visit: @visit %>
+</div>

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -111,6 +111,7 @@ en:
         no_bookings: No bookings
         no_cancellations: No cancellations
         cancelled_visits: Cancelled visits
+        visit_list: Visit list
       search:
         cancellations: Cancellations
         processed: Processed
@@ -330,6 +331,7 @@ en:
     cancel: Cancel
     cancel_visit: Cancel visit
     cancelled: Cancelled
+    cell_location: Cell location
     closed: Closed
     dob: Date of birth
     email_address: Email address
@@ -357,6 +359,7 @@ en:
     time_slot: Time slot
     view: View
     visit_date: Visit date
+    visit_time: Visit time
     visitors: Visitors
     visitor_no: Visitor %{n}
     visitor_name: Visitor name


### PR DESCRIPTION
Staff print visit details for prisoners, currently using the 'processed visit' screen. This enables them to print all visits for a day in one go.