### PR TITLE
Remove PUBLIC_PRISONER_AVAILABILITY_ENABLED flag

### DIFF
--- a/app/models/api_slot_availability.rb
+++ b/app/models/api_slot_availability.rb
@@ -8,8 +8,7 @@ class ApiSlotAvailability
 
   # rubocop:disable Metrics/MethodLength
   def restrict_by_prisoner(prisoner_number:, prisoner_dob:)
-    # Skip restriction if prisoner availability is enabled
-    return unless public_prisoner_availability_enabled?
+    return unless Nomis::Api.enabled?
 
     offender = Nomis::Api.instance.lookup_active_offender(
       noms_id: prisoner_number,
@@ -53,10 +52,5 @@ private
 
   def public_prison_slots_enabled?(_prison)
     false
-  end
-
-  def public_prisoner_availability_enabled?
-    Nomis::Api.enabled? &&
-      Rails.configuration.nomis_public_prisoner_availability_enabled
   end
 end

--- a/app/services/slot_availability.rb
+++ b/app/services/slot_availability.rb
@@ -32,7 +32,7 @@ private
   attr_reader :prison, :noms_id, :date_of_birth, :start_date, :end_date
 
   def prisoner_unavailable?(slot)
-    nomis_public_prisoner_availability_enabled? &&
+    Nomis::Api.enabled? &&
       offender.valid? &&
       !offender_availability_dates.include?(slot.to_date)
   end
@@ -73,11 +73,6 @@ private
 
   def offender_availability_dates
     @offender_availability_dates ||= offender_availability[:dates]
-  end
-
-  def nomis_public_prisoner_availability_enabled?
-    Nomis::Api.enabled? &&
-      Rails.configuration.nomis_public_prisoner_availability_enabled
   end
 
   def calculate_end_date(date_range)

--- a/config/application.rb
+++ b/config/application.rb
@@ -94,15 +94,6 @@ module PrisonVisits
       ENV['NOMIS_PUBLIC_PRISONER_CHECK_ENABLED']&.downcase == 'true'
     end
 
-    # Prisoner availability depends on the prisoner check flag because to check
-    # the availability we need to call the api used in the prisoner check to get
-    # the offender id.
-
-    config.nomis_public_prisoner_availability_enabled = feature_flag_value.call do
-      config.nomis_public_prisoner_check_enabled &&
-      ENV['NOMIS_PUBLIC_PRISONER_AVAILABILITY_ENABLED']&.downcase == 'true'
-    end
-
     config.nomis_staff_slot_availability_enabled = feature_flag_value.call do
       ENV['NOMIS_STAFF_SLOT_AVAILABILITY_ENABLED']&.downcase == 'true'
     end

--- a/spec/models/api_slot_availability_spec.rb
+++ b/spec/models/api_slot_availability_spec.rb
@@ -104,10 +104,6 @@ RSpec.describe ApiSlotAvailability, type: :model do
     end
 
     describe 'restricting by prisoner availability' do
-      before do
-        switch_on :nomis_public_prisoner_availability_enabled
-      end
-
       it 'can intersect available slots with prisoner availability' do
         offender = Nomis::Offender.new(id: 123)
         prisoner_availability = Nomis::PrisonerAvailability.new(

--- a/spec/services/slot_availability_spec.rb
+++ b/spec/services/slot_availability_spec.rb
@@ -1,3 +1,4 @@
+
 require "rails_helper"
 
 RSpec.describe SlotAvailability do
@@ -56,7 +57,7 @@ RSpec.describe SlotAvailability do
   describe '#slots' do
     context 'with the api disabled' do
       before do
-        allow(Nomis::Api).to receive(:enabled?).and_return(false)
+        switch_off_api
       end
 
       it { expect(subject.slots).to eq(all_slots_available) }
@@ -68,9 +69,9 @@ RSpec.describe SlotAvailability do
         mock_service_with(SlotAvailabilityValidation, slot_availability)
       end
 
-      describe 'with nomis public prisoner check enabled' do
+      describe 'with a successful nomis public prisoner check api call' do
         before do
-          switch_on :nomis_public_prisoner_availability_enabled
+          switch_on_api
           mock_nomis_with(:lookup_active_offender, offender)
         end
 
@@ -136,24 +137,6 @@ RSpec.describe SlotAvailability do
           end
         end
       end
-
-      describe 'without nomis public prisoner check enabled' do
-        it 'applies the prison availability' do
-          expect(subject.slots).to eq(
-            "2017-02-07T09:00/10:00" => [],
-            "2017-02-07T14:00/16:10" => [],
-            "2017-02-13T14:00/16:10" => [],
-            "2017-02-14T09:00/10:00" => [],
-            "2017-02-14T14:00/16:10" => [],
-            "2017-02-20T14:00/16:10" => [],
-            "2017-02-21T09:00/10:00" => [],
-            "2017-02-21T14:00/16:10" => [],
-            "2017-02-27T14:00/16:10" => [],
-            "2017-02-28T09:00/10:00" => ['prison_unavailable'],
-            "2017-02-28T14:00/16:10" => []
-          )
-        end
-      end
     end
 
     describe 'with a prison not in the trial' do
@@ -163,7 +146,6 @@ RSpec.describe SlotAvailability do
 
       describe 'and prisoner availability enabled' do
         before do
-          switch_on :nomis_public_prisoner_availability_enabled
           mock_nomis_with(:lookup_active_offender, offender)
           mock_nomis_with(:offender_visiting_availability, prisoner_availability)
         end
@@ -186,7 +168,7 @@ RSpec.describe SlotAvailability do
 
       describe 'and prisoner availability disabled' do
         before do
-          switch_off(:nomis_public_prisoner_availability_enabled)
+          switch_off_api
         end
 
         it { expect(subject.slots).to eq(all_slots_available) }

--- a/spec/support/helpers/service_helpers.rb
+++ b/spec/support/helpers/service_helpers.rb
@@ -7,6 +7,10 @@ module ServiceHelpers
     allow(Nomis::Api).to receive(:enabled?).and_return(false)
   end
 
+  def switch_on_api
+    allow(Nomis::Api).to receive(:enabled?).and_return(true)
+  end
+
   def mock_service_with(klass, double_or_spy)
     expect(klass).to receive(:new).and_return(double_or_spy)
   end


### PR DESCRIPTION
The PUBLIC_PRISONER_AVAILABILITY_ENABLED feature has been successfully
rolled out across all prisons and no longer requires a flag to toggle
this on or off. This piece of work removes the flag and reduces
complexity within the code.