### PR TITLE
Fix prisoner details validation when location API call fails

### DIFF
--- a/app/decorators/visit_decorator.rb
+++ b/app/decorators/visit_decorator.rb
@@ -12,6 +12,7 @@ class VisitDecorator < Draper::Decorator
 
   delegate :prisoner_existance_status,
     :prisoner_existance_error,
+    :prisoner_location_error,
     :details_incorrect?,
     to: :prisoner_details
 

--- a/app/presenters/prisoner_details_presenter.rb
+++ b/app/presenters/prisoner_details_presenter.rb
@@ -7,7 +7,8 @@ class PrisonerDetailsPresenter
 
   VALIDATION_ERRORS = [
     PrisonerValidation::UNKNOWN,
-    PrisonerLocationValidation::INVALID
+    PrisonerLocationValidation::INVALID,
+    PrisonerLocationValidation::UNKNOWN
   ].freeze
 
   def initialize(prisoner_validation, prisoner_location)
@@ -20,8 +21,6 @@ class PrisonerDetailsPresenter
     return VALID    if valid?
 
     case prisoner_existance_error
-    when nil
-      VALID
     when *VALIDATION_ERRORS
       prisoner_existance_error
     else
@@ -34,7 +33,7 @@ class PrisonerDetailsPresenter
   end
 
   def prisoner_existance_error
-    prisoner_validation_errors.first
+    prisoner_validation_errors.first || prisoner_location_error
   end
 
   def prisoner_location_error

--- a/app/presenters/prisoner_details_presenter.rb
+++ b/app/presenters/prisoner_details_presenter.rb
@@ -7,8 +7,7 @@ class PrisonerDetailsPresenter
 
   VALIDATION_ERRORS = [
     PrisonerValidation::UNKNOWN,
-    PrisonerLocationValidation::INVALID,
-    PrisonerLocationValidation::UNKNOWN
+    PrisonerLocationValidation::INVALID
   ].freeze
 
   def initialize(prisoner_validation, prisoner_location)
@@ -18,6 +17,8 @@ class PrisonerDetailsPresenter
 
   def prisoner_existance_status
     return NOT_LIVE unless Nomis::Api.enabled?
+    return VALID    if valid?
+
     case prisoner_existance_error
     when nil
       VALID
@@ -33,8 +34,16 @@ class PrisonerDetailsPresenter
   end
 
   def prisoner_existance_error
-    prisoner_validation_errors.first || prisoner_location_errors.first
+    prisoner_validation_errors.first
   end
+
+  def prisoner_location_error
+    prisoner_location_errors.first
+  end
+
+private
+
+  attr_accessor :prisoner_validation, :prisoner_location
 
   def prisoner_validation_errors
     @prisoner_validation_errors ||= prisoner_validation.tap(&:valid?).errors.full_messages
@@ -44,7 +53,7 @@ class PrisonerDetailsPresenter
     @prisoner_location_errors ||= prisoner_location.tap(&:valid?).errors.full_messages
   end
 
-private
-
-  attr_accessor :prisoner_validation, :prisoner_location
+  def valid?
+    prisoner_validation.valid? && prisoner_location.valid?
+  end
 end

--- a/app/services/prisoner_location_validation.rb
+++ b/app/services/prisoner_location_validation.rb
@@ -32,10 +32,7 @@ private
   end
 
   def located_at_given_prison
-    if prison_code.nil?
-      errors.add(:base, UNKNOWN)
-      return
-    end
+    return if prison_code.nil?
 
     unless establishment.code == prison_code
       errors.add(:base, INVALID)

--- a/app/services/prisoner_location_validation.rb
+++ b/app/services/prisoner_location_validation.rb
@@ -32,7 +32,10 @@ private
   end
 
   def located_at_given_prison
-    return if prison_code.nil?
+    if prison_code.nil?
+      errors.add(:base, UNKNOWN)
+      return
+    end
 
     unless establishment.code == prison_code
       errors.add(:base, INVALID)

--- a/app/views/prison/visits/_prisoner_details.html.erb
+++ b/app/views/prison/visits/_prisoner_details.html.erb
@@ -58,7 +58,7 @@
     <% case @visit.prisoner_existance_status %>
     <% when PrisonerDetailsPresenter::VALID %>
       <div class="font-xsmall tag tag--booked"><%= t('.verified') %></div>
-    <% when PrisonerLocationValidation::INVALID %>
+    <% when PrisonerDetailsPresenter::INVALID %>
       <div class="font-xsmall tag tag--error"><%= t(".#{@visit.prisoner_existance_status}") %></div>
     <% end %>
   </div>

--- a/app/views/prison/visits/_prisoner_details.html.erb
+++ b/app/views/prison/visits/_prisoner_details.html.erb
@@ -7,19 +7,20 @@
     </i>
     <strong class="bold-small"><%= t('.verified_html') %></strong>
   </div>
-<% when PrisonerDetailsPresenter::INVALID, PrisonerLocationValidation::INVALID %>
+<% when PrisonerDetailsPresenter::INVALID %>
   <div class="notice push-top">
     <i class="icon icon-information">
       <span class="visuallyhidden"><%= t('warning', scope: :shared) %></span>
     </i>
     <strong class="bold-small"><%= t(".#{@visit.prisoner_existance_error}_text") %></strong>
   </div>
-<% when PrisonerValidation::UNKNOWN, PrisonerLocationValidation::UNKNOWN %>
+<% end %>
+<% if @visit.prisoner_location_error %>
   <div class="notice push-top">
     <i class="icon icon-important">
       <span class="visuallyhidden"><%= t('warning', scope: :shared) %></span>
     </i>
-    <strong class="bold-small"><%= t(".#{@visit.prisoner_existance_error}_text") %></strong>
+    <strong class="bold-small"><%= t(".#{@visit.prisoner_location_error}_text") %></strong>
   </div>
 <% end %>
 
@@ -55,11 +56,13 @@
   <div class="column-one-quarter">
     <span class="text-secondary"><%= t('.prison_name') %></span>
     <div class="bold-small"><%= @visit.prison_name %></div>
-    <% case @visit.prisoner_existance_status %>
-    <% when PrisonerDetailsPresenter::VALID %>
+    <% case @visit.prisoner_location_error %>
+    <% when nil %>
       <div class="font-xsmall tag tag--booked"><%= t('.verified') %></div>
-    <% when PrisonerDetailsPresenter::INVALID %>
-      <div class="font-xsmall tag tag--error"><%= t(".#{@visit.prisoner_existance_status}") %></div>
+    <% when PrisonerLocationValidation::INVALID %>
+      <div class="font-xsmall tag tag--error"><%= t(".#{@visit.prisoner_location_error}") %></div>
+    <% when PrisonerLocationValidation::UNKNOWN %>
+      <div class="font-xsmall tag tag--warning"><%= t(".#{@visit.prisoner_location_error}") %></div>
     <% end %>
   </div>
 </div>
@@ -100,12 +103,14 @@
   <div class="column-one-quarter">
     <% if Nomis::Feature.internal_location_enabled? %>
       <span class="text-secondary"><%= t('.internal_location') %></span>
-      <div class="bold-small"><%= prisoner_details.internal_location%></div>
-      <% case @visit.prisoner_existance_status %>
-      <% when PrisonerDetailsPresenter::VALID %>
+      <div class="bold-small"><%= prisoner_details.internal_location %></div>
+      <% case @visit.prisoner_location_error %>
+      <% when nil %>
         <div class="font-xsmall tag tag--booked"><%= t('.verified') %></div>
       <% when PrisonerLocationValidation::INVALID %>
-        <div class="font-xsmall tag tag--error"><%= t(".#{@visit.prisoner_existance_status}") %></div>
+        <div class="font-xsmall tag tag--error"><%= t(".#{@visit.prisoner_location_error}") %></div>
+      <% when PrisonerLocationValidation::UNKNOWN %>
+        <div class="font-xsmall tag tag--warning"><%= t(".#{@visit.prisoner_location_error}") %></div>
       <% end %>
     <% end %>
   </div>

--- a/app/views/prison/visits/_prisoner_details.html.erb
+++ b/app/views/prison/visits/_prisoner_details.html.erb
@@ -7,7 +7,7 @@
     </i>
     <strong class="bold-small"><%= t('.verified_html') %></strong>
   </div>
-<% when PrisonerDetailsPresenter::INVALID %>
+<% when PrisonerDetailsPresenter::INVALID, PrisonerLocationValidation::INVALID %>
   <div class="notice push-top">
     <i class="icon icon-information">
       <span class="visuallyhidden"><%= t('warning', scope: :shared) %></span>
@@ -20,7 +20,7 @@
     <i class="icon icon-important">
       <span class="visuallyhidden"><%= t('warning', scope: :shared) %></span>
     </i>
-    <strong class="bold-small"><%= t(".#{@visit.prisoner_location_error}_text") %></strong>
+    <strong class="bold-small"><%= t(".#{@visit.prisoner_existance_error}_text") %></strong>
   </div>
 <% end %>
 

--- a/spec/presenters/prisoner_details_presenter_spec.rb
+++ b/spec/presenters/prisoner_details_presenter_spec.rb
@@ -43,14 +43,14 @@ RSpec.describe PrisonerDetailsPresenter do
           describe 'with an invalid location' do
             let(:code) { 'CCC' }
 
-            it { expect(subject.prisoner_existance_status).to eq('valid') }
+            it { expect(subject.prisoner_existance_status).to eq('location_invalid') }
             it { expect(subject.prisoner_location_error).to eq('location_invalid') }
           end
 
           describe 'with an unkown location' do
             let(:api_call_successful) { false }
 
-            it { expect(subject.prisoner_existance_status).to eq('valid') }
+            it { expect(subject.prisoner_existance_status).to eq('location_unknown') }
             it { expect(subject.prisoner_location_error).to eq('location_unknown') }
           end
         end

--- a/spec/presenters/prisoner_details_presenter_spec.rb
+++ b/spec/presenters/prisoner_details_presenter_spec.rb
@@ -43,13 +43,15 @@ RSpec.describe PrisonerDetailsPresenter do
           describe 'with an invalid location' do
             let(:code) { 'CCC' }
 
-            it { expect(subject.prisoner_existance_status).to eq('location_invalid') }
+            it { expect(subject.prisoner_existance_status).to eq('valid') }
+            it { expect(subject.prisoner_location_error).to eq('location_invalid') }
           end
 
           describe 'with an unkown location' do
             let(:api_call_successful) { false }
 
-            it { expect(subject.prisoner_existance_status).to eq('location_unknown') }
+            it { expect(subject.prisoner_existance_status).to eq('valid') }
+            it { expect(subject.prisoner_location_error).to eq('location_unknown') }
           end
         end
 


### PR DESCRIPTION
**CHANGES:**

When the call to the location API fails, the other prisoner validation aren't displayed