### PR TITLE
Format date selection display

### DIFF
--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -19,3 +19,7 @@
   line-height: 1;
   margin-top: 27px;
 }
+
+.button-secondary {
+  @include button($grey-3);
+}

--- a/app/decorators/concrete_slot_decorator.rb
+++ b/app/decorators/concrete_slot_decorator.rb
@@ -140,7 +140,7 @@ private
   def options_for_label_key
     {
       day:  h.format_date_day(object),
-      date: h.format_date_of_birth(object),
+      date: h.format_date(object),
       time: h.format_slot_times(object),
       scope: %w[prison visits visit_date_section]
     }

--- a/app/helpers/date_helper.rb
+++ b/app/helpers/date_helper.rb
@@ -1,15 +1,19 @@
 module DateHelper
-  def format_date_of_birth(date)
-    I18n.l(date.to_date, format: :date_of_birth)
+  def format_date(datetime)
+    datetime.to_date.to_s(:short_abbrev)
   end
 
-  def format_date_without_year(date)
-    return unless date
-    I18n.l(date.to_date, format: :date_without_year)
+  def format_date_of_birth(datetime)
+    I18n.l(datetime.to_date, format: :date_of_birth)
   end
 
-  def format_date_day(date)
-    I18n.l(date.to_date, format: '%A')
+  def format_date_without_year(datetime)
+    return unless datetime
+    I18n.l(datetime.to_date, format: :date_without_year)
+  end
+
+  def format_date_day(datetime)
+    I18n.l(datetime.to_date, format: '%A')
   end
 
   def format_time_12hr(time)

--- a/app/views/prison/visits/_visit_date_section.html.erb
+++ b/app/views/prison/visits/_visit_date_section.html.erb
@@ -30,10 +30,18 @@
 <div class="grid-row push-top choose-date">
   <%= error_container(f, :slot_granted) do %>
     <% f.object.slots.each do |slot| %>
-      <div class="column-one-third">
+      <div class="column-one-quarter">
         <%= slot.slot_picker(f) %>
       </div>
     <% end %>
+    <div class="column-one-quarter">
+      <div class="date-box">
+        <div class="multiple-choice">
+          <%= f.radio_button :slot_granted, Rejection::SLOT_UNAVAILABLE, { checked: @visit.slots_unavailable?, id: 'no_slot_available', class: 'js-Conditional js-Rejection', 'data-rejection-el': 'rejection-message', 'data-success-el': 'nomis-opt-out' }%>
+          <%= f.label :slot_granted, t('.none_available'), for: 'no_slot_available' %>
+        </div>
+      </div>
+    </div>
   <% end %>
 
   <div class="column-one-half">
@@ -43,16 +51,8 @@
     </div>
   </div>
 
-  <div class="column-two-thirds push-top push-bottom--half">
-    <%= error_container f, :slot_granted do %>
-      <div class="multiple-choice">
-        <%= f.radio_button :slot_granted, Rejection::SLOT_UNAVAILABLE, { checked: @visit.slots_unavailable?, id: 'no_slot_available', class: 'js-Conditional js-Rejection', 'data-rejection-el': 'rejection-message', 'data-success-el': 'nomis-opt-out' }%>
-        <%= f.label :slot_granted, t('.none_available'), for: 'no_slot_available' %>
-      </div>
-    <% end %>
-  </div>
 </div>
 
 <div class="js-clearRadioButtons">
-  <a href="#" class="js-clearRadioButton" data-target="visit[slot_granted]"><%= t('clear_selection', scope: :shared) %></a>
+  <a href="#" class="button button-secondary js-clearRadioButton" data-target="visit[slot_granted]"><%= t('clear_selection', scope: :shared) %></a>
 </div>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,6 +1,7 @@
 # The format used in Nomis, allows staff to copy / paste
 Date::DATE_FORMATS[:full_nomis] = '%A %d/%m/%Y'
 Date::DATE_FORMATS[:short_nomis] = '%d/%m/%Y'
+Date::DATE_FORMATS[:short_abbrev] = '%d %b %Y'
 
 Time::DATE_FORMATS[:timeline_date] = '%d %B %Y'
 Time::DATE_FORMATS[:timeline_time] = '%R'

--- a/spec/decorators/concrete_slot_decorator_spec.rb
+++ b/spec/decorators/concrete_slot_decorator_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ConcreteSlotDecorator do
             expect(html_fragment).to have_css('span.tag--verified',    text: 'Prisoner available')
             expect(html_fragment).to have_css('span.tag--error',       text: 'Closed visit restriction')
             expect(html_fragment).to have_css('input.js-closedRestriction')
-            expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %B %Y')} 14:00–15:30")
+            expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %b %Y')} 14:00–15:30")
           end
         end
 
@@ -53,7 +53,7 @@ RSpec.describe ConcreteSlotDecorator do
           it 'renders the checkbox without errors ' do
             expect(html_fragment).to have_css('label.date-box__label')
             expect(html_fragment).to have_css('span.date-box__day',    text: date.strftime('%A'))
-            expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %B %Y')} 14:00–15:30")
+            expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %b %Y')} 14:00–15:30")
             expect(html_fragment).not_to have_css("input[disabled='disabled']")
           end
         end
@@ -65,7 +65,7 @@ RSpec.describe ConcreteSlotDecorator do
             it 'renders the checkbox with errors' do
               expect(html_fragment).to have_css('label.date-box__label.date-box--error')
               expect(html_fragment).to have_css('span.date-box__day',    text: date.strftime('%A'))
-              expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %B %Y')} 14:00–15:30")
+              expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %b %Y')} 14:00–15:30")
               expect(html_fragment).to have_css('span.tag--error', text: 'Visits banned')
             end
           end
@@ -76,7 +76,7 @@ RSpec.describe ConcreteSlotDecorator do
             it 'renders the checkbox neither verified or errors' do
               expect(html_fragment).to have_css('label.date-box__label')
               expect(html_fragment).to have_css('span.date-box__day',    text: date.strftime('%A'))
-              expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %B %Y')} 14:00–15:30")
+              expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %b %Y')} 14:00–15:30")
               expect(html_fragment).not_to have_css('span.tag--error')
               expect(html_fragment).not_to have_css('span.tag--verified')
             end
@@ -92,7 +92,7 @@ RSpec.describe ConcreteSlotDecorator do
         it 'renders the checkbox without errors' do
           expect(html_fragment).to have_css('label.date-box__label')
           expect(html_fragment).to have_css('span.date-box__day',    text: date.strftime('%A'))
-          expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %B %Y')} 14:00–15:30")
+          expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %b %Y')} 14:00–15:30")
         end
       end
     end
@@ -108,7 +108,7 @@ RSpec.describe ConcreteSlotDecorator do
           it 'renders the checkbox' do
             expect(html_fragment).to have_css('label.date-box__label')
             expect(html_fragment).to have_css('span.date-box__day',    text: date.strftime('%A'))
-            expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %B %Y')} 14:00–15:30")
+            expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %b %Y')} 14:00–15:30")
           end
         end
 
@@ -119,7 +119,7 @@ RSpec.describe ConcreteSlotDecorator do
             it 'renders the checkbox' do
               expect(html_fragment).to have_css('label.date-box__label.date-box--error')
               expect(html_fragment).to have_css('span.date-box__day',    text: date.strftime('%A'))
-              expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %B %Y')} 14:00–15:30")
+              expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %b %Y')} 14:00–15:30")
               expect(html_fragment).to have_css('span.tag--error', text: 'Fully booked')
             end
           end
@@ -130,7 +130,7 @@ RSpec.describe ConcreteSlotDecorator do
             it 'renders the checkbox neither verified or errors' do
               expect(html_fragment).to have_css('label.date-box__label.disabled')
               expect(html_fragment).to have_css('span.date-box__day',    text: date.strftime('%A'))
-              expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %B %Y')} 14:00–15:30")
+              expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %b %Y')} 14:00–15:30")
               expect(html_fragment).to have_css("input[disabled='disabled']")
               expect(html_fragment).not_to have_css('span.tag--error')
               expect(html_fragment).not_to have_css('span.tag--verified')
@@ -148,7 +148,7 @@ RSpec.describe ConcreteSlotDecorator do
         it 'renders the checkbox without errors' do
           expect(html_fragment).to have_css('label.date-box__label')
           expect(html_fragment).to have_css('span.date-box__day',    text: date.strftime('%A'))
-          expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %B %Y')} 14:00–15:30")
+          expect(html_fragment).to have_text("#{slot.to_date.strftime('%e %b %Y')} 14:00–15:30")
         end
       end
     end


### PR DESCRIPTION
In order to facilitate the design for PVO & VO selection correctly, we will need to move the radio button for No Dates Available to be inline to date selections. This will allow the date selections to be interacted with like a radio button selection.

We're also highlighting the Clear Selection by making the link into a secondary button.