### PR TITLE
Add singular page name for tracking

### DIFF
--- a/app/assets/javascripts/modules/moj.AsyncGA.js
+++ b/app/assets/javascripts/modules/moj.AsyncGA.js
@@ -4,13 +4,19 @@
 
   moj.Modules.AsyncGA = {
     el: '.js-AsyncGA',
+
     init: function() {
       GOVUK.Analytics.load();
+      if($(this.el).length>0){
+        this.render();
+      }
+    },
 
+    render: function(){
       // Use document.domain in dev, preview and staging so that tracking works
       // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
       var cookieDomain = (document.domain === 'www.gov.uk') ? '.www.gov.uk' : document.domain;
-      var gaTrackingId = $(this.el).eq(0).data('ga-tracking-id');
+      var gaTrackingId = $(this.el).data('ga-tracking-id');
 
       // Configure profiles and make interface public
       // for custom dimensions, virtual pageviews and events
@@ -19,13 +25,13 @@
         cookieDomain: cookieDomain
       });
 
-      this.hitTypePage  = $(this.el).eq(0).data('hit-type-page');
+      this.hitTypePage  = $(this.el).data('hit-type-page');
       if (this.hitTypePage) {
-        GOVUK.analytics.trackPageview(location.pathname + '#' + this.hitTypePage);
+        GOVUK.analytics.trackPageview(this.hitTypePage);
       } else {
         GOVUK.analytics.trackPageview();
       }
-    },
+    }
   };
 
 }());

--- a/app/assets/javascripts/modules/moj.AsyncGA.js
+++ b/app/assets/javascripts/modules/moj.AsyncGA.js
@@ -10,7 +10,7 @@
       // Use document.domain in dev, preview and staging so that tracking works
       // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
       var cookieDomain = (document.domain === 'www.gov.uk') ? '.www.gov.uk' : document.domain;
-      var gaTrackingId = $(this.el).data('ga-tracking-id');
+      var gaTrackingId = $(this.el).eq(0).data('ga-tracking-id');
 
       // Configure profiles and make interface public
       // for custom dimensions, virtual pageviews and events
@@ -19,7 +19,7 @@
         cookieDomain: cookieDomain
       });
 
-      this.hitTypePage  = $(this.el).data('hit-type-page');
+      this.hitTypePage  = $(this.el).eq(0).data('hit-type-page');
       if (this.hitTypePage) {
         GOVUK.analytics.trackPageview(location.pathname + '#' + this.hitTypePage);
       } else {

--- a/app/views/prison/visits/show.html.erb
+++ b/app/views/prison/visits/show.html.erb
@@ -1,7 +1,11 @@
 <%= render 'prison/dashboards/navigation' %>
 
 <% if @visit.processable? || (@booking_response.present? && !@booking_response.success?) %>
-  <%= render 'prison/visits/requested', visit: @visit %>
+  <div class="js-AsyncGA" data-hit-type-page="Visit request">
+    <%= render 'prison/visits/requested', visit: @visit %>
+  </div>
 <% else %>
-  <%= render 'prison/visits/processed', visit: @visit %>
+  <div class="js-AsyncGA" data-hit-type-page="Visit processed">
+    <%= render 'prison/visits/processed', visit: @visit %>
+  </div>
 <% end %>

--- a/app/views/prison/visits/show.html.erb
+++ b/app/views/prison/visits/show.html.erb
@@ -1,11 +1,11 @@
 <%= render 'prison/dashboards/navigation' %>
 
 <% if @visit.processable? || (@booking_response.present? && !@booking_response.success?) %>
-  <div class="js-AsyncGA" data-hit-type-page="Visit request">
+  <div class="js-AsyncGA" data-ga-tracking-id="<%= config_item :ga_id %>" data-hit-type-page="Visit request">
     <%= render 'prison/visits/requested', visit: @visit %>
   </div>
 <% else %>
-  <div class="js-AsyncGA" data-hit-type-page="Visit processed">
+  <div class="js-AsyncGA" data-ga-tracking-id="<%= config_item :ga_id %>" data-hit-type-page="Visit processed">
     <%= render 'prison/visits/processed', visit: @visit %>
   </div>
 <% end %>


### PR DESCRIPTION
GA is currently tracking pages by URL so each visit request/processed page only has one view count as the unique visit ID is part of the URL.

This will override the page name being sent to 'Visit request' and 'Visit processed'.