### PR TITLE
Remove details polyfill

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,7 +8,6 @@
 // GOVUK modules
 //= require govuk_toolkit
 //= require vendor/polyfills/bind
-//= require details.polyfill
 //= require moj
 //= require lodash
 //= require jquery-ui-autocomplete


### PR DESCRIPTION
This pollyfill was needed for Firefox version 47 and earlier. Staff users are now all on 52 so is no longer needed.