### PR TITLE
Remove db default value in migration

### DIFF
--- a/db/migrate/20171121152149_add_other_rejection_reason_to_visitors.rb
+++ b/db/migrate/20171121152149_add_other_rejection_reason_to_visitors.rb
@@ -1,5 +1,5 @@
 class AddOtherRejectionReasonToVisitors < ActiveRecord::Migration[5.1]
   def change
-    add_column :visitors, :other_rejection_reason, :boolean, default: false
+    add_column :visitors, :other_rejection_reason, :boolean
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -139,7 +139,7 @@ ActiveRecord::Schema.define(version: 20171121152149) do
     t.boolean "not_on_list", default: false
     t.date "banned_until"
     t.integer "nomis_id"
-    t.boolean "other_rejection_reason", default: false
+    t.boolean "other_rejection_reason"
     t.index ["visit_id", "sort_index"], name: "index_visitors_on_visit_id_and_sort_index", unique: true
     t.index ["visit_id"], name: "index_visitors_on_visit_id"
   end


### PR DESCRIPTION
The default is locking the visitors table in production when migrating