### PR TITLE
Disable lograge for app running on heroku

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -40,11 +40,6 @@ module PrisonVisits
     config.sentry_dsn = ENV['SENTRY_DSN']
     config.sentry_js_dsn = ENV['SENTRY_JS_DSN']
 
-    config.lograge.enabled = Rails.env.production?
-    config.lograge.custom_options = lambda do |event|
-      event.payload[:custom_log_items]
-    end
-
     config.middleware.insert_before Rack::Head, HttpMethodNotAllowed
 
     config.sendgrid_api_user = ENV['SMTP_USERNAME']

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -17,13 +17,19 @@ Rails.application.configure do
   config.assets.js_compressor = :uglifier
   config.assets.compile = false
   config.assets.digest = true
-  config.log_level = :info
+  config.log_level = :debug
   config.i18n.fallbacks = true
   config.active_support.deprecation = :notify
   config.log_formatter = ::Logger::Formatter.new
   config.active_record.dump_schema_after_migration = false
 
   config.lograge.formatter = Lograge::Formatters::Logstash.new
+  config.lograge.enabled = !ENV['HEROKU_APP_NAME']
+
+  config.lograge.custom_options = lambda do |event|
+    event.payload[:custom_log_items]
+  end
+
   config.lograge.logger = ActiveSupport::Logger.new \
     "#{Rails.root}/log/logstash_#{Rails.env}.json"
 


### PR DESCRIPTION
**CHANGES:**

In order to debug the intermitant failure on for integration tests running off
the heroku deployed application I need to be able to look at the SQL query made