### PR TITLE
Remove database-cleaner:

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,5 @@ group :test do
   gem 'vcr'
   gem 'webmock'
   gem 'shoulda-matchers'
-  gem 'database_cleaner'
   gem 'rails-controller-testing'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,6 @@ GEM
     crass (1.0.2)
     css_parser (1.5.0)
       addressable
-    database_cleaner (1.6.1)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     did_you_mean (1.1.2)
@@ -384,7 +383,6 @@ DEPENDENCIES
   byebug
   capybara
   connection_pool
-  database_cleaner
   did_you_mean
   draper
   excon

--- a/lib/tasks/factory_girl.rake
+++ b/lib/tasks/factory_girl.rake
@@ -2,12 +2,7 @@ namespace :factory_girl do
   desc 'Verify that all FactoryGirl factories are valid'
   task lint: :environment do
     if Rails.env.test?
-      begin
-        DatabaseCleaner.start
-        FactoryGirl.lint
-      ensure
-        DatabaseCleaner.clean
-      end
+      FactoryGirl.lint
     else
       sh 'rake db:environment:set[test] db:test:prepare factory_girl:lint'
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,7 @@ ActiveRecord::Migration.maintain_test_schema!
 OmniAuth.config.test_mode = true
 
 RSpec.configure do |config|
-  config.use_transactional_fixtures = false
+  config.use_transactional_fixtures = true
   config.include FactoryGirl::Syntax::Methods
   config.include ActiveSupport::Testing::TimeHelpers
   config.include StaffResponseHelper
@@ -33,27 +33,11 @@ RSpec.configure do |config|
 
   config.infer_spec_type_from_file_location!
 
-  config.before(:suite) do
-    DatabaseCleaner.clean_with(:truncation, except: %w(public.ar_internal_metadata))
-  end
-
   config.before(:each) do
     I18n.locale = I18n.default_locale
     RequestStore.clear!
-    DatabaseCleaner.strategy = :transaction
   end
 
-  config.before(:each, js: true) do
-    DatabaseCleaner.strategy = :truncation
-  end
-
-  config.before(:each) do
-    DatabaseCleaner.start
-  end
-
-  config.after(:each) do
-    DatabaseCleaner.clean
-  end
 end
 
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
**CHANGES:**
As of rspec-rails 3.7 which ingrates with rails system test case,
database-cleaner is no longer needed.
Rails in system test mode shares the the server AR thread connection with the
test runner.
So byebye database-cleaner