### PR TITLE
Not hardcode confirmed bookings metrics date range

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -13,8 +13,8 @@ class AdminMailer < ActionMailer::Base
     )
   end
 
-  def confirmed_bookings(email_address)
-    exporter = WeeklyMetricsConfirmedCsvExporter.new(weeks: 12)
+  def confirmed_bookings(email_address, dates_to_export = nil)
+    exporter = WeeklyMetricsConfirmedCsvExporter.new(dates_to_export)
 
     attachments['confirmed_bookings.csv'] = {
       mime_type: 'text/csv',
@@ -24,7 +24,7 @@ class AdminMailer < ActionMailer::Base
     mail(
       from: I18n.t('mailer.noreply', domain: smtp_settings[:domain]),
       to: email_address,
-      subject: 'Latest confirmed bookings (CSV)'
+      subject: 'Confirmed bookings (CSV)'
     )
   end
 end

--- a/app/metrics/counters.rb
+++ b/app/metrics/counters.rb
@@ -22,12 +22,8 @@ module Counters
 
   class CountVisitsByPrisonAndCalendarWeek < ActiveRecord::Base
     extend CounterSupport
-    def self.ordered_counters(
-      year: Time.zone.now.year,
-      week: (Time.zone.today - 12.weeks).cweek
-        )
-      where('year = ? AND week > ?', year, week).
-        pluck(:prison_name, :year, :week, :processing_state, :count)
+    def self.ordered_counters
+      pluck(:prison_name, :year, :week, :processing_state, :count)
     end
   end
 

--- a/app/metrics/formatter.rb
+++ b/app/metrics/formatter.rb
@@ -1,0 +1,15 @@
+require 'support/counter_support'
+
+module Metrics
+  class Formatter
+    include CounterSupport
+
+    def initialize(ordered_counters)
+      self.ordered_counters = ordered_counters
+    end
+
+  private
+
+    attr_accessor :ordered_counters
+  end
+end

--- a/spec/features/metrics_spec.rb
+++ b/spec/features/metrics_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature 'Metrics', js: true do
         click_on 'Email latest confirmed bookings (CSV)'
         expect(email_address).
           to receive_email.
-          with_subject(/Latest confirmed bookings \(CSV\)/).
+          with_subject(/Confirmed bookings \(CSV\)/).
           with_attachment('confirmed_bookings.csv')
       end
     end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -58,12 +58,11 @@ RSpec.describe AdminMailer do
     before do
       expect(WeeklyMetricsConfirmedCsvExporter).
         to receive(:new).
-        with(weeks: 12).
         and_return(exporter)
     end
 
     it { expect(mail.to).to include(email_address) }
-    it { expect(mail.subject).to eq('Latest confirmed bookings (CSV)') }
+    it { expect(mail.subject).to eq('Confirmed bookings (CSV)') }
 
     it 'includes a csv attachment with the data' do
       expect(mail.attachments).

--- a/spec/metrics/counters_spec.rb
+++ b/spec/metrics/counters_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Counters do
   context 'when they are organised by date' do
     include_examples 'when creating visits with dates'
 
-    xdescribe Counters::CountVisitsByPrisonAndCalendarWeek do
+    describe Counters::CountVisitsByPrisonAndCalendarWeek do
       before do
         luna_visits_with_dates
       end

--- a/spec/metrics/weekly_metrics_confirmed_csv_exporter_spec.rb
+++ b/spec/metrics/weekly_metrics_confirmed_csv_exporter_spec.rb
@@ -1,15 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe WeeklyMetricsConfirmedCsvExporter do
-  let(:weeks) { 2 }
-  let(:instance) { described_class.new(weeks: weeks) }
+  let(:instance) { described_class.new(dates_to_export) }
 
   describe '#to_csv' do
     let(:prison1) { create(:prison, name: 'A Prison') }
     let(:prison2) { create(:prison, name: 'B Prison') }
     let(:prison3) { create(:prison, name: 'C Prison') }
-    let(:week_ago) { 1.week.ago }
-    let(:two_weeks_ago) { 2.weeks.ago }
+    let(:week_ago) { 1.week.ago.beginning_of_week.to_date }
+    let(:two_weeks_ago) { 2.weeks.ago.beginning_of_week.to_date }
+    let(:dates_to_export) { [week_ago, two_weeks_ago] }
 
     let!(:recent_confirmed_visit) do
       create(:booked_visit, prison: prison3)
@@ -24,8 +24,8 @@ RSpec.describe WeeklyMetricsConfirmedCsvExporter do
     subject { instance.to_csv }
 
     it 'returns a CSV string' do
-      week1 = week_ago.beginning_of_week.to_date.to_s
-      week2 = two_weeks_ago.beginning_of_week.to_date.to_s
+      week1 = week_ago.to_s
+      week2 = two_weeks_ago.to_s
 
       expect(subject).to eq(<<~CSV)
         Prison,#{week1},#{week2}


### PR DESCRIPTION
It is now possible to generate an export email with a custom range from the
console.

The wrapper class for the weekly prison counter view was hardcoded to pull
always the last 12 weeks of data regardless of what the exporter object was
configured to export.

It also had a bug if used within the first 3 months because the year was
hardcoded.