### PR TITLE
Add config vars to app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,6 +26,15 @@
     "NOMIS_STAFF_SLOT_AVAILABILITY_ENABLED": {
       "required": true
     },
+    "NOMIS_INTERNAL_LOCATION_ENABLED": {
+      "required": true
+    },
+    "NOMIS_SENTENCE_STATUS_ENABLED": {
+      "required": true
+    },
+    "NOMIS_IEP_LEVEL_ENABLED": {
+      "required": true
+    },
     "STAFF_PRISONS_WITH_SLOT_AVAILABILITY": {
       "required": true
     },


### PR DESCRIPTION
We have rolled out three additional features for staff so that they are
now presented with IEP level, sentence status and internal location.  To
ensure that our pull request deployments in Heroku represent our
production app we need to add these config vars.