### PR TITLE
Let a visitor be rejected for other reason

### DIFF
--- a/app/assets/stylesheets/modules/_visitor-list.scss
+++ b/app/assets/stylesheets/modules/_visitor-list.scss
@@ -5,6 +5,7 @@
     padding: $gutter-half $gutter-half 0;
     vertical-align: middle;
     select {
+      margin-bottom: 5px;
       width: 100%;
     }
   }

--- a/app/controllers/concerns/staff_response_context.rb
+++ b/app/controllers/concerns/staff_response_context.rb
@@ -88,6 +88,7 @@ private
         :nomis_id,
         :banned,
         :not_on_list,
+        :other_rejection_reason,
         banned_until: [:day, :month, :year]
       ],
       prisoner_attributes: [:nomis_offender_id]

--- a/app/decorators/rejection_decorator.rb
+++ b/app/decorators/rejection_decorator.rb
@@ -87,7 +87,9 @@ class RejectionDecorator < Draper::Decorator
 private
 
   def email_reasons
-    object.reasons.reject{ |reason| reason == Rejection::OTHER_REJECTION_REASON }
+    object.reasons.reject do |reason|
+      reason.in? [Rejection::OTHER_REJECTION_REASON, Rejection::VISITOR_OTHER_REASON]
+    end
   end
 
   def email_formatted_reason(reason)

--- a/app/models/rejection.rb
+++ b/app/models/rejection.rb
@@ -15,6 +15,7 @@ class Rejection < ActiveRecord::Base
   PRISONER_BANNED = 'prisoner_banned'.freeze
   PRISONER_OUT_OF_PRISON = 'prisoner_out_of_prison'.freeze
   OTHER_REJECTION_REASON = 'other'.freeze
+  VISITOR_OTHER_REASON = 'visitor_other_reason'.freeze
 
   REASONS = [
     CHILD_PROTECTION_ISSUES,
@@ -30,7 +31,8 @@ class Rejection < ActiveRecord::Base
     'duplicate_visit_request',
     PRISONER_BANNED,
     PRISONER_OUT_OF_PRISON,
-    OTHER_REJECTION_REASON
+    OTHER_REJECTION_REASON,
+    VISITOR_OTHER_REASON
   ].freeze
 
   belongs_to :visit, inverse_of: :rejection

--- a/app/models/staff_response.rb
+++ b/app/models/staff_response.rb
@@ -77,7 +77,7 @@ privileged_allowance_expires_on rejection_reason_detail])
 
   def visitors_attributes
     @visitors_attributes ||= begin
-      fields = %w[id not_on_list banned]
+      fields = %w[id not_on_list banned other_rejection_reason]
 
       visit.visitors.each_with_object({}).with_index do |(visitor, attrs), i|
         attrs[i.to_s] = visitor.attributes.slice(*fields)
@@ -107,6 +107,9 @@ privileged_allowance_expires_on rejection_reason_detail])
       visit.slot_granted = nil
     elsif principal_visitor.not_on_list?
       rejection.reasons << Rejection::NOT_ON_THE_LIST
+      visit.slot_granted = nil
+    elsif principal_visitor.other_rejection_reason?
+      rejection.reasons << Rejection::VISITOR_OTHER_REASON
       visit.slot_granted = nil
     end
   end

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -106,6 +106,10 @@ class Visit < ActiveRecord::Base
     visitors.select(&:not_on_list?)
   end
 
+  def visitors_rejected_for_other_reasons
+    visitors.select(&:other_rejection_reason?)
+  end
+
   def confirm_nomis_cancelled
     Cancellation.
       where(visit_id: id, nomis_cancelled: false).
@@ -167,6 +171,8 @@ private
 
   def not_allowed_visitor_ids
     @not_allowed_visitor_ids ||=
-      unlisted_visitors.map(&:id) + banned_visitors.map(&:id)
+      unlisted_visitors.map(&:id) +
+      banned_visitors.map(&:id) +
+      visitors_rejected_for_other_reasons.map(&:id)
   end
 end

--- a/app/models/visitor.rb
+++ b/app/models/visitor.rb
@@ -15,7 +15,7 @@ class Visitor < ActiveRecord::Base
   scope :allowed,  -> { where(banned: false, not_on_list: false) }
 
   def allowed?
-    !(banned || not_on_list)
+    !(banned || not_on_list || other_rejection_reason)
   end
 
   def status

--- a/app/views/prison/visits/_other_reason.html.erb
+++ b/app/views/prison/visits/_other_reason.html.erb
@@ -1,0 +1,6 @@
+<div class="multiple-choice form-group">
+  <%= vf.check_box :other_rejection_reason %>
+  <%= vf.label :other_rejection_reason do %>
+    <%= t('.other_reason') %>
+  <% end %>
+</div>

--- a/app/views/prison/visits/_rejection_manual.html.erb
+++ b/app/views/prison/visits/_rejection_manual.html.erb
@@ -12,10 +12,10 @@
         <%= render 'rejection_reason', rf: rf, id: :child_protection_issues %>
       </div>
     <% end %>
-    <div class="multiple-choice" data-target="rejection_reason">
+    <div class="multiple-choice other-reason" data-target="other_reason_detail">
       <%= render 'rejection_reason', rf: rf, id: :other %>
     </div>
-    <div class="panel panel-border-narrow js-hidden" id="rejection_reason">
+    <div class="panel panel-border-narrow js-hidden" id="other_reason_detail">
       <%= single_field rf, :rejection_reason_detail, :text_area, rows: 4, class: 'form-control form-control-full-width' %>
     </div>
   </div>

--- a/app/views/prison/visits/_visitor_contact.html.erb
+++ b/app/views/prison/visits/_visitor_contact.html.erb
@@ -29,8 +29,10 @@
       <% if Nomis::Feature.contact_list_enabled?(@visit.prison_name) && !@visit.contact_list_unknown? %>
         <%= v.contact_list_matching(vf) %>
       <% end %>
+      <div class="bold-small push-bottom--half">Visitor rejection reasons</div>
       <%= render 'prison/visits/not_on_list', vf: vf, v: v  %>
       <%= render 'prison/visits/banned', vf: vf, v: v  %>
+      <%= render 'prison/visits/other_reason', vf: vf, v: v  %>
     </div>
   </div>
 </li>

--- a/app/views/visitor_mailer/booked.html.erb
+++ b/app/views/visitor_mailer/booked.html.erb
@@ -57,6 +57,12 @@
   <p><%= t('.not_on_list_instructions') %></p>
 <% end %>
 
+<% if @visit.visitors_rejected_for_other_reasons.any? %>
+  <% @visit.visitors_rejected_for_other_reasons.each do |v| %>
+    <p><%= t('.visitor_rejected_other_reason_html', name: v.anonymized_name) %></p>
+  <% end %>
+<% end %>
+
 <h2><%= t('.cancel_change_title') %></h2>
 
 <p>

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -307,6 +307,8 @@ en:
         banned: Visitor is banned
       not_on_list:
         not_on_list: Not on contact list
+      other_reason:
+        other_reason: Other reason
       contact_list:
         nomis_list: "Match to prisoner's contact list"
       duplicate_request:
@@ -384,6 +386,7 @@ en:
     visitor_banned: A visitor has been banned
     visitor_cancelled: The visitor cancelled the visit
     visitor_not_on_list: A visitor is not on the contact list
+    visitor_other_reason: Visitor rejected for other reasons
     duplicate_visit_request: Duplicate visit request
     reference_number: Reference number
     clear_selection: Clear selection

--- a/config/locales/en/pvb2-mailers.yml
+++ b/config/locales/en/pvb2-mailers.yml
@@ -24,6 +24,9 @@ en:
       visitor_not_on_list_html: >-
         <strong>%{name} cannot attend</strong> as they are
         <strong>not on the prisoner's contact list</strong>
+      visitor_rejected_other_reason_html: >-
+        <strong>%{name} cannot attend</strong><br/>
+        Please contact the prison for more information about why they can’t attend.
       not_on_list_instructions: >-
         Visitors not on contact lists need to ask prisoners to update their
         lists with correct details, making sure that names appear exactly the

--- a/db/migrate/20171121152149_add_other_rejection_reason_to_visitors.rb
+++ b/db/migrate/20171121152149_add_other_rejection_reason_to_visitors.rb
@@ -1,0 +1,5 @@
+class AddOtherRejectionReasonToVisitors < ActiveRecord::Migration[5.1]
+  def change
+    add_column :visitors, :other_rejection_reason, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171113140333) do
+ActiveRecord::Schema.define(version: 20171121152149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -139,6 +139,7 @@ ActiveRecord::Schema.define(version: 20171113140333) do
     t.boolean "not_on_list", default: false
     t.date "banned_until"
     t.integer "nomis_id"
+    t.boolean "other_rejection_reason", default: false
     t.index ["visit_id", "sort_index"], name: "index_visitors_on_visit_id_and_sort_index", unique: true
     t.index ["visit_id"], name: "index_visitors_on_visit_id"
   end

--- a/spec/decorators/rejection_decorator_spec.rb
+++ b/spec/decorators/rejection_decorator_spec.rb
@@ -75,6 +75,16 @@ RSpec.describe RejectionDecorator do
         end
       end
 
+      context 'when containing visitor_other_reason' do
+        let!(:other_rejection_visitor) do
+          create(:visitor, visit: rejection.visit, other_rejection_reason: true)
+        end
+
+        let(:reasons) { [Rejection::VISITOR_OTHER_REASON] }
+
+        it { expect(subject.email_formatted_reasons.map(&:explanation)).to be_empty }
+      end
+
       context 'when containing banned' do
         let(:reasons) { [Rejection::BANNED] }
 

--- a/spec/features/process_a_request_accept_without_contact_list_spec.rb
+++ b/spec/features/process_a_request_accept_without_contact_list_spec.rb
@@ -154,6 +154,30 @@ RSpec.feature 'Processing a request - Acceptance without the contact list enable
           and_body(/cannot attend as they are not on the prisoner's contact list/)
       end
 
+      scenario 'accepting a booking while indicating a visitor cannot go for other reasons' do
+        visit prison_visit_path(vst, locale: 'en')
+
+        choose_date
+        fill_in 'Reference number', with: '12345678'
+
+        within "#visitor_#{visitor.id}" do
+          check 'Other reason'
+        end
+
+        click_button 'Process'
+
+        expect(page).to have_css('#content .notification', text: 'Thank you for processing the visit')
+
+        vst.reload
+        expect(vst).to be_booked
+        expect(vst.reference_no).to eq('12345678')
+
+        expect(contact_email_address).
+          to receive_email.
+          with_subject(/Visit confirmed: your visit for \w+ \d+ \w+ has been confirmed/).
+          and_body(/cannot attend/)
+      end
+
       context 'with specific prisoner details' do
         let(:prisoner_number) { 'A1484AE' }
         let(:prisoner_dob) { '1971-11-11' }

--- a/spec/models/metrics/rejection_percentage_spec.rb
+++ b/spec/models/metrics/rejection_percentage_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Metrics::RejectionPercentage do
                                     visitor_not_on_list:        0,
                                     duplicate_visit_request:    0,
                                     other:                      0,
+                                    visitor_other_reason:       0,
                                     date:                       nil
                                    )
     end

--- a/spec/models/staff_response_spec.rb
+++ b/spec/models/staff_response_spec.rb
@@ -142,7 +142,9 @@ RSpec.describe StaffResponse, type: :model do
     end
 
     context 'with slot availability' do
-      before do subject.valid? end
+      before do
+        subject.valid?
+      end
 
       context 'when a slot is available' do
         it { is_expected.to be_valid }
@@ -170,6 +172,20 @@ RSpec.describe StaffResponse, type: :model do
       it 'is rejected for not having lead visitor on the list' do
         expect(subject).to be_valid
         expect(subject.visit.rejection.reasons).to include(Rejection::NOT_ON_THE_LIST)
+      end
+    end
+
+    context "when the lead visitor can't go for other reasons" do
+      before do
+        params[:visitors_attributes]['0']['other_rejection_reason'] = true
+        params[:visitors_attributes]['1'] = other_visitor.attributes.slice('id', 'banned', 'not_on_list')
+      end
+
+      let(:other_visitor) { build(:visitor, visit: visit) }
+
+      it 'is rejected for not having lead visitor on the list' do
+        expect(subject).to be_valid
+        expect(subject.visit.rejection.reasons).to contain_exactly(Rejection::VISITOR_OTHER_REASON)
       end
     end
 

--- a/spec/models/visitor_spec.rb
+++ b/spec/models/visitor_spec.rb
@@ -15,11 +15,13 @@ RSpec.describe Visitor do
     before do
       instance.not_on_list = not_on_list
       instance.banned = banned
+      instance.other_rejection_reason = other_rejection_reason
     end
 
-    context 'when not banned or is the contact list' do
+    context 'when not banned or is the contact list or rejected for other reason' do
       let(:not_on_list) { false }
       let(:banned) { false }
+      let(:other_rejection_reason) { false }
 
       it { is_expected.to eq(true) }
     end
@@ -27,12 +29,22 @@ RSpec.describe Visitor do
     context 'when banned' do
       let(:not_on_list) { false }
       let(:banned) { true }
+      let(:other_rejection_reason) { false }
 
       it { is_expected.to eq(false) }
     end
 
     context 'when not in the contact list' do
       let(:not_on_list) { true }
+      let(:banned) { false }
+      let(:other_rejection_reason) { false }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when rejected for other reason' do
+      let(:other_rejection_reason) { true }
+      let(:not_on_list) { false }
       let(:banned) { false }
 
       it { is_expected.to eq(false) }

--- a/spec/presenters/graph_metrics_presenter_spec.rb
+++ b/spec/presenters/graph_metrics_presenter_spec.rb
@@ -280,7 +280,8 @@ RSpec.describe GraphMetricsPresenter do
                                    slot_unavailable:           12.12,
                                    visitor_banned:             13.64,
                                    visitor_not_on_list:        15.15,
-                                   other:                      0)
+                                   other:                      0,
+                                   visitor_other_reason:       0)
       end
     end
   end

--- a/spec/support/shared/booking_request_processor_setup.rb
+++ b/spec/support/shared/booking_request_processor_setup.rb
@@ -3,7 +3,7 @@ RSpec.shared_context 'with staff response setup' do
   let(:visit)             { create :visit_with_three_slots }
   let(:slot_granted)      { visit.slot_option_0 }
   let(:processing_state)  { 'requested' }
-  let(:visitor_fields)    { %w[id not_on_list banned] }
+  let(:visitor_fields)    { %w[id not_on_list banned other_rejection_reason] }
   let(:params) do
     {
       slot_option_0:        visit.slot_option_0,


### PR DESCRIPTION
It behaves the same way as other visitor rejections. If the lead visitor is
rejected for other reason the visit is rejected, otherwise the booked email
lists the visitors that can't attend for other reasons.