### PR TITLE
Correctly display prisoner restrictions error message

### DIFF
--- a/app/services/staff_nomis_checker.rb
+++ b/app/services/staff_nomis_checker.rb
@@ -14,7 +14,7 @@ class StaffNomisChecker
   end
 
   def prisoner_restrictions_unknown?
-    Nomis::Feature.offender_restrictions_enabled? &&
+    Nomis::Feature.offender_restrictions_info_enabled?(@visit.prison_name) &&
       prisoner_restriction_list.unknown_result?
   end
 


### PR DESCRIPTION
When the NOMIS api is down staff are seeing an error message stating
that we are unable to display the prisoner restrictions and they need
to check this manually.  However, this should only be displayed to
those prisons where this feature is enabled, not in all prisons.