### PR TITLE
Add 'other' rejection reason checkbox

### DIFF
--- a/app/controllers/concerns/staff_response_context.rb
+++ b/app/controllers/concerns/staff_response_context.rb
@@ -64,6 +64,7 @@ private
         'allowance_renews_on(1i)',
         'allowance_renews_on(2i)',
         'allowance_renews_on(3i)',
+        :rejection_reason_detail,
         reasons: []
       ],
       visitors_attributes:  [

--- a/app/helpers/form_elements_helper.rb
+++ b/app/helpers/form_elements_helper.rb
@@ -57,7 +57,7 @@ module FormElementsHelper
 
   def error_container(form, name, options = { class: 'form-group' }, &blk)
     if form.object&.errors&.include?(name)
-      klass = [options[:class], 'form-group-error'].compact.join(' ')
+      klass = [options[:class], 'form-group-error error'].compact.join(' ')
     else
       klass = options[:class]
     end

--- a/app/models/rejection/reason.rb
+++ b/app/models/rejection/reason.rb
@@ -2,5 +2,13 @@ class Rejection < ActiveRecord::Base
   class Reason
     include ActiveModel::Model
     attr_accessor :explanation
+
+    def eql?(other)
+      other.explanation.eql?(explanation)
+    end
+
+    def hash
+      explanation.hash
+    end
   end
 end

--- a/app/models/staff_response.rb
+++ b/app/models/staff_response.rb
@@ -66,7 +66,7 @@ private
       attrs = visit.rejection.serializable_hash(
         except: %i[
 created_at updated_at allowance_renews_on
-privileged_allowance_expires_on])
+privileged_allowance_expires_on rejection_reason_detail])
 
       attrs['allowance_renews_on'] =
         rejection.allowance_renews_on.to_s
@@ -148,7 +148,7 @@ privileged_allowance_expires_on])
 
   def visitors_selection
     return unless validate_visitors_nomis_ready?
-    return if rejection.valid?
+    return if rejection_reasons?
 
     invalid_visitors = visit.visitors.select { |visitor|
       visitor.nomis_id.present? == visitor.not_on_list?
@@ -167,5 +167,9 @@ privileged_allowance_expires_on])
 
   def sanitise_reasons
     rejection.reasons.uniq!
+  end
+
+  def rejection_reasons?
+    rejection.reasons.any?
   end
 end

--- a/app/views/prison/visits/_processed.html.erb
+++ b/app/views/prison/visits/_processed.html.erb
@@ -34,16 +34,8 @@
           <i class="icon icon-information align-vertical--middle"></i> Rejected reason(s)
         </div>
         <ul class="list list-bullet">
-          <% @visit.rejection.reasons.each do |reason| %>
-              <% if reason == 'no_allowance' %>
-                <% if @visit.allowance_renews_on %>
-                  <li><%= t("#{reason}_#{@visit.allowance_renews_on.future?}", vo_date: @visit.allowance_renews_on.to_s(:short_nomis), scope: :shared) %></li>
-                <% else %>
-                  <li><%= t(reason, scope: :shared) %></li>
-                <% end %>
-              <% else %>
-                <li><%= t(reason, scope: :shared) %></li>
-              <% end %>
+          <% @visit.rejection.staff_formatted_reasons.each do |reason| %>
+            <li><%= reason %></li>
           <% end %>
         </ul>
       </div>
@@ -72,15 +64,15 @@
   <h2 class="bold-medium push-top"><%= t('.visit_date') %></h2>
   <div class="grid-row push-top">
     <% @visit.slots.each_with_index do |slot, i| %>
-    <div class="column-one-third">
-      <div class="date-box date-box--number">
-        <div class="date-box__label <%= 'selected' if @visit.slot_granted == slot.object %>">
-          <span class="date-box__number"><%= i+1 %></span>
-          <span class="date-box__day"><%= format_date_day(slot) %></span>
-          <br><%= format_date_of_birth(slot) %> <br><%= format_slot_times(slot) %>
+      <div class="column-one-third">
+        <div class="date-box date-box--number">
+          <div class="date-box__label <%= 'selected' if @visit.slot_granted == slot.object %>">
+            <span class="date-box__number"><%= i+1 %></span>
+            <span class="date-box__day"><%= format_date_day(slot) %></span>
+            <br><%= format_date_of_birth(slot) %> <br><%= format_slot_times(slot) %>
+        </div>
         </div>
       </div>
-    </div>
     <% end %>
   </div>
 
@@ -102,9 +94,7 @@
               <h3 class="bold-medium"><%= t('.send_a_message') %></h3>
               <%= form_for [:prison, @visit, @message], html: { class: 'js-SubmitOnce  form' } do |f| -%>
                 <%= single_field(f, :body, :text_area, class: 'form-control form-control-full-width', rows: 4) %>
-                <div class="">
-                  <%= f.submit t('.send_email'), class: 'button' %>
-                </div>
+                <%= f.submit t('.send_email'), class: 'button' %>
               <% end -%>
             </div>
           </details>

--- a/app/views/prison/visits/_rejection_manual.html.erb
+++ b/app/views/prison/visits/_rejection_manual.html.erb
@@ -4,54 +4,35 @@
   <div class="column-one-half">
     <%= error_container(rf, :reasons) do %>
       <div class="multiple-choice">
-        <%= rf.object.checkbox_for(:prisoner_moved,
-          id: :prisoner_moved,
-          class: 'js-Rejection',
-          'data-rejection-el': 'rejection-message',
-          'data-success-el': 'nomis-opt-out') %>
-        <%= rf.label t('.prisoner_moved'), for: :prisoner_moved %>
+        <%= render 'rejection_reason', rf: rf, id: :prisoner_moved %>
       </div>
     <% end %>
     <%= error_container(rf, :reasons) do %>
       <div class="multiple-choice">
-        <%= rf.object.checkbox_for(:child_protection_issues,
-          id: :child_protection_issues,
-          class: 'js-Rejection',
-          'data-rejection-el': 'rejection-message',
-          'data-success-el': 'nomis-opt-out') %>
-        <%= rf.label t('.child_protection_issues'), for: :child_protection_issues %>
+        <%= render 'rejection_reason', rf: rf, id: :child_protection_issues %>
       </div>
     <% end %>
-    <%= error_container(rf, :reasons) do %>
-      <div class="multiple-choice">
-        <%= rf.object.checkbox_for :duplicate_visit_request,
-          id: :duplicate_visit_request,
-          class: 'js-Rejection',
-          'data-rejection-el': 'rejection-message',
-          'data-success-el': 'nomis-opt-out' %>
-        <%= rf.label t('.duplicate_visit_request'), for: :duplicate_visit_request %>
-      </div>
-    <% end %>
+    <div class="multiple-choice" data-target="rejection_reason">
+      <%= render 'rejection_reason', rf: rf, id: :other %>
+    </div>
+    <div class="panel panel-border-narrow js-hidden" id="rejection_reason">
+      <%= single_field rf, :rejection_reason_detail, :text_area, rows: 4, class: 'form-control form-control-full-width' %>
+    </div>
   </div>
   <div class="column-one-half">
     <%= error_container(rf, :reasons) do %>
       <div class="multiple-choice">
-        <%= rf.object.checkbox_for(:prisoner_released,
-          id: :prisoner_released,
-          class: 'js-Rejection',
-          'data-rejection-el': 'rejection-message',
-          'data-success-el': 'nomis-opt-out') %>
-        <%= rf.label t('.prisoner_released'), for: :prisoner_released %>
+        <%= render 'rejection_reason', rf: rf, id: :prisoner_released %>
       </div>
     <% end %>
     <%= error_container(rf, :reasons) do %>
       <div class="multiple-choice">
-        <%= rf.object.checkbox_for(:prisoner_non_association,
-          id: :prisoner_non_association,
-          class: 'js-Rejection',
-          'data-rejection-el': 'rejection-message',
-          'data-success-el': 'nomis-opt-out') %>
-        <%= rf.label t('.prisoner_non_association'), for: :prisoner_non_association %>
+        <%= render 'rejection_reason', rf: rf, id: :prisoner_non_association %>
+      </div>
+    <% end %>
+    <%= error_container(rf, :reasons) do %>
+      <div class="multiple-choice">
+        <%= render 'rejection_reason', rf: rf, id: :duplicate_visit_request %>
       </div>
     <% end %>
   </div>

--- a/app/views/visitor_mailer/_multiple_rejection.html.erb
+++ b/app/views/visitor_mailer/_multiple_rejection.html.erb
@@ -1,5 +1,5 @@
 <%= t('intro_html', prison_name: @visit.prison_name, scope: [:visitor_mailer, :rejected]) %>
 <p><%= t('cant_visit', scope: [:visitor_mailer, :rejected]) %>:</p>
 <ul class="list list-bullet">
-  <%= render @rejection.formatted_reasons %>
+  <%= render @rejection.email_formatted_reasons %>
 </ul>

--- a/app/views/visitor_mailer/_single_rejection.html.erb
+++ b/app/views/visitor_mailer/_single_rejection.html.erb
@@ -1,8 +1,10 @@
-<% if @rejection.reasons.first == 'duplicate_visit_request' %>
+<% if @rejection.email_formatted_reasons.first == 'duplicate_visit_request' %>
   <%= t('duplicate_visit_request_single_html', prisoner: @visit.prisoner_full_name, prison_name: @visit.prison_name, scope: [:visitor_mailer, :rejected]) %>
+<% elsif @rejection.email_formatted_reasons.empty? %>
+  <%= t('intro_html', prison_name: @visit.prison_name, scope: [:visitor_mailer, :rejected]) %>
 <% else %>
   <%= t('intro_html', prison_name: @visit.prison_name, scope: [:visitor_mailer, :rejected]) %>
   <p><%= t('cant_visit', scope: [:visitor_mailer, :rejected]) %>
-    <%= @rejection.formatted_reasons.first.explanation %>.
+    <%= @rejection.email_formatted_reasons.first.explanation %>.
   </p>
 <% end %>

--- a/app/views/visitor_mailer/rejected.html.erb
+++ b/app/views/visitor_mailer/rejected.html.erb
@@ -1,14 +1,14 @@
 <p><%= t('.salutation', name: @visit.visitor_first_name) %></p>
 
-<% if @rejection.reasons.size == 1 %>
-  <%= render 'visitor_mailer/single_rejection' %>
-<% else %>
+<% if @rejection.email_formatted_reasons.size > 1 %>
   <%= render 'visitor_mailer/multiple_rejection' %>
+<% else %>
+  <%= render 'visitor_mailer/single_rejection' %>
 <% end %>
 
 <% if @visit.unlisted_visitors.any? && !@rejection.reasons.include?('visitor_not_on_list') %>
   <p>
-    <%= @rejection.visitor_not_on_list_explanation %>
+    <%= @rejection.email_visitor_not_on_list_explanation %>
   </p>
   <p><%= t('.update_list') %></p>
   <p><%= t('.first_visit') %></p>
@@ -17,7 +17,7 @@
 <% if @visit.banned_visitors.any? && !@rejection.reasons.include?('visitor_banned') %>
   <% @visit.banned_visitors.each do |v| %>
     <p>
-      <%= @rejection.visitor_banned_explanation(v) %>
+      <%= @rejection.email_visitor_banned_explanation(v) %>
     </p>
   <% end %>
 <% end %>

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -254,6 +254,7 @@ en:
         overriding_restrictions: You are overriding these restrictions
         update_nomis: Please update any incorrect restrictions in NOMIS
         visiting_allowance: Visiting allowance
+        allowance_renews_on: Allowance renews on
         prisoner_banned: Prisoner banned from receiving visits
         prisoner_out_of_prison: Prisoner on external movement
         no_allowance: Prisoner does not have any visiting allowance
@@ -263,11 +264,15 @@ en:
         prisoner_out_of_prison: Prisoner on external movement
         no_allowance: Prisoner does not have any visiting allowance
         prisoner_details_incorrect: Prisoner details are incorrect
+        prisoner_moved: Prisoner has moved prisons
+        prisoner_non_association: Prisoner has a non-association
+        child_protection_issues: Prisoner has child protection measures
+        duplicate_visit_request: Duplicate visit request
+        prisoner_released: Prisoner has been released
+        other: Other reason
       rejection_manual:
         other_rejection_title: Other rejection reasons
         other_rejection_intro: Please check these details in NOMIS and tick any that apply.
-        prisoner_moved: Prisoner has moved prisons
-        prisoner_released: Prisoner has been released
         no_allowance_tell_more: >-
           You can also tell the visitor more about the VO status:
         allowance_will_renew: >-
@@ -275,9 +280,8 @@ en:
           be renewed:
         allowance_renews_on: Date visiting allowance will be renewed
         allowance_renews_on_hint: eg 28 04 1996
-        prisoner_non_association: Prisoner has a non-association
-        child_protection_issues: Prisoner has child protection measures
-        duplicate_visit_request: Duplicate visit request
+        rejection_reason_detail: Enter rejection reason
+        rejection_reason_detail_hint: This will not be shown to the visitor
       visitor_details:
         title: Visitor details
         help_text: Match each visitor to a name on the prisoner’s contact list.
@@ -384,3 +388,4 @@ en:
     reference_number: Reference number
     clear_selection: Clear selection
     to: to
+    other_reason: "Other: %{detail}"

--- a/db/migrate/20171113140333_add_rejection_reason_detail_to_rejections.rb
+++ b/db/migrate/20171113140333_add_rejection_reason_detail_to_rejections.rb
@@ -1,0 +1,5 @@
+class AddRejectionReasonDetailToRejections < ActiveRecord::Migration[5.1]
+  def change
+    add_column :rejections, :rejection_reason_detail, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171010153655) do
+ActiveRecord::Schema.define(version: 20171113140333) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -102,6 +102,7 @@ ActiveRecord::Schema.define(version: 20171010153655) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "reasons", default: [], array: true
+    t.string "rejection_reason_detail"
     t.index ["visit_id"], name: "index_rejections_on_visit_id", unique: true
   end
 

--- a/spec/features/process_a_request_reject_spec.rb
+++ b/spec/features/process_a_request_reject_spec.rb
@@ -185,5 +185,25 @@ RSpec.feature 'Processing a request', js: true do
       expect(vst).to be_rejected
       expect(vst.visitors.first).to be_not_on_list
     end
+
+    scenario 'rejecting a booking for any reason',
+      vcr: { cassette_name: 'process_booking_happy_path', allow_playback_repeats: true } do
+      check 'Other', visible: false
+      click_button 'Process'
+
+      fill_in 'Enter rejection reason', with: 'Other reason'
+      click_button 'Process'
+
+      expect(page).to have_text('Thank you for processing the visit')
+
+      vst.reload
+      expect(vst.rejection_reasons).to include('other')
+      expect(vst).to be_rejected
+
+      expect(contact_email_address).
+        to receive_email.
+        with_subject(/Your visit to #{prison.name} is NOT booked/).
+        and_body(/not been able to book your visit to #{prison.name}. Please do NOT go to the prison/)
+    end
   end
 end

--- a/spec/models/metrics/rejection_percentage_spec.rb
+++ b/spec/models/metrics/rejection_percentage_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Metrics::RejectionPercentage do
                                     visitor_banned:             0,
                                     visitor_not_on_list:        0,
                                     duplicate_visit_request:    0,
+                                    other:                      0,
                                     date:                       nil
                                    )
     end

--- a/spec/models/rejection/reason_spec.rb
+++ b/spec/models/rejection/reason_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Rejection::Reason, model: true do
+  subject { described_class.new(explanation: explanation) }
+
+  let(:explanation) { 'prisoner has a restriction' }
+
+  context 'when there is another reason with the same explanation' do
+    let(:second_reason) { described_class.new(explanation: explanation) }
+
+    it { is_expected.to eql(second_reason) }
+
+    it { expect(subject.hash).to eq(second_reason.hash) }
+  end
+
+  context 'when there is another reason with a different explanation' do
+    let(:second_reason) { described_class.new(explanation: 'prisoner_banned') }
+
+    it { is_expected.not_to eql(second_reason) }
+
+    it { expect(subject.hash).not_to eq(second_reason.hash) }
+  end
+end

--- a/spec/presenters/graph_metrics_presenter_spec.rb
+++ b/spec/presenters/graph_metrics_presenter_spec.rb
@@ -279,7 +279,8 @@ RSpec.describe GraphMetricsPresenter do
                                    prisoner_released:          10.61,
                                    slot_unavailable:           12.12,
                                    visitor_banned:             13.64,
-                                   visitor_not_on_list:        15.15)
+                                   visitor_not_on_list:        15.15,
+                                   other:                      0)
       end
     end
   end


### PR DESCRIPTION
This commit will implement the addition of an 'other' rejection reason
for staff to use when processing visit requests.  Metrics have shown a
high number of rejection reasons as 'slot unavailable', but we now
understand that staff are using this rejection reason in lieu of an
option that actually matches their case.  The 'other' checkbox also has
a text field for staff to write down their reason for this rejection.
The aim is to monitor the 'other' rejection reasons and ensure that we
add checkboxes, where necessary, to cover a wider range of rejection
reasons that staff use on a regular basis.