### PR TITLE
Add missing translations

### DIFF
--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -184,6 +184,8 @@ en:
         location_invalid_text: The prisoner is not registered at this prison.
         location_unknown_text: Check NOMIS to verify prisoner location.
         prisoner_does_not_exist_text: The prisoner date of birth and number do not match.
+        invalid: Not verified
+        unknown: Unknown
         unknown_text: "The check couldn't take place due to a system error, please verify manually"
         verified: NOMIS verified
         verified_html: |


### PR DESCRIPTION
Add missing translations for "invalid" and "unknown" within the
prisoner_details section of the prison_views.yml file.