### PR TITLE
Remove STAFF_PRISONER_AVAILABILITY_ENABLED flag

### DIFF
--- a/app/decorators/concrete_slot_decorator.rb
+++ b/app/decorators/concrete_slot_decorator.rb
@@ -94,7 +94,6 @@ private
 
   def prisoner_available?
     object.to_date.future? &&
-    Nomis::Feature.prisoner_availability_enabled? &&
       !nomis_checker.prisoner_availability_unknown? &&
       errors.none? do |e|
         PrisonerAvailabilityValidation::PRISONER_ERRORS.include?(e)

--- a/app/services/book_to_nomis_config.rb
+++ b/app/services/book_to_nomis_config.rb
@@ -46,8 +46,7 @@ private
   end
 
   def prisoner_availability_working?
-    Nomis::Feature.prisoner_availability_enabled? &&
-      !staff_nomis_checker.prisoner_availability_unknown?
+    !staff_nomis_checker.prisoner_availability_unknown?
   end
 
   def slot_availability_working?

--- a/app/services/nomis/feature.rb
+++ b/app/services/nomis/feature.rb
@@ -1,9 +1,5 @@
 module Nomis
   class Feature
-    def self.prisoner_availability_enabled?
-      Nomis::Api.enabled? && config.nomis_staff_prisoner_availability_enabled
-    end
-
     def self.slot_availability_enabled?(prison_name)
       Nomis::Api.enabled? && config.nomis_staff_slot_availability_enabled &&
         config.staff_prisons_with_slot_availability.include?(prison_name)

--- a/app/services/staff_nomis_checker.rb
+++ b/app/services/staff_nomis_checker.rb
@@ -5,8 +5,7 @@ class StaffNomisChecker
   end
 
   def prisoner_availability_unknown?
-    Nomis::Feature.prisoner_availability_enabled? &&
-      prisoner_availability_validation.unknown_result?
+    prisoner_availability_validation.unknown_result?
   end
 
   def slot_availability_unknown?
@@ -76,7 +75,7 @@ private
   end
 
   def prisoner_availability_errors(slot)
-    if Nomis::Feature.prisoner_availability_enabled? && offender.valid?
+    if offender.valid?
       prisoner_availability_validation.slot_errors(slot)
     else
       []

--- a/config/application.rb
+++ b/config/application.rb
@@ -97,10 +97,6 @@ module PrisonVisits
     # Prisoner availability depends on the prisoner check flag because to check
     # the availability we need to call the api used in the prisoner check to get
     # the offender id.
-    config.nomis_staff_prisoner_availability_enabled = feature_flag_value.call do
-      config.nomis_staff_prisoner_check_enabled &&
-      ENV['NOMIS_STAFF_PRISONER_AVAILABILITY_ENABLED']&.downcase == 'true'
-    end
 
     config.nomis_public_prisoner_availability_enabled = feature_flag_value.call do
       config.nomis_public_prisoner_check_enabled &&

--- a/spec/decorators/concrete_slot_decorator_spec.rb
+++ b/spec/decorators/concrete_slot_decorator_spec.rb
@@ -36,9 +36,6 @@ RSpec.describe ConcreteSlotDecorator do
 
     describe 'prisoner availability' do
       context 'when the api is enabled' do
-        before do
-          switch_on :nomis_staff_prisoner_availability_enabled
-        end
         context 'with a closed restriction' do
           let(:slot_errors) { [Nomis::Restriction::CLOSED_NAME] }
 
@@ -89,7 +86,7 @@ RSpec.describe ConcreteSlotDecorator do
 
       context 'when the api is disabled' do
         before do
-          switch_off :nomis_staff_prisoner_availability_enabled
+          switch_off_api
         end
 
         it 'renders the checkbox without errors' do
@@ -159,10 +156,6 @@ RSpec.describe ConcreteSlotDecorator do
 
   describe '#bookable?' do
     context 'when the prisoner is avaliable' do
-      before do
-        switch_on :nomis_staff_prisoner_availability_enabled
-      end
-
       context 'when the slot is not avaliable' do
         before do
           switch_on :nomis_staff_slot_availability_enabled
@@ -185,10 +178,6 @@ RSpec.describe ConcreteSlotDecorator do
     end
 
     context 'when the prisoner is not avaliable' do
-      before do
-        switch_on :nomis_staff_prisoner_availability_enabled
-      end
-
       let(:slot_errors) { ['prisoner_banned'] }
 
       context 'when the slot is avaliable' do

--- a/spec/features/cancel_booked_to_nomis_visit_spec.rb
+++ b/spec/features/cancel_booked_to_nomis_visit_spec.rb
@@ -69,7 +69,6 @@ RSpec.feature 'Cancel a visit booked to NOMIS', js: true do
   context 'with book to nomis enabled' do
     before do
       switch_on :nomis_staff_prisoner_check_enabled
-      switch_on :nomis_staff_prisoner_availability_enabled
 
       switch_on :nomis_staff_slot_availability_enabled
       switch_feature_flag_with(:staff_prisons_with_slot_availability, [prison.name])

--- a/spec/features/process_a_request_accept_with_contact_list_spec.rb
+++ b/spec/features/process_a_request_accept_with_contact_list_spec.rb
@@ -28,7 +28,6 @@ RSpec.feature 'Processing a request - Acceptance with the contact list enabled',
   context 'with book to nomis enabled' do
     before do
       switch_on :nomis_staff_prisoner_check_enabled
-      switch_on :nomis_staff_prisoner_availability_enabled
 
       switch_on :nomis_staff_book_to_nomis_enabled
       switch_feature_flag_with(:staff_prisons_with_book_to_nomis, [prison.name])
@@ -129,9 +128,7 @@ RSpec.feature 'Processing a request - Acceptance with the contact list enabled',
   context 'when book to nomis is not enabled' do
     before do
       switch_off :nomis_staff_book_to_nomis_enabled
-
       switch_on :nomis_staff_prisoner_check_enabled
-      switch_on :nomis_staff_prisoner_availability_enabled
     end
 
     scenario 'accepting a booking', vcr: { cassette_name: 'process_happy_path_with_contact_list' } do

--- a/spec/features/process_a_request_nomis_disabled_spec.rb
+++ b/spec/features/process_a_request_nomis_disabled_spec.rb
@@ -29,7 +29,6 @@ RSpec.feature 'Processing a request - NOMIS API disasbled', :js do
     before do
       switch_off_api
       switch_on :nomis_staff_prisoner_check_enabled
-      switch_on :nomis_staff_prisoner_availability_enabled
 
       switch_on :nomis_staff_book_to_nomis_enabled
       switch_feature_flag_with(:staff_prisons_with_book_to_nomis, [prison.name])

--- a/spec/features/process_a_request_unprocessable_spec.rb
+++ b/spec/features/process_a_request_unprocessable_spec.rb
@@ -57,7 +57,6 @@ RSpec.feature 'Processing a request', js: true do
     end
 
     before do
-      switch_on :nomis_staff_prisoner_availability_enabled
       switch_on :nomis_staff_prisoner_check_enabled
 
       switch_on :nomis_staff_book_to_nomis_enabled

--- a/spec/services/book_to_nomis_config_spec.rb
+++ b/spec/services/book_to_nomis_config_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe BookToNomisConfig do
 
   shared_context 'with prisoner availability working' do
     before do
-      allow(Nomis::Feature).to receive(:prisoner_availability_enabled?).and_return(true)
       allow(checker).to receive(:prisoner_availability_unknown?).and_return(false)
     end
   end
@@ -128,7 +127,7 @@ RSpec.describe BookToNomisConfig do
       it { is_expected.not_to be_possible_to_book }
     end
 
-    context 'when all the prisoner availability is not working' do
+    context 'with the api call response being unknown for the prisoner availability' do
       include_context 'when not booked in NOMIS'
       include_context 'with book to nomis enabled'
       include_context 'with prisoner exists'
@@ -136,22 +135,11 @@ RSpec.describe BookToNomisConfig do
       include_context 'with contact list working'
       include_context 'with offender restrictions working'
 
-      context 'with the feature being disabled' do
-        before do
-          expect(Nomis::Feature).to receive(:prisoner_availability_enabled?).and_return(false)
-        end
-
-        it { is_expected.not_to be_possible_to_book }
+      before do
+        expect(checker).to receive(:prisoner_availability_unknown?).and_return(true)
       end
 
-      context 'with the api call response being unknown' do
-        before do
-          allow(Nomis::Feature).to receive(:prisoner_availability_enabled?).and_return(true)
-          expect(checker).to receive(:prisoner_availability_unknown?).and_return(true)
-        end
-
-        it { is_expected.not_to be_possible_to_book }
-      end
+      it { is_expected.not_to be_possible_to_book }
     end
 
     context 'when all the slot availability is not working' do

--- a/spec/services/nomis/feature_spec.rb
+++ b/spec/services/nomis/feature_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Nomis::Feature do
       switch_off_api
     end
 
-    it { expect(described_class.prisoner_availability_enabled?).to eq(false) }
     it { expect(described_class.slot_availability_enabled?(anything)).to eq(false) }
   end
 
@@ -18,10 +17,6 @@ RSpec.describe Nomis::Feature do
     it { expect(described_class).not_to be_offender_restrictions_enabled }
 
     context 'with the prisoner check enabled' do
-      before do
-        switch_on :nomis_staff_prisoner_check_enabled
-      end
-
       context 'with the offender restrictions enabled' do
         before do
           switch_on :nomis_staff_offender_restrictions_enabled
@@ -36,24 +31,6 @@ RSpec.describe Nomis::Feature do
         end
 
         it { expect(described_class).not_to be_offender_restrictions_enabled }
-      end
-    end
-
-    describe '.prisoner_availability_enabled?' do
-      context 'when the prisoner availability is disabled' do
-        before do
-          switch_off :nomis_staff_prisoner_availability_enabled
-        end
-
-        it { expect(described_class.prisoner_availability_enabled?).to eq(false) }
-      end
-
-      context 'when the prisoner availability enabled' do
-        before do
-          switch_on :nomis_staff_prisoner_availability_enabled
-        end
-
-        it { expect(described_class.prisoner_availability_enabled?).to eq(true) }
       end
     end
   end


### PR DESCRIPTION
The STAFF_PRISONER_AVAILABILITY_ENABLED feature has been successfully
rolled out to all prisons and no longer requires a flag to toggle this
on or off.  This piece of work removes the flag and reduces complexity
within the code.