### PR TITLE
Add GA tracking for booked visits

### DIFF
--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -70,6 +70,7 @@ private
       ga_tracker.send_processing_timing
       ga_tracker.send_unexpected_rejection_event
       ga_tracker.send_rejection_event
+      ga_tracker.send_booked_visit_event
     end
   end
 

--- a/app/services/ga_tracker.rb
+++ b/app/services/ga_tracker.rb
@@ -24,6 +24,10 @@ class GATracker
     send_data(rejection_event_payload('Rejection')) if visit_rejected?
   end
 
+  def send_booked_visit_event
+    send_data(booked_visit_event_payload('Booked')) if visit.booked?
+  end
+
   def send_processing_timing
     return unless timing_value
     send_data(timing_payload_data)
@@ -44,6 +48,10 @@ private
       headers: { 'Content-Type' => 'application/x-www-form-urlencoded' },
       body:    URI.encode_www_form(payload)
     )
+  end
+
+  def booked_method
+    visit.nomis_id.nil? ? 'Manual' : 'NOMIS'
   end
 
   def visit_rejected_unexpectedly?
@@ -88,6 +96,14 @@ private
       v: 1, uip: ip, tid: web_property_id, cid: cookies['_ga'] || SecureRandom.base64,
       ua:  user_agent, t: 'event', ec: prison.name, ea: action,
       el: visit.rejection.reasons.sort.join('-')
+    }
+  end
+
+  def booked_visit_event_payload(action)
+    {
+      v: 1, uip: ip, tid: web_property_id, cid: cookies['_ga'] || SecureRandom.base64,
+      ua:  user_agent, t: 'event', ec: prison.name, ea: action,
+      el: booked_method
     }
   end
 

--- a/spec/controllers/prison/visits_controller_spec.rb
+++ b/spec/controllers/prison/visits_controller_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe Prison::VisitsController, type: :controller do
           expect(google_tracker).to receive(:send_processing_timing)
           expect(google_tracker).to receive(:send_unexpected_rejection_event)
           expect(google_tracker).to receive(:send_rejection_event)
+          expect(google_tracker).to receive(:send_booked_visit_event)
         end
 
         it { is_expected.to redirect_to(prison_inbox_path) }

--- a/spec/features/cancel_booked_to_nomis_visit_spec.rb
+++ b/spec/features/cancel_booked_to_nomis_visit_spec.rb
@@ -63,6 +63,7 @@ RSpec.feature 'Cancel a visit booked to NOMIS', js: true do
           send_processing_timing: nil,
           send_unexpected_rejection_event: nil,
           send_rejection_event: nil,
+          send_booked_visit_event: nil,
           set_visit_processing_time_cookie: nil))
   end
 

--- a/spec/fixtures/vcr_cassettes/book_to_nomis.yml
+++ b/spec/fixtures/vcr_cassettes/book_to_nomis.yml
@@ -35,7 +35,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"found":true,"offender":{"id":1057307}}'
-    http_version:
+    http_version: 
   recorded_at: Tue, 09 May 2017 23:00:00 GMT
 - request:
     method: get
@@ -72,7 +72,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"2017-06-27":{"external_movement":false,"existing_visits":[{"id":5555,"slot":"2017-06-27T10:00\/11:00"}],"out_of_vo":false,"banned":false}}'
-    http_version:
+    http_version: 
   recorded_at: Tue, 09 May 2017 23:00:00 GMT
 - request:
     method: get
@@ -109,7 +109,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"slots":[{"time":"2017-06-27T10:00\/11:00","capacity":100,"max_groups":100,"max_adults":100,"groups_booked":1,"visitors_booked":2,"adults_booked":2},{"time":"2017-06-27T14:00\/16:00","capacity":100,"max_groups":3,"max_adults":10,"groups_booked":0,"visitors_booked":0,"adults_booked":0}]}'
-    http_version:
+    http_version: 
   recorded_at: Tue, 09 May 2017 23:00:00 GMT
 - request:
     method: get
@@ -149,7 +149,7 @@ http_interactions:
         Family"},"approved_visitor":true,"active":true,"restrictions":[]},{"id":13428,"given_name":"IRMA","middle_names":"CHRISTINE","surname":"ITSU","date_of_birth":"1975-04-03","gender":{"code":"F","desc":"Female"},"relationship_type":{"code":"WIFE","desc":"Wife"},"contact_type":{"code":"S","desc":"Social\/
         Family"},"approved_visitor":true,"active":true,"restrictions":[]},{"id":13429,"given_name":"ISAIAH","surname":"ITSU","date_of_birth":"1981-11-16","gender":{"code":"M","desc":"Male"},"relationship_type":{"code":"BRO","desc":"Brother"},"contact_type":{"code":"S","desc":"Social\/
         Family"},"approved_visitor":true,"active":false,"restrictions":[]},{"id":13432,"given_name":"SHAY","surname":"DEE","date_of_birth":"1978-06-07","gender":{"code":"M","desc":"Male"},"relationship_type":{"code":"SOL","desc":"Solicitor"},"contact_type":{"code":"O","desc":"Official"},"approved_visitor":true,"active":false,"restrictions":[]}]}'
-    http_version:
+    http_version: 
   recorded_at: Tue, 09 May 2017 23:00:00 GMT
 - request:
     method: get
@@ -186,7 +186,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"restrictions":[]}'
-    http_version:
+    http_version: 
   recorded_at: Thu, 13 Jul 2017 14:40:38 GMT
 - request:
     method: post
@@ -223,7 +223,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"visit_id":5493}'
-    http_version:
+    http_version: 
   recorded_at: Tue, 09 May 2017 23:00:00 GMT
 - request:
     method: get
@@ -260,7 +260,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"establishment":{"code":"LEI","desc":"Leeds"},"housing_location":{"description":"LEI-H-1-003","levels":[{"type":"Wing","value":"2"},{"type":"Landing","value":"1"},{"type":"Cell","value":"1"}]}}'
-    http_version:
+    http_version: 
   recorded_at: Sun, 11 Jun 2017 23:00:00 GMT
 - request:
     method: get
@@ -298,6 +298,51 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"given_name":"IZZY","surname":"ITSU","date_of_birth":"1971-11-11","aliases":[],"gender":{"code":"M","desc":"Male"},"convicted":true,"imprisonment_status":{"code":"UNK_SENT","desc":"Unknown
         Sentenced"},"iep_level":{"code":"STD","desc":"Standard"}}'
-    http_version:
+    http_version: 
   recorded_at: Sun, 11 Jun 2017 23:00:00 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: post
+    uri: https://www.google-analytics.com/collect
+    body:
+      encoding: US-ASCII
+      string: v=1&uip=127.0.0.1&tid=UA-105607968-1&cid=GA1.4.23189845.1519981629&ua=Mozilla%2F5.0+%28Macintosh%3B+Intel+Mac+OS+X+10.13%3B+rv%3A57.0%29+Gecko%2F20100101+Firefox%2F57.0&t=event&ec=Leicester&ea=Booked
+    headers:
+      User-Agent:
+      - excon/0.60.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Date:
+      - Fri, 02 Mar 2018 09:07:11 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Last-Modified:
+      - Sun, 17 May 1998 03:00:00 GMT
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - image/gif
+      Server:
+      - Golfe2
+      Content-Length:
+      - '35'
+      Alt-Svc:
+      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303338; quic=51303337;
+        quic=51303335,quic=":443"; ma=2592000; v="41,39,38,37,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhAQABAID/AP///wAAACwAAAAAAQABAAACAkQBADs=
+    http_version: 
+  recorded_at: Sun, 11 Jun 2017 23:00:00 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/book_to_nomis_duplicate.yml
+++ b/spec/fixtures/vcr_cassettes/book_to_nomis_duplicate.yml
@@ -146,7 +146,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"slots":[{"time":"2017-06-20T10:00\/11:00","capacity":100,"max_groups":100,"max_adults":100,"groups_booked":1,"visitors_booked":2,"adults_booked":2},{"time":"2017-06-20T14:00\/16:00","capacity":100,"max_groups":3,"max_adults":10,"groups_booked":0,"visitors_booked":0,"adults_booked":0}]}'
-    http_version:
+    http_version: 
   recorded_at: Sun, 11 Jun 2017 23:00:00 GMT
 - request:
     method: get
@@ -183,7 +183,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"restrictions":[]}'
-    http_version:
+    http_version: 
   recorded_at: Thu, 13 Jul 2017 14:40:38 GMT
 - request:
     method: get
@@ -410,7 +410,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"slots":[{"time":"2017-06-20T10:00\/11:00","capacity":100,"max_groups":100,"max_adults":100,"groups_booked":1,"visitors_booked":2,"adults_booked":2},{"time":"2017-06-20T14:00\/16:00","capacity":100,"max_groups":3,"max_adults":10,"groups_booked":0,"visitors_booked":0,"adults_booked":0}]}'
-    http_version:
+    http_version: 
   recorded_at: Sun, 11 Jun 2017 23:00:00 GMT
 - request:
     method: get
@@ -447,7 +447,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"restrictions":[]}'
-    http_version:
+    http_version: 
   recorded_at: Thu, 13 Jul 2017 14:40:38 GMT
 - request:
     method: get
@@ -489,4 +489,49 @@ http_interactions:
         Family"},"approved_visitor":true,"active":false,"restrictions":[]},{"id":13432,"given_name":"SHAY","surname":"DEE","date_of_birth":"1978-06-07","gender":{"code":"M","desc":"Male"},"relationship_type":{"code":"SOL","desc":"Solicitor"},"contact_type":{"code":"O","desc":"Official"},"approved_visitor":true,"active":false,"restrictions":[]}]}'
     http_version: 
   recorded_at: Sun, 11 Jun 2017 23:00:00 GMT
-recorded_with: VCR 3.0.3
+- request:
+    method: post
+    uri: https://www.google-analytics.com/collect
+    body:
+      encoding: US-ASCII
+      string: v=1&uip=127.0.0.1&tid=UA-105607968-1&cid=GA1.4.1674248177.1519981524&ua=Mozilla%2F5.0+%28Macintosh%3B+Intel+Mac+OS+X+10.13%3B+rv%3A57.0%29+Gecko%2F20100101+Firefox%2F57.0&t=event&ec=Leicester&ea=Booked
+    headers:
+      User-Agent:
+      - excon/0.60.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Date:
+      - Fri, 02 Mar 2018 09:05:25 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Last-Modified:
+      - Sun, 17 May 1998 03:00:00 GMT
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - image/gif
+      Server:
+      - Golfe2
+      Content-Length:
+      - '35'
+      Alt-Svc:
+      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303338; quic=51303337;
+        quic=51303335,quic=":443"; ma=2592000; v="41,39,38,37,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhAQABAID/AP///wAAACwAAAAAAQABAAACAkQBADs=
+    http_version: 
+  recorded_at: Sun, 11 Jun 2017 23:00:00 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/booked_visit_event.yml
+++ b/spec/fixtures/vcr_cassettes/booked_visit_event.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.google-analytics.com/collect
+    body:
+      encoding: US-ASCII
+      string: v=1&uip=166.29.34.238&tid=UA-96772907-2&cid=some_client_id&ua=some+user+agent+string&t=event&ec=Triciaberg+Open+Prison&ea=Booked&el=Manual
+    headers:
+      User-Agent:
+      - excon/0.60.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Date:
+      - Mon, 05 Mar 2018 09:42:54 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Last-Modified:
+      - Sun, 17 May 1998 03:00:00 GMT
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - image/gif
+      Server:
+      - Golfe2
+      Content-Length:
+      - '35'
+      Alt-Svc:
+      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303338; quic=51303337;
+        quic=51303335,quic=":443"; ma=2592000; v="41,39,38,37,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhAQABAID/AP///wAAACwAAAAAAQABAAACAkQBADs=
+    http_version: 
+  recorded_at: Mon, 05 Mar 2018 09:42:54 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/booked_with_nomis_visit_event.yml
+++ b/spec/fixtures/vcr_cassettes/booked_with_nomis_visit_event.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.google-analytics.com/collect
+    body:
+      encoding: US-ASCII
+      string: v=1&uip=63.49.124.25&tid=UA-96772907-2&cid=some_client_id&ua=some+user+agent+string&t=event&ec=Gibsonchester+Open+Prison&ea=Booked&el=NOMIS
+    headers:
+      User-Agent:
+      - excon/0.60.0
+      Content-Type:
+      - application/x-www-form-urlencoded
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Date:
+      - Mon, 05 Mar 2018 09:55:24 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Last-Modified:
+      - Sun, 17 May 1998 03:00:00 GMT
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - image/gif
+      Server:
+      - Golfe2
+      Content-Length:
+      - '35'
+      Alt-Svc:
+      - hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303338; quic=51303337;
+        quic=51303335,quic=":443"; ma=2592000; v="41,39,38,37,35"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        R0lGODlhAQABAID/AP///wAAACwAAAAAAQABAAACAkQBADs=
+    http_version: 
+  recorded_at: Mon, 05 Mar 2018 09:55:24 GMT
+recorded_with: VCR 4.0.0

--- a/spec/services/ga_tracker_spec.rb
+++ b/spec/services/ga_tracker_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe GATracker do
               el: "slot_unavailable"
             ),
             headers: { 'Content-Type' => 'application/x-www-form-urlencoded', 'Host' => 'www.google-analytics.com:443', 'User-Agent' => Excon::USER_AGENT }
-        )
+          )
       end
     end
 
@@ -105,6 +105,61 @@ RSpec.describe GATracker do
               ec: visit.prison.name,
               ea: 'Rejection',
               el: "prisoner_details_incorrect"
+            ),
+            headers: { 'Content-Type' => 'application/x-www-form-urlencoded', 'Host' => 'www.google-analytics.com:443', 'User-Agent' => Excon::USER_AGENT }
+          )
+      end
+    end
+  end
+
+  describe '#send_booked_visit_event' do
+    before do
+      accept_visit(visit, visit.slots.first)
+      cookies['_ga'] = 'some_client_id'
+      switch_feature_flag_with :ga_id, web_property_id
+    end
+    context "when the visit was booked manually" do
+      it 'sends an event', vcr: { cassette_name: 'booked_visit_event' } do
+        subject.send_booked_visit_event
+
+        expect(WebMock).
+          to have_requested(:post, GATracker::ENDPOINT).with(
+            body: URI.encode_www_form(
+              v: 1,
+              uip: ip,
+              tid: web_property_id,
+              cid: "some_client_id",
+              ua: user_agent,
+              t: "event",
+              ec: visit.prison.name,
+              ea: 'Booked',
+              el: 'Manual'
+            ),
+            headers: { 'Content-Type' => 'application/x-www-form-urlencoded', 'Host' => 'www.google-analytics.com:443', 'User-Agent' => Excon::USER_AGENT }
+          )
+      end
+    end
+
+    context 'when the visit was booked via the NOMIS API' do
+      before do
+        visit.nomis_id = '12345'
+        visit.save!
+      end
+      it 'sends an event', vcr: { cassette_name: 'booked_with_nomis_visit_event' } do
+        subject.send_booked_visit_event
+
+        expect(WebMock).
+          to have_requested(:post, GATracker::ENDPOINT).with(
+            body: URI.encode_www_form(
+              v: 1,
+              uip: ip,
+              tid: web_property_id,
+              cid: "some_client_id",
+              ua: user_agent,
+              t: "event",
+              ec: visit.prison.name,
+              ea: 'Booked',
+              el: 'NOMIS'
             ),
             headers: { 'Content-Type' => 'application/x-www-form-urlencoded', 'Host' => 'www.google-analytics.com:443', 'User-Agent' => Excon::USER_AGENT }
         )


### PR DESCRIPTION
Following the addition of the GA tracking to send data for all rejected
visits, we wanted to include tracking for all booked visits too.