### PR TITLE
Update CreateNomisVisit to reflect api changes

### DIFF
--- a/app/services/create_nomis_visit.rb
+++ b/app/services/create_nomis_visit.rb
@@ -47,7 +47,10 @@ private
       lead_contact: visit.principal_visitor.nomis_id,
       other_contacts: visit.allowed_additional_visitors.map(&:nomis_id),
       slot: visit.slot_granted.to_s,
-      override_restrictions: false,
+      override_offender_restrictions: false,
+      override_visitor_restrictions: false,
+      override_vo_balance: false,
+      override_slot_capacity: false,
       client_unique_ref: visit.id
     }
   end

--- a/spec/services/create_nomis_visit_spec.rb
+++ b/spec/services/create_nomis_visit_spec.rb
@@ -32,7 +32,10 @@ RSpec.describe CreateNomisVisit do
                  lead_contact: lead_visitor.nomis_id,
                  other_contacts: [additional_visitor.nomis_id],
                  slot: visit.slot_granted.to_s,
-                 override_restrictions: false,
+                 override_offender_restrictions: false,
+                 override_visitor_restrictions: false,
+                 override_vo_balance: false,
+                 override_slot_capacity: false,
                  client_unique_ref: visit.id
                }).and_return(Nomis::Booking.new)
 

--- a/spec/services/nomis/api_spec.rb
+++ b/spec/services/nomis/api_spec.rb
@@ -293,7 +293,10 @@ RSpec.describe Nomis::Api do
         lead_contact: 12_588,
         other_contacts: [13_428],
         slot: '2017-05-15T10:00/16:00',
-        override_restrictions: false,
+        override_offender_restrictions: false,
+        override_visitor_restrictions: false,
+        override_vo_balance: false,
+        override_slot_capacity: false,
         client_unique_ref: 'visit_id_1234'
       }
     end


### PR DESCRIPTION
The Nomis api has been updated to include additional options to
override certain restrictions.  The original flag was
"override_restrictions",but this has been separated out to allow a
greater degree of configuration depending on the situation.  The new
options are:

override_offender_restrictions
override_visitor_restrictions
override_vo_balance
override_slot_capacity

At present we do not allow overriding of any restrictions so the default setting for all of these options is false.