### PR TITLE
Correctly display prisoner restrictions error message

### DIFF
--- a/app/services/staff_nomis_checker.rb
+++ b/app/services/staff_nomis_checker.rb
@@ -14,7 +14,7 @@ class StaffNomisChecker
   end
 
   def prisoner_restrictions_unknown?
-    Nomis::Feature.offender_restrictions_enabled? &&
+    Nomis::Feature.offender_restrictions_info_enabled?(@visit.prison_name) &&
       prisoner_restriction_list.unknown_result?
   end
 

--- a/spec/services/staff_nomis_checker_spec.rb
+++ b/spec/services/staff_nomis_checker_spec.rb
@@ -346,6 +346,7 @@ RSpec.describe StaffNomisChecker do
 
       before do
         switch_on(:nomis_staff_offender_restrictions_enabled)
+        switch_feature_flag_with(:staff_prisons_with_prisoner_restrictions_info, %w[Pentonville])
         mock_nomis_with(:lookup_active_offender, offender)
         expect(restrictions_list).to receive(:unknown_result?).and_return(offender_restrictions_api_error)
         mock_service_with(PrisonerRestrictionList, restrictions_list)


### PR DESCRIPTION
When the NOMIS api is down staff are seeing an error message stating
that we are unable to display the prisoner restrictions and they need
to check this manually.  However, this should only be displayed to
those prisons where this feature is enabled, not in all prisons.