### PR TITLE
Avoid a memory leak in Excon

### DIFF
--- a/config/puma_prod.rb
+++ b/config/puma_prod.rb
@@ -1,7 +1,7 @@
 require 'yaml'
 db_pool = YAML.load_file('config/database.yml')['production']['pool']
 workers Integer(ENV['WEB_CONCURRENCY'] || 3)
-threads 0, db_pool
+threads db_pool, db_pool
 
 preload_app!
 


### PR DESCRIPTION
Current version of Excon has a memory leak when threads using an Excon
connection get destroyed.

Applies same fix as
https://github.com/ministryofjustice/prison-visits-public/pull/346

The memory leak in pvb2 is slower because Puma is configured to use less threads
so they probably get recycled less often.

Also sets a constant number of threads for Puma in production as we do in
pvb-public.