### PR TITLE
Refactor VisitDecorator and StaffNomisChecker

### DIFF
--- a/app/controllers/prison/cancellations_controller.rb
+++ b/app/controllers/prison/cancellations_controller.rb
@@ -12,7 +12,7 @@ class Prison::CancellationsController < ApplicationController
       redirect_to prison_visit_path(memoised_visit)
     else
       flash.now[:alert] = cancellation_response.error_message
-      @visit = decorate_visit(memoised_visit)
+      @visit = memoised_visit.decorate
       @message = Message.new
       render :new
     end

--- a/app/controllers/prison/messages_controller.rb
+++ b/app/controllers/prison/messages_controller.rb
@@ -11,7 +11,7 @@ class Prison::MessagesController < ApplicationController
       flash[:notice] = t('message_created', scope: %i[prison flash])
       redirect_to prison_visit_path(memoised_visit)
     else
-      @visit = decorate_visit(memoised_visit)
+      @visit = memoised_visit.decorate
       flash[:notice] = t('message_create_error', scope: %i[prison flash])
       render 'prison/visits/show'
     end

--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -19,7 +19,7 @@ class Prison::VisitsController < ApplicationController
     else
       # Always decorate object last once they've been mutated
       @message = message
-      @visit = decorate_visit(memoised_visit)
+      @visit = memoised_visit.decorate
       render :show
     end
   end
@@ -37,7 +37,7 @@ class Prison::VisitsController < ApplicationController
                messages: :user,
                visit_state_changes: :processed_by).
              find(memoised_visit.id)
-    @visit = decorate_visit(visit)
+    @visit = visit.decorate
     @message = Message.new
   end
 

--- a/app/decorators/concrete_slot_decorator.rb
+++ b/app/decorators/concrete_slot_decorator.rb
@@ -158,7 +158,7 @@ private
   end
 
   def nomis_checker
-    context[:nomis_checker]
+    h.nomis_checker
   end
 
   def visit

--- a/app/decorators/rejection_decorator.rb
+++ b/app/decorators/rejection_decorator.rb
@@ -70,16 +70,16 @@ class RejectionDecorator < Draper::Decorator
     )
   end
 
-  def apply_nomis_reasons(nomis_checker)
-    if unbookable?(nomis_checker)
-      reasons << Rejection::NO_ALLOWANCE if no_allowance?(nomis_checker)
-      reasons << Rejection::PRISONER_BANNED if prisoner_banned?(nomis_checker)
-      if prisoner_out_of_prison?(nomis_checker)
+  def apply_nomis_reasons
+    if unbookable?
+      reasons << Rejection::NO_ALLOWANCE if no_allowance?
+      reasons << Rejection::PRISONER_BANNED if prisoner_banned?
+      if prisoner_out_of_prison?
         reasons << Rejection::PRISONER_OUT_OF_PRISON
       end
     end
 
-    if nomis_checker.prisoner_details_incorrect?
+    if prisoner_details.prisoner_details_incorrect?
       reasons << Rejection::PRISONER_DETAILS_INCORRECT
     end
   end
@@ -98,20 +98,28 @@ private
     end
   end
 
-  def unbookable?(nomis_checker)
+  def nomis_checker
+    h.nomis_checker
+  end
+
+  def prisoner_details
+    h.prisoner_details
+  end
+
+  def unbookable?
     future_slots.any? &&
       future_slots.all? { |slot| nomis_checker.errors_for(slot).any? }
   end
 
-  def no_allowance?(nomis_checker)
+  def no_allowance?
     visit.slots.any? { |slot| nomis_checker.no_allowance?(slot) }
   end
 
-  def prisoner_banned?(nomis_checker)
+  def prisoner_banned?
     visit.slots.any? { |slot| nomis_checker.prisoner_banned?(slot) }
   end
 
-  def prisoner_out_of_prison?(nomis_checker)
+  def prisoner_out_of_prison?
     visit.slots.any? { |slot| nomis_checker.prisoner_out_of_prison?(slot) }
   end
 

--- a/app/decorators/rejection_decorator.rb
+++ b/app/decorators/rejection_decorator.rb
@@ -79,7 +79,7 @@ class RejectionDecorator < Draper::Decorator
       end
     end
 
-    if prisoner_details.prisoner_details_incorrect?
+    if prisoner_details.details_incorrect?
       reasons << Rejection::PRISONER_DETAILS_INCORRECT
     end
   end

--- a/app/decorators/visit_decorator.rb
+++ b/app/decorators/visit_decorator.rb
@@ -11,7 +11,7 @@ class VisitDecorator < Draper::Decorator
 
   delegate :prisoner_existance_status,
     :prisoner_existance_error,
-    :prisoner_details_incorrect?,
+    :details_incorrect?,
     to: :prisoner_details
 
   def slots

--- a/app/models/prisoner_validation.rb
+++ b/app/models/prisoner_validation.rb
@@ -1,8 +1,6 @@
 class PrisonerValidation
-  UNKNOWN                   = 'unknown'.freeze
-  PRISONER_NOT_EXIST        = 'prisoner_does_not_exist'.freeze
-  PRISONER_LOCATION_INVALID = 'location_invalid'.freeze
-  PRISONER_LOCATION_UNKNOWN = 'location_unknown'.freeze
+  UNKNOWN            = 'unknown'.freeze
+  PRISONER_NOT_EXIST = 'prisoner_does_not_exist'.freeze
 
   include ActiveModel::Validations
   validate :active_offender_exists
@@ -12,15 +10,10 @@ class PrisonerValidation
     self.api_error = false
   end
 
-  def prisoner_located_at?(prison_code)
-    prisoner_location.code == prison_code
-  end
-
 private
 
   attr_accessor :offender, :api_error
 
-  # rubocop:disable Metrics/MethodLength
   def active_offender_exists
     unless Nomis::Api.enabled? && offender.api_call_successful?
       errors.add :base, UNKNOWN
@@ -29,25 +22,6 @@ private
 
     unless offender.valid?
       errors.add :base, PRISONER_NOT_EXIST
-      return
     end
-
-    unless prisoner_location.api_call_successful?
-      errors.add :base, PRISONER_LOCATION_UNKNOWN
-    end
-  end
-  # rubocop:enable Metrics/MethodLength
-
-  def prisoner_location
-    @prisoner_location ||= load_prisoner_location
-  end
-
-  def load_prisoner_location
-    Nomis::Api.instance.lookup_offender_location(noms_id: offender.noms_id)
-  rescue Nomis::APIError => e
-    Raven.capture_exception(
-      e, fingerprint: %w[nomis lookup_offender_location_error])
-    PVB::Instrumentation.append_to_log(lookup_offender_location: false)
-    Nomis::Establishment.new(api_call_successful: false)
   end
 end

--- a/app/presenters/prisoner_details_presenter.rb
+++ b/app/presenters/prisoner_details_presenter.rb
@@ -20,7 +20,7 @@ class PrisonerDetailsPresenter
     end
   end
 
-  def prisoner_details_incorrect?
+  def details_incorrect?
     prisoner_existance_status == INVALID
   end
 

--- a/app/presenters/prisoner_details_presenter.rb
+++ b/app/presenters/prisoner_details_presenter.rb
@@ -1,0 +1,42 @@
+class PrisonerDetailsPresenter
+  VALID    = 'valid'.freeze
+  INVALID  = 'invalid'.freeze
+  NOT_LIVE = 'not_live'.freeze
+
+  def initialize(prisoner_validation, prisoner_location)
+    self.prisoner_validation = prisoner_validation
+    self.prisoner_location   = prisoner_location
+  end
+
+  def prisoner_existance_status
+    return NOT_LIVE unless Nomis::Api.enabled?
+    case prisoner_existance_error
+    when nil
+      VALID
+    when PrisonerValidation::UNKNOWN, PrisonerLocation::INVALID, PrisonerLocation::UNKNOWN
+      prisoner_existance_error
+    else
+      INVALID
+    end
+  end
+
+  def prisoner_details_incorrect?
+    prisoner_existance_status == INVALID
+  end
+
+  def prisoner_existance_error
+    prisoner_validation_errors.first || prisoner_location_errors.first
+  end
+
+  def prisoner_validation_errors
+    @prisoner_validation_errors ||= prisoner_validation.tap(&:valid?).errors.full_messages
+  end
+
+  def prisoner_location_errors
+    @prisoner_location_errors ||= prisoner_location.tap(&:valid?).errors.full_messages
+  end
+
+private
+
+  attr_accessor :prisoner_validation, :prisoner_location
+end

--- a/app/services/api_prisoner_checker.rb
+++ b/app/services/api_prisoner_checker.rb
@@ -16,12 +16,16 @@ class ApiPrisonerChecker
   end
 
   def error
-    prisoner_validation.errors[:base].first
+    prisoner_validation.errors[:base].first || prisoner_location.errors[:base].first
   end
 
 private
 
   def prisoner_validation
     @prisoner_validation ||= PrisonerValidation.new(@offender).tap(&:valid?)
+  end
+
+  def prisoner_location
+    @prisoner_location ||= PrisonerLocation.new(@offender).tap(&:valid?)
   end
 end

--- a/app/services/book_to_nomis_config.rb
+++ b/app/services/book_to_nomis_config.rb
@@ -1,9 +1,13 @@
 class BookToNomisConfig
-  def initialize(staff_nomis_checker, prison_name, opted_in, already_booked_in_nomis)
-    self.staff_nomis_checker = staff_nomis_checker
-    self.prison_name = prison_name
-    self.opted_in = opted_in
-    self.already_booked_in_nomis = already_booked_in_nomis
+  def initialize(staff_nomis_checker,
+    prison_name, opted_in,
+    already_booked_in_nomis,
+    prisoner_details_presenter)
+    self.staff_nomis_checker        = staff_nomis_checker
+    self.prison_name                = prison_name
+    self.opted_in                   = opted_in
+    self.already_booked_in_nomis    = already_booked_in_nomis
+    self.prisoner_details_presenter = prisoner_details_presenter
   end
 
   def possible_to_book?
@@ -25,7 +29,11 @@ class BookToNomisConfig
 
 private
 
-  attr_accessor :staff_nomis_checker, :prison_name, :already_booked_in_nomis
+  attr_accessor :staff_nomis_checker,
+    :prison_name,
+    :already_booked_in_nomis,
+    :prisoner_details_presenter
+
   attr_reader :opted_in
 
   def opted_in=(val)
@@ -33,7 +41,8 @@ private
   end
 
   def prisoner_existance_valid?
-    staff_nomis_checker.prisoner_existance_status == StaffNomisChecker::VALID
+    prisoner_details_presenter.
+      prisoner_existance_status == PrisonerDetailsPresenter::VALID
   end
 
   def prisoner_availability_working?

--- a/app/services/prisoner_location.rb
+++ b/app/services/prisoner_location.rb
@@ -1,0 +1,46 @@
+class PrisonerLocation
+  INVALID = 'location_invalid'.freeze
+  UNKNOWN = 'location_unknown'.freeze
+
+  include ActiveModel::Model
+
+  validate :located_at_given_prison
+  validate :validate_has_location
+
+  def initialize(offender, prison_code = nil)
+    self.offender    = offender
+    self.prison_code = prison_code
+  end
+
+private
+
+  attr_accessor :offender, :prison_code
+
+  def validate_has_location
+    unless prisoner_location.api_call_successful?
+      errors.clear
+      errors.add(:base, UNKNOWN)
+    end
+  end
+
+  def prisoner_location
+    @prisoner_location ||= load_prisoner_location
+  end
+
+  def located_at_given_prison
+    return if prison_code.nil?
+
+    unless prisoner_location.code == prison_code
+      errors.add(:base, INVALID)
+    end
+  end
+
+  def load_prisoner_location
+    Nomis::Api.instance.lookup_offender_location(noms_id: offender.noms_id)
+  rescue Nomis::APIError => e
+    Raven.capture_exception(
+      e, fingerprint: %w[nomis lookup_offender_location_error])
+    PVB::Instrumentation.append_to_log(lookup_offender_location: false)
+    Nomis::Establishment.new(api_call_successful: false)
+  end
+end

--- a/app/services/staff_nomis_checker.rb
+++ b/app/services/staff_nomis_checker.rb
@@ -1,37 +1,7 @@
 # Gets prisoner and slot availability details from NOMIS.
 class StaffNomisChecker
-  VALID    = 'valid'.freeze
-  INVALID  = 'invalid'.freeze
-  UNKNOWN  = 'unknown'.freeze
-  NOT_LIVE = 'not_live'.freeze
-
-  LOCATION_VALID    = 'location_valid'.freeze
-  LOCATION_INVALID  = 'location_invalid'.freeze
-  LOCATION_UNKNOWN  = 'location_unknown'.freeze
-
   def initialize(visit)
     @visit = visit
-  end
-
-  def prisoner_existance_status
-    return NOT_LIVE unless Nomis::Api.enabled?
-    case prisoner_existance_error
-    when nil
-      VALID
-    when UNKNOWN, LOCATION_INVALID, LOCATION_UNKNOWN
-      prisoner_existance_error
-    else
-      INVALID
-    end
-  end
-
-  def prisoner_details_incorrect?
-    prisoner_existance_status == INVALID
-  end
-
-  def prisoner_existance_error
-    return prisoner_validation_errors.first if prisoner_validation_errors.first
-    return LOCATION_INVALID if prisoner_moved?
   end
 
   def prisoner_availability_unknown?
@@ -125,24 +95,12 @@ private
     end
   end
 
-  def prisoner_validation_errors
-    @prisoner_validation_errors ||= prisoner_validation.errors.full_messages
-  end
-
   def prisoner_contact_list
     @prisoner_contact_list ||= PrisonerContactList.new(offender)
   end
 
   def prisoner_restriction_list
     @prisoner_restriction_list ||= PrisonerRestrictionList.new(offender)
-  end
-
-  def prisoner_validation
-    @prisoner_validation ||= PrisonerValidation.new(offender).tap(&:valid?)
-  end
-
-  def prisoner_moved?
-    @prisoner_moved ||= !prisoner_validation.prisoner_located_at?(@visit.prison.nomis_id)
   end
 
   def prisoner_availability_validation

--- a/app/views/prison/visits/_prisoner_details.html.erb
+++ b/app/views/prison/visits/_prisoner_details.html.erb
@@ -1,20 +1,20 @@
 <h2 class="bold-medium"><%= t('.title') %></h2>
 <% case @visit.prisoner_existance_status %>
-<% when StaffNomisChecker::VALID %>
+<% when PrisonerDetailsPresenter::VALID %>
   <div class="notice push-top">
     <i class="icon icon-information">
       <span class="visuallyhidden"><%= t('warning', scope: :shared) %></span>
     </i>
     <strong class="bold-small"><%= t('.verified_html') %></strong>
   </div>
-<% when StaffNomisChecker::INVALID, StaffNomisChecker::LOCATION_INVALID %>
+<% when PrisonerDetailsPresenter::INVALID, PrisonerLocation::INVALID %>
   <div class="notice push-top">
     <i class="icon icon-information">
       <span class="visuallyhidden"><%= t('warning', scope: :shared) %></span>
     </i>
     <strong class="bold-small"><%= t(".#{@visit.prisoner_existance_error}_text") %></strong>
   </div>
-<% when StaffNomisChecker::UNKNOWN, StaffNomisChecker::LOCATION_UNKNOWN %>
+<% when PrisonerValidation::UNKNOWN, PrisonerLocation::UNKNOWN %>
   <div class="notice push-top">
     <i class="icon icon-important">
       <span class="visuallyhidden"><%= t('warning', scope: :shared) %></span>
@@ -34,9 +34,9 @@
     <span class="text-secondary"><%= t('.prisoner_dob') %></span>
     <div class="bold-small"><%= @visit.prisoner_date_of_birth.to_s(:short_nomis) %></div>
     <% case @visit.prisoner_existance_status %>
-    <% when StaffNomisChecker::VALID, StaffNomisChecker::LOCATION_INVALID %>
+    <% when PrisonerDetailsPresenter::VALID, PrisonerLocation::INVALID %>
       <div class="tag tag--booked font-xsmall"><%= t('.verified') %></div>
-    <% when StaffNomisChecker::INVALID, StaffNomisChecker::LOCATION_INVALID %>
+    <% when PrisonerDetailsPresenter::INVALID, PrisonerLocation::INVALID %>
       <div class="tag tag--error font-xsmall"><%= t(".#{@visit.prisoner_existance_status}") %></div>
     <% end %>
   </div>
@@ -45,9 +45,9 @@
     <span class="text-secondary"><%= t('.prisoner_number') %></span>
     <div class="bold-small"><%= @visit.prisoner_number %></div>
     <% case @visit.prisoner_existance_status %>
-    <% when StaffNomisChecker::VALID, StaffNomisChecker::LOCATION_INVALID  %>
+    <% when PrisonerDetailsPresenter::VALID, PrisonerLocation::INVALID  %>
       <div class="font-xsmall tag tag--booked"><%= t('.verified') %></div>
-    <% when StaffNomisChecker::INVALID %>
+    <% when PrisonerDetailsPresenter::INVALID %>
       <div class="font-xsmall tag tag--error"><%= t(".#{@visit.prisoner_existance_status}") %></div>
     <% end %>
   </div>
@@ -56,9 +56,9 @@
     <span class="text-secondary"><%= t('.prison_name') %></span>
     <div class="bold-small"><%= @visit.prison_name %></div>
     <% case @visit.prisoner_existance_status %>
-    <% when StaffNomisChecker::VALID %>
+    <% when PrisonerDetailsPresenter::VALID %>
       <div class="font-xsmall tag tag--booked"><%= t('.verified') %></div>
-    <% when StaffNomisChecker::LOCATION_INVALID %>
+    <% when PrisonerLocation::INVALID %>
       <div class="font-xsmall tag tag--error"><%= t(".#{@visit.prisoner_existance_status}") %></div>
     <% end %>
   </div>

--- a/spec/decorators/concrete_slot_decorator_spec.rb
+++ b/spec/decorators/concrete_slot_decorator_spec.rb
@@ -16,18 +16,12 @@ RSpec.describe ConcreteSlotDecorator do
   end
 
   subject do
-    described_class.decorate(
-      slot,
-      context: {
-        visit: visit,
-        nomis_checker: nomis_checker,
-        index: 0
-      }
-    )
+    described_class.decorate(slot, context: { index: 0, visit: visit })
   end
 
   before do
     subject.h.output_buffer = ""
+    allow(subject).to receive(:nomis_checker).and_return(nomis_checker)
   end
 
   describe '#slot_picker' do

--- a/spec/decorators/rejection_decorator_spec.rb
+++ b/spec/decorators/rejection_decorator_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe RejectionDecorator do
         end
 
       allow(prisoner_details_presenter).
-        to receive(:prisoner_details_incorrect?).
+        to receive(:details_incorrect?).
         and_return(details_incorrect)
 
       allow(nomis_checker).

--- a/spec/decorators/rejection_decorator_spec.rb
+++ b/spec/decorators/rejection_decorator_spec.rb
@@ -245,7 +245,13 @@ RSpec.describe RejectionDecorator do
       double(StaffNomisChecker)
     end
 
+    let(:prisoner_details_presenter) do
+      instance_double(PrisonerDetailsPresenter)
+    end
+
     before do
+      allow(subject).to receive(:nomis_checker).and_return(nomis_checker)
+      allow(subject).to receive(:prisoner_details).and_return(prisoner_details_presenter)
       allow(nomis_checker).
         to receive(:errors_for).
         with(anything) do
@@ -256,7 +262,7 @@ RSpec.describe RejectionDecorator do
           end
         end
 
-      allow(nomis_checker).
+      allow(prisoner_details_presenter).
         to receive(:prisoner_details_incorrect?).
         and_return(details_incorrect)
 
@@ -297,14 +303,14 @@ RSpec.describe RejectionDecorator do
     end
 
     context 'with no unvisitable reasons and bookable slots' do
-      let(:visit_bookable) { true }
-      let(:details_incorrect) { false }
-      let(:no_allowance) { false }
-      let(:prisoner_banned) { false }
+      let(:visit_bookable)         { true }
+      let(:details_incorrect)      { false }
+      let(:no_allowance)           { false }
+      let(:prisoner_banned)        { false }
       let(:prisoner_out_of_prison) { false }
 
       before do
-        subject.apply_nomis_reasons(nomis_checker)
+        subject.apply_nomis_reasons
       end
 
       it_behaves_like :unchecked, :prisoner_details_incorrect
@@ -321,7 +327,7 @@ RSpec.describe RejectionDecorator do
       let(:prisoner_out_of_prison) { false }
 
       before do
-        subject.apply_nomis_reasons(nomis_checker)
+        subject.apply_nomis_reasons
       end
 
       it_behaves_like :unchecked, :prisoner_details_incorrect
@@ -335,7 +341,7 @@ RSpec.describe RejectionDecorator do
       let(:details_incorrect) { true }
 
       before do
-        subject.apply_nomis_reasons(nomis_checker)
+        subject.apply_nomis_reasons
       end
 
       it_behaves_like :checked, :prisoner_details_incorrect
@@ -346,7 +352,7 @@ RSpec.describe RejectionDecorator do
       let(:details_incorrect) { true }
 
       before do
-        subject.apply_nomis_reasons(nomis_checker)
+        subject.apply_nomis_reasons
       end
 
       it_behaves_like :checked, :prisoner_details_incorrect
@@ -354,7 +360,7 @@ RSpec.describe RejectionDecorator do
 
     context 'with no allowance and bookable slots' do
       before do
-        subject.apply_nomis_reasons(nomis_checker)
+        subject.apply_nomis_reasons
       end
 
       let(:visit_bookable) { true }
@@ -365,7 +371,7 @@ RSpec.describe RejectionDecorator do
 
     context 'with no allowance and unbookable slots' do
       before do
-        subject.apply_nomis_reasons(nomis_checker)
+        subject.apply_nomis_reasons
       end
 
       let(:visit_bookable) { false }
@@ -376,7 +382,7 @@ RSpec.describe RejectionDecorator do
 
     context 'when prisoner banned and bookable slots' do
       before do
-        subject.apply_nomis_reasons(nomis_checker)
+        subject.apply_nomis_reasons
       end
 
       let(:visit_bookable) { true }
@@ -387,7 +393,7 @@ RSpec.describe RejectionDecorator do
 
     context 'when prisoner banned and unbookable slots' do
       before do
-        subject.apply_nomis_reasons(nomis_checker)
+        subject.apply_nomis_reasons
       end
 
       let(:visit_bookable) { false }
@@ -398,7 +404,7 @@ RSpec.describe RejectionDecorator do
 
     context 'when prisoner out of prison and bookable slots' do
       before do
-        subject.apply_nomis_reasons(nomis_checker)
+        subject.apply_nomis_reasons
       end
 
       let(:visit_bookable) { true }
@@ -409,7 +415,7 @@ RSpec.describe RejectionDecorator do
 
     context 'when prisoner out of prison and unbookable slots' do
       before do
-        subject.apply_nomis_reasons(nomis_checker)
+        subject.apply_nomis_reasons
       end
 
       let(:visit_bookable) { false }

--- a/spec/decorators/visit_decorator_spec.rb
+++ b/spec/decorators/visit_decorator_spec.rb
@@ -2,10 +2,13 @@ require 'rails_helper'
 
 RSpec.describe VisitDecorator do
   let(:visit) { create(:visit) }
-  let(:checker) { instance_double(StaffNomisChecker) }
+  let(:offender) { double(Nomis::Offender, id: 1234) }
+  let(:checker) { instance_double(StaffNomisChecker, offender: offender) }
 
-  subject do
-    described_class.decorate(visit, context: { staff_nomis_checker: checker })
+  subject { described_class.decorate(visit) }
+
+  before do
+    allow(subject).to receive(:nomis_checker).and_return(checker)
   end
 
   describe '#prisoner_restrictions' do
@@ -27,12 +30,6 @@ RSpec.describe VisitDecorator do
 
   describe '#nomis_offender_id' do
     context 'when the Nomis::Api is enabled' do
-      let(:offender) { double(Nomis::Offender, id: 1234) }
-
-      before do
-        expect(checker).to receive(:offender).and_return(offender)
-      end
-
       it 'returns the offender id' do
         expect(subject.nomis_offender_id).to eq(offender.id)
       end

--- a/spec/models/prisoner_validation_spec.rb
+++ b/spec/models/prisoner_validation_spec.rb
@@ -11,47 +11,7 @@ RSpec.describe PrisonerValidation, type: :model do
 
   context 'when the API finds a match' do
     context 'with a prisoner number, dob' do
-      before do
-        mock_nomis_with(:lookup_offender_location, establishment)
-      end
-
-      context 'when the location matches' do
-        let(:establishment) { Nomis::Establishment.new(code: 'BMI', api_call_successful: true) }
-
-        it { is_expected.to be_valid }
-
-        it 'calls the api with a normalised noms_id' do
-          expect_any_instance_of(Nomis::Api).
-            to receive(:lookup_offender_location).
-            with(noms_id: 'A1234BC').
-            and_return(establishment)
-
-          is_expected.to be_valid
-        end
-
-        describe '#prisoner_located_at?' do
-          describe 'when prison code matches' do
-            let(:code) { 'BMI' }
-
-            it { is_expected.to be_prisoner_located_at(code) }
-          end
-
-          describe 'when prison code matches' do
-            let(:code) { 'RANDOME_CODE' }
-
-            it { is_expected.not_to be_prisoner_located_at(code) }
-          end
-        end
-      end
-
-      context 'when the location API call fails' do
-        let(:establishment) { Nomis::Establishment.new(api_call_successful: false) }
-
-        it 'is invalid an has a validation error for unknown state'do
-          is_expected.not_to be_valid
-          expect(subject.errors.full_messages).to eq(['location_unknown'])
-        end
-      end
+      it { is_expected.to be_valid }
     end
   end
 
@@ -62,17 +22,12 @@ RSpec.describe PrisonerValidation, type: :model do
       let(:success) { true }
 
       it { is_expected.not_to be_valid }
-
-      it 'does try to validate the location' do
-        expect(Nomis::Api.instance).not_to receive(:lookup_offender_location)
-        expect(subject).not_to be_valid
-      end
     end
 
-    context 'when the API does not find a match' do
-      let(:offender) { Nomis::NullOffender.new }
+    context 'with an unsuccessful API call' do
+      let(:success) { false }
 
-      it { is_expected.not_to be_valid }
+      it { is_expected.to be_invalid }
     end
   end
 end

--- a/spec/presenters/prisoner_details_presenter_spec.rb
+++ b/spec/presenters/prisoner_details_presenter_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe PrisonerDetailsPresenter do
+  let(:prison)   { build_stubbed(:prison, name: 'Pentonville') }
+  let(:prisoner) { build_stubbed(:prisoner) }
+  let(:offender) { Nomis::Offender.new(id: prisoner.number, noms_id: 'some_noms_id') }
+
+  let(:prisoner_validation) { PrisonerValidation.new(offender) }
+  let(:prisoner_location)   { PrisonerLocation.new(offender, prison.nomis_id) }
+
+  subject { described_class.new(prisoner_validation, prisoner_location) }
+
+  describe '#prisoner_existance_status' do
+    describe 'when the nomis api is live' do
+      before do
+        switch_on :nomis_staff_prisoner_check_enabled
+      end
+
+      describe 'when this API is available' do
+        describe 'with valid prisoner details' do
+          let(:api_call_successful) { true }
+          let(:code) { prison.nomis_id }
+
+          let(:establishment) do
+            Nomis::Establishment.new(code: code, api_call_successful: api_call_successful)
+          end
+
+          before do
+            mock_nomis_with(:lookup_offender_location, establishment)
+          end
+
+          describe '#details_incorrect?' do
+            it { is_expected.not_to be_prisoner_details_incorrect }
+          end
+
+          describe 'with valid location' do
+            it do
+              expect(subject.prisoner_existance_status).
+                to eq('valid')
+            end
+          end
+
+          describe 'with an invalid location' do
+            let(:code) { 'CCC' }
+
+            it { expect(subject.prisoner_existance_status).to eq('location_invalid') }
+          end
+
+          describe 'with an unkown location' do
+            let(:api_call_successful) { false }
+
+            it { expect(subject.prisoner_existance_status).to eq('location_unknown') }
+          end
+        end
+
+        describe 'with invalid prisoner details' do
+          let(:offender) { Nomis::NullOffender.new(api_call_successful: true) }
+
+          describe 'and the prisoner location is valid' do
+            it do
+              expect(subject.prisoner_existance_status).
+                to eq('invalid')
+            end
+
+            describe '#details_incorrect?' do
+              it { is_expected.to be_prisoner_details_incorrect }
+            end
+          end
+        end
+      end
+
+      describe "and the API is unavailable" do
+        let(:offender) { Nomis::NullOffender.new(api_call_successful: false) }
+
+        it { expect(subject.prisoner_existance_status).to eq('unknown') }
+      end
+    end
+  end
+end

--- a/spec/presenters/prisoner_details_presenter_spec.rb
+++ b/spec/presenters/prisoner_details_presenter_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe PrisonerDetailsPresenter do
           end
 
           describe '#details_incorrect?' do
-            it { is_expected.not_to be_prisoner_details_incorrect }
+            it { is_expected.not_to be_details_incorrect }
           end
 
           describe 'with valid location' do
@@ -63,7 +63,7 @@ RSpec.describe PrisonerDetailsPresenter do
             end
 
             describe '#details_incorrect?' do
-              it { is_expected.to be_prisoner_details_incorrect }
+              it { is_expected.to be_details_incorrect }
             end
           end
         end

--- a/spec/services/book_to_nomis_config_spec.rb
+++ b/spec/services/book_to_nomis_config_spec.rb
@@ -1,13 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe BookToNomisConfig do
-  let(:checker) { instance_double(StaffNomisChecker) }
-  let(:prison_name) { build_stubbed(:prison).name }
-  let(:opted_in) { true }
-  let(:already_booked_in_nomis) { true }
+  let(:checker)                    { instance_double(StaffNomisChecker) }
+  let(:prisoner_details_presenter) { instance_double(PrisonerDetailsPresenter) }
+  let(:prison_name)                { build_stubbed(:prison).name }
+  let(:opted_in)                   { true }
+  let(:already_booked_in_nomis)    { true }
 
   subject do
-    described_class.new(checker, prison_name, opted_in, already_booked_in_nomis)
+    described_class.new(
+      checker,
+      prison_name,
+      opted_in,
+      already_booked_in_nomis,
+      prisoner_details_presenter
+    )
   end
 
   describe '#opted_in?' do
@@ -53,7 +60,8 @@ RSpec.describe BookToNomisConfig do
 
   shared_context 'with prisoner exists' do
     before do
-      allow(checker).to receive(:prisoner_existance_status).and_return(StaffNomisChecker::VALID)
+      allow(prisoner_details_presenter).
+        to receive(:prisoner_existance_status).and_return(PrisonerDetailsPresenter::VALID)
     end
   end
 
@@ -114,9 +122,9 @@ RSpec.describe BookToNomisConfig do
       include_context 'with offender restrictions working'
 
       before do
-        expect(checker).
+        expect(prisoner_details_presenter).
           to receive(:prisoner_existance_status).
-          and_return(StaffNomisChecker::UNKNOWN)
+          and_return(PrisonerValidation::UNKNOWN)
       end
 
       it { is_expected.not_to be_possible_to_book }

--- a/spec/services/prisoner_location_spec.rb
+++ b/spec/services/prisoner_location_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe PrisonerLocation do
+  let(:offender)       { Nomis::Offender.new(id: 'someid', noms_id: 'a1234bc') }
+  let(:prison_code)    { 'BMI' }
+  let(:establishment)  { Nomis::Establishment.new(code: code, api_call_successful: api_successful) }
+
+  subject { described_class.new(offender, prison_code) }
+
+  describe 'validation' do
+    context 'when the API call is successful' do
+      before do
+        mock_nomis_with(:lookup_offender_location, establishment)
+      end
+
+      let(:api_successful) { true }
+
+      context 'when the offender is located at the given prison' do
+        let(:code)  { prison_code }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'when the offender is not located at the given prison' do
+        let(:code) { 'NOT_AT_THIS_PRISON_CODE' }
+
+        it { is_expected.to be_invalid }
+      end
+    end
+
+    context 'when the API call fails' do
+      before do
+        simulate_api_error_for :lookup_offender_location
+      end
+
+      it { is_expected.to be_invalid }
+      it 'has an unknown location error' do
+        subject.valid?
+        expect(subject.errors.full_messages_for(:base)).
+                 to eq([described_class::UNKNOWN])
+      end
+    end
+  end
+end


### PR DESCRIPTION
**CHANGES:**

This changeset aims at extracting some of the logic inside the VisitDecorator to
a PrisonerDetailsPresenter.

the high level API interacting objects are shared between decorators and controller as helper methods, so easier to share/inject between decorators/view layer and service objects.

I think our decorators are doing a little too much now and we could use higher level objects between the views/decorators and service objects,  that would have the downside of having one more indirection level but on the flip side overall simpler Decorators and Service objects, easier to compose.