### PR TITLE
Add Firefox browser and Geckodriver versions to dependencies section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ The source of the predecessor can be found at
 - [Sidekiq](https://sidekiq.org/) - for background processing.
 - [Redis](https://redis.io/) - for managing queues (required by Sidekiq)
 - [Postgres](https://www.postgresql.org/) - for persisting data
+- [Firefox browser v57.0.4](https://download-installer.cdn.mozilla.net/pub/firefox/releases/57.0.4/mac/en-US/Firefox%2057.0.4.dmg)
 - [Selenium webdriver](https://www.seleniumhq.org/projects/webdriver/) - for executing tests against different browsers.
-- [Geckodriver](https://github.com/mozilla/geckodriver) - for executing tests against the firefox browser.
+- [Geckodriver v0.19.1](https://github.com/mozilla/geckodriver) - for executing tests against the firefox browser.
 - [direnv](https://direnv.net/) - for managing environment variables and storing credentials.
 - [NOMIS API access](http://ministryofjustice.github.io/nomis-api/) - prison and offender data is accessed via the National Offender Management Information System. An [authentication token](https://nomis-api-access.service.justice.gov.uk/) is required to access this.
 - (Optional) Transifex Client - for managing site translation. See [additional documentation](docs/welsh_translation.md) for setup and updating translations.       


### PR DESCRIPTION
If the latest version of Firefox is installed locally then the tests break.