### PR TITLE
Change feedback link to banner

### DIFF
--- a/app/assets/stylesheets/_helpers.scss
+++ b/app/assets/stylesheets/_helpers.scss
@@ -28,6 +28,9 @@
 .push-right--half {
   margin-right: $gutter-half;
 }
+.push--none {
+  margin: 0;
+}
 .text-left {
   text-align: left !important;
 }

--- a/app/assets/stylesheets/_navigation.scss
+++ b/app/assets/stylesheets/_navigation.scss
@@ -87,3 +87,7 @@
     }
   }
 }
+.phase-banner + .navigation {
+  border-top: 0;
+  margin-top: 0;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,7 +48,9 @@
   <![endif]-->
 
   <main id="content">
-    <a target="_blank" href="https://www.surveymonkey.co.uk/r/36LDWKD" class="feedback-link hidden--print"><%= t('.feedback') %></a>
+    <p class="phase-banner push-top--half push--none font-xsmall">
+      <%= t('.contact_banner_html', url: new_prison_feedback_path) %>
+    </p>
     <%= yield :banner %>
     <%= yield :navigation %>
     <% if content_for?(:header) %>

--- a/app/views/staff_info/show.html.erb
+++ b/app/views/staff_info/show.html.erb
@@ -19,7 +19,7 @@
 <div class="grid-row">
   <div class="column-one-third">
     <h2>
-      <%= link_to 'Contact Us', new_prison_feedback_path %>
+      <%= link_to 'Contact us', new_prison_feedback_path %>
     </h2>
     <p>If you need any help or something changed</p>
   </div>

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -3,6 +3,8 @@ en:
     none: None
   layouts:
     application:
+      contact_banner_html: |
+        <a href='%{url}'>Contact us</a> with feedback or to let us know about a problem.
       contact_us: Contact us
       cookies_intro: GOV.UK uses cookies to make the site simpler.
       downloads: Downloads


### PR DESCRIPTION
Change the Feedback link from Survey Monkey to our Zendesk contact page as no one is tasked to monitoring this feedback or managing the expectation of the staff who take the time out to use this channel.