### PR TITLE
[WIP] Send all rejection data to GA

### DIFF
--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -69,6 +69,7 @@ private
     if @booking_response.success?
       ga_tracker.send_processing_timing
       ga_tracker.send_unexpected_rejection_event
+      ga_tracker.send_rejection_event
     end
   end
 

--- a/app/services/ga_tracker.rb
+++ b/app/services/ga_tracker.rb
@@ -20,6 +20,10 @@ class GATracker
     send_data(rejection_event_payload) if visit_rejected_unexpectedly?
   end
 
+  def send_rejection_event
+    send_data(rejection_event_payload) if visit_rejected?
+  end
+
   def send_processing_timing
     return unless timing_value
     send_data(timing_payload_data)
@@ -45,6 +49,10 @@ private
   def visit_rejected_unexpectedly?
     visit.rejected? &&
       ActiveRecord::Type::Boolean.new.cast(request.params[:was_bookable])
+  end
+
+  def visit_rejected?
+    visit.rejected?
   end
 
   def timing_value

--- a/app/services/ga_tracker.rb
+++ b/app/services/ga_tracker.rb
@@ -17,11 +17,11 @@ class GATracker
   end
 
   def send_unexpected_rejection_event
-    send_data(rejection_event_payload) if visit_rejected_unexpectedly?
+    send_data(rejection_event_payload('Manual rejection')) if visit_rejected_unexpectedly?
   end
 
   def send_rejection_event
-    send_data(rejection_event_payload) if visit_rejected?
+    send_data(rejection_event_payload('Rejection')) if visit_rejected?
   end
 
   def send_processing_timing
@@ -83,10 +83,10 @@ private
     }
   end
 
-  def rejection_event_payload
+  def rejection_event_payload(action)
     {
       v: 1, uip: ip, tid: web_property_id, cid: cookies['_ga'] || SecureRandom.base64,
-      ua:  user_agent, t: 'event', ec: prison.name, ea: 'Manual rejection',
+      ua:  user_agent, t: 'event', ec: prison.name, ea: action,
       el: visit.rejection.reasons.sort.join('-')
     }
   end

--- a/spec/controllers/prison/visits_controller_spec.rb
+++ b/spec/controllers/prison/visits_controller_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Prison::VisitsController, type: :controller do
           expect(GATracker).to receive(:new).and_return(google_tracker)
           expect(google_tracker).to receive(:send_processing_timing)
           expect(google_tracker).to receive(:send_unexpected_rejection_event)
+          expect(google_tracker).to receive(:send_rejection_event)
         end
 
         it { is_expected.to redirect_to(prison_inbox_path) }

--- a/spec/features/cancel_booked_to_nomis_visit_spec.rb
+++ b/spec/features/cancel_booked_to_nomis_visit_spec.rb
@@ -62,6 +62,7 @@ RSpec.feature 'Cancel a visit booked to NOMIS', js: true do
         double(GATracker,
           send_processing_timing: nil,
           send_unexpected_rejection_event: nil,
+          send_rejection_event: nil,
           set_visit_processing_time_cookie: nil))
   end
 

--- a/spec/fixtures/vcr_cassettes/rejection_event.yml
+++ b/spec/fixtures/vcr_cassettes/rejection_event.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.google-analytics.com/collect
+    body:
+      encoding: US-ASCII
+      string: v=1&uip=239.55.120.3&tid=UA-96772907-2&cid=some_client_id&ua=some+user+agent+string&t=event&ec=Asleyshire+Open+Prison&ea=Manual+rejection&el=slot_unavailable
+    headers:
+      User-Agent:
+      - excon/0.60.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Date:
+      - Fri, 23 Feb 2018 08:55:39 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Last-Modified:
+      - Sun, 17 May 1998 03:00:00 GMT
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - image/gif
+      Server:
+      - Golfe2
+      Content-Length:
+      - '35'
+      Alt-Svc:
+      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303338; quic=51303337;
+        quic=51303335,quic=":443"; ma=2592000; v="41,39,38,37,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhAQABAID/AP///wAAACwAAAAAAQABAAACAkQBADs=
+    http_version: 
+  recorded_at: Fri, 23 Feb 2018 08:55:39 GMT
+recorded_with: VCR 4.0.0

--- a/spec/services/ga_tracker_spec.rb
+++ b/spec/services/ga_tracker_spec.rb
@@ -83,12 +83,10 @@ RSpec.describe GATracker do
   end
 
   describe '#send_rejection_event' do
-    context "when the visit was not bookable and it was rejected" do
-      let(:was_bookable) { 'false' }
+    context "when the visit was rejected" do
 
       before do
-        reject_visit visit
-        visit.rejection.reasons = ['prisoner_details_incorrect']
+        reject_visit(visit, ['prisoner_details_incorrect'])
         cookies['_ga'] = 'some_client_id'
         switch_feature_flag_with :ga_id, web_property_id
       end

--- a/spec/services/ga_tracker_spec.rb
+++ b/spec/services/ga_tracker_spec.rb
@@ -84,7 +84,6 @@ RSpec.describe GATracker do
 
   describe '#send_rejection_event' do
     context "when the visit was rejected" do
-
       before do
         reject_visit(visit, ['prisoner_details_incorrect'])
         cookies['_ga'] = 'some_client_id'

--- a/spec/services/ga_tracker_spec.rb
+++ b/spec/services/ga_tracker_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe GATracker do
               ua: user_agent,
               t: "event",
               ec: visit.prison.name,
-              ea: 'Manual rejection',
+              ea: 'Rejection',
               el: "prisoner_details_incorrect"
             ),
             headers: { 'Content-Type' => 'application/x-www-form-urlencoded', 'Host' => 'www.google-analytics.com:443', 'User-Agent' => Excon::USER_AGENT }


### PR DESCRIPTION
For us to be able to monitor whether the slot updates and rollout of
slot availability are having a positive impact we need to track more
data around the visit rejection reasons.