### PR TITLE
Check API is enabled for public slot availaiblity

### DIFF
--- a/app/services/slot_availability.rb
+++ b/app/services/slot_availability.rb
@@ -86,8 +86,7 @@ private
   end
 
   def live_availability_enabled?
-    Rails.configuration.public_prisons_with_slot_availability.include?(
-      prison.name
-    )
+    Nomis::Api.enabled? &&
+      Rails.configuration.public_prisons_with_slot_availability.include?(prison.name)
   end
 end

--- a/spec/services/slot_availability_spec.rb
+++ b/spec/services/slot_availability_spec.rb
@@ -54,6 +54,14 @@ RSpec.describe SlotAvailability do
   end
 
   describe '#slots' do
+    context 'with the api disabled' do
+      before do
+        allow(Nomis::Api).to receive(:enabled?).and_return(false)
+      end
+
+      it { expect(subject.slots).to eq(all_slots_available) }
+    end
+
     describe 'with prison in the slot availability trial' do
       before do
         switch_feature_flag_with(:public_prisons_with_slot_availability, [prison.name])


### PR DESCRIPTION
The Nomis API is going to be unavailable for over 2 days. For the best
experience for the public is to avoid making calls to the API to reduce latency.

Slot availability was the only check in public that didn't check if the API was
enabled.