### PR TITLE
Always display reference num option

### DIFF
--- a/app/views/prison/visits/_book_to_nomis_opt_in.html.erb
+++ b/app/views/prison/visits/_book_to_nomis_opt_in.html.erb
@@ -28,15 +28,4 @@
     <p class="bold-small"><%= t('.closed_visit') %></p>
     <p><%= t('.closed_book_to_nomis') %></p>
   </div>
-
-  <div id="booktonomis-message" class="push-top">
-    <div class="grid-row">
-      <div class="column-one-half">
-        <div id="selected_slot_details" class="">
-          <%= single_field f, :reference_no, :text_field, class: 'form-control' %>
-          <%= single_field f, :closed, :check_box  %>
-        </div>
-      </div>
-    </div>
-  </div>
 </div>

--- a/app/views/prison/visits/_visit_date_section.html.erb
+++ b/app/views/prison/visits/_visit_date_section.html.erb
@@ -36,14 +36,12 @@
     <% end %>
   <% end %>
 
-  <% unless Nomis::Feature.book_to_nomis_enabled?(@visit.prison_name) %>
-    <div class="column-one-half">
-      <div id="selected_slot_details" class="panel panel-border-narrow">
-        <%= single_field f, :reference_no, :text_field, class: 'form-control' %>
-        <%= single_field f, :closed, :check_box  %>
-      </div>
+  <div class="column-one-half">
+    <div id="selected_slot_details" class="panel panel-border-narrow">
+      <%= single_field f, :reference_no, :text_field, class: 'form-control' %>
+      <%= single_field f, :closed, :check_box  %>
     </div>
-  <% end %>
+  </div>
 
   <div class="column-two-thirds push-top push-bottom--half">
     <%= error_container f, :slot_granted do %>

--- a/spec/features/process_a_request_accept_with_contact_list_spec.rb
+++ b/spec/features/process_a_request_accept_with_contact_list_spec.rb
@@ -56,6 +56,8 @@ RSpec.feature 'Processing a request - Acceptance with the contact list enabled',
 
       choose_date
 
+      fill_in 'Reference number',   with: '11223344'
+
       fill_in 'This message will be included in the email sent to the visitor', with: 'A staff message'
 
       within "#visitor_#{visitor.id}" do
@@ -71,6 +73,7 @@ RSpec.feature 'Processing a request - Acceptance with the contact list enabled',
       vst.reload
       expect(vst).to be_booked
       expect(vst.nomis_id).to eq(5493)
+      expect(vst.reference_no).to eq('11223344')
     end
 
     scenario 'opting out of booking to nomis', vcr: { cassette_name: 'process_happy_path_with_contact_list' } do


### PR DESCRIPTION
Following the trial rollout of 'Book To Nomis' to Featherstone we
received feedback from staff stating that they still need the option of
adding a reference number to each visit.  The feature had been
implemented in such a way that if a visit could be booked directly to 
Nomis then we no longer displayed the reference number, unless the 
user specifically opted out, or if it needed to be a closed visit.

Therefore, we have amended the feature to allow the user the option of
including a reference number regardless of whether the prison has the
'Book To Nomis' feature enabled or not.