### PR TITLE
Hook codeclimate to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,19 @@ jobs:
               sudo tar -zxvf geckodriver-v0.19.0-linux64.tar.gz -C /opt
             fi
             [[ -L /usr/local/bin/geckodriver ]] || sudo ln -sf /opt/geckodriver /usr/local/bin/geckodriver
+      - run:
+          name: Setup Code Climate test-reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
       - run: bundle exec rake db:create
       - run: bundle exec rake db:schema:load
-      - run: bundle exec rake
+      - run:
+          name: Run tests
+          command: |
+            ./cc-test-reporter before-build
+            bundle exec rake
+            ./cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
       - save_cache:
           key: prison-visits-2-{{ checksum "Gemfile.lock" }}
           paths:

--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,6 @@ group :test do
   gem 'rspec-collection_matchers'
   gem 'selenium-webdriver'
   gem 'simplecov'
-  gem 'simplecov-rcov'
   gem 'vcr'
   gem 'webmock'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,8 +325,6 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    simplecov-rcov (0.2.3)
-      simplecov (>= 0.4.1)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-commands-rspec (1.0.4)
@@ -440,7 +438,6 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq
   simplecov
-  simplecov-rcov
   spring-commands-rspec
   state_machines-activerecord
   string_scrubber

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Maintainability](https://api.codeclimate.com/v1/badges/20ad81e6cb95ffd082d2/maintainability)](https://codeclimate.com/github/ministryofjustice/prison-visits-2/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/20ad81e6cb95ffd082d2/test_coverage)](https://codeclimate.com/github/ministryofjustice/prison-visits-2/test_coverage)
+
 # Visit someone in prison
 
 This is a full rewrite from the ground up, using a database instead of

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,4 @@
 require 'simplecov'
-require 'simplecov-rcov'
-SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
 SimpleCov.minimum_coverage 100
 
 if ENV['CIRCLE_ARTIFACTS']


### PR DESCRIPTION
Send coverage results from CircleCI.

Removes simplecov-rcov as it is an abandoned project and breaks with Ruby 2.5