### PR TITLE
Remove did-you-mean version from Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -391,7 +391,7 @@ DEPENDENCIES
   capybara
   connection_pool
   database_cleaner
-  did_you_mean (~> 1.1.0)
+  did_you_mean
   draper
   email_address_validation!
   excon


### PR DESCRIPTION
A change was merged into master that is now causing our deploys to fail
so we need to remove this.