### PR TITLE
Not to load the offender if the API is disabled

### DIFF
--- a/app/services/staff_nomis_checker.rb
+++ b/app/services/staff_nomis_checker.rb
@@ -54,10 +54,7 @@ class StaffNomisChecker
   end
 
   def offender
-    @offender ||= Nomis::Api.instance.lookup_active_offender(
-      noms_id:       @visit.prisoner_number,
-      date_of_birth: @visit.prisoner.date_of_birth
-    )
+    @offender ||= load_offender
   end
 
   def prisoner_restrictions
@@ -116,5 +113,16 @@ private
         prison: @visit.prison,
         requested_slots: @visit.slots).
       tap(&:valid?)
+  end
+
+  def load_offender
+    if Nomis::Api.enabled?
+      Nomis::Api.instance.lookup_active_offender(
+        noms_id:       @visit.prisoner_number,
+        date_of_birth: @visit.prisoner.date_of_birth
+      )
+    else
+      Nomis::NullOffender.new
+    end
   end
 end

--- a/spec/services/staff_nomis_checker_spec.rb
+++ b/spec/services/staff_nomis_checker_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe StaffNomisChecker do
     describe '#errors_for' do
       it { expect(subject.errors_for(visit.slots.first)).to be_empty }
     end
+
+    describe '#offender' do
+      it { expect(subject.offender).to be_instance_of(Nomis::NullOffender) }
+    end
   end
 
   describe '#prisoner_availability_unknown?' do
@@ -442,5 +446,13 @@ RSpec.describe StaffNomisChecker do
 
       it { expect(subject.prisoner_restrictions).to be_empty }
     end
+  end
+
+  describe '#offender' do
+    before do
+      mock_nomis_with(:lookup_active_offender, offender)
+    end
+
+    it { expect(subject.offender).to eq(offender) }
   end
 end


### PR DESCRIPTION
The rest of the checks work as expected, it was only the offender API that was
being called.