### PR TITLE
Remove old routes without locale in the path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,11 +42,6 @@ Rails.application.routes.draw do
   end
 
   namespace :prison do
-    ### deprecated, for backwards compatibility. Delete soon after deploying
-    resources :visits, only: %i[show update]
-
-    #######
-
     resources :print_visits, only: %i[new create]
 
     scope controller: :dashboards do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,9 +49,9 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :print_visits, only: %i[new create]
-
     #######
+
+    resources :print_visits, only: %i[new create]
 
     scope controller: :dashboards do
       get '/inbox', action: :inbox, as: 'inbox'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,10 +49,6 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :visits, only: [] do
-      resource :email_preview, only: :update
-    end
-
     resources :print_visits, only: %i[new create]
 
     #######

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,8 +47,6 @@ Rails.application.routes.draw do
       member do
         post 'nomis_cancelled'
       end
-
-      resources :messages, only: :create
     end
 
     resources :visits, only: [] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,11 +43,7 @@ Rails.application.routes.draw do
 
   namespace :prison do
     ### deprecated, for backwards compatibility. Delete soon after deploying
-    resources :visits, only: %i[show update] do
-      member do
-        post 'nomis_cancelled'
-      end
-    end
+    resources :visits, only: %i[show update]
 
     #######
 

--- a/spec/controllers/prison/email_previews_controller_spec.rb
+++ b/spec/controllers/prison/email_previews_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Prison::EmailPreviewsController do
     end
 
     it 'renders the errors message' do
-      put :update, params: { visit_id: visit.id, visit: visit.attributes }
+      put :update, params: { visit_id: visit.id, visit: visit.attributes, locale: 'en' }
       expect(response.body).to include('invalid booking response')
     end
   end

--- a/spec/controllers/prison/messages_controller_spec.rb
+++ b/spec/controllers/prison/messages_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Prison::MessagesController do
   describe '#create' do
     subject do
-      post :create, params: { message: { body: message_body }, visit_id: visit.id }
+      post :create, params: { message: { body: message_body }, visit_id: visit.id, locale: 'en' }
     end
 
     let(:prison) { FactoryBot.create(:prison, estate: estate) }

--- a/spec/controllers/prison/visits_controller_spec.rb
+++ b/spec/controllers/prison/visits_controller_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Prison::VisitsController, type: :controller do
     let(:user)   { create(:user) }
 
     context 'with security' do
-      subject { get :show, params: { id: 1 } }
+      subject { get :show, params: { id: 1, locale: 'en' } }
 
       it_behaves_like 'disallows untrusted ips'
     end
@@ -99,7 +99,7 @@ RSpec.describe Prison::VisitsController, type: :controller do
       before do
         travel_to nowish do
           login_user(user, current_estates: [estate])
-          get :show, params: { id: visit.id }
+          get :show, params: { id: visit.id, locale: 'en' }
         end
       end
 
@@ -117,7 +117,7 @@ RSpec.describe Prison::VisitsController, type: :controller do
     end
 
     context "when logged out" do
-      before do get :show, params: { id: visit.id } end
+      before do get :show, params: { id: visit.id, locale: 'en' } end
 
       it { expect(response).not_to be_successful }
     end

--- a/spec/controllers/prison/visits_controller_spec.rb
+++ b/spec/controllers/prison/visits_controller_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Prison::VisitsController, type: :controller do
     let(:cancellation) { FactoryBot.create(:cancellation) }
     let(:visit) { cancellation.visit }
 
-    subject { post :nomis_cancelled, params: { id: visit.id } }
+    subject { post :nomis_cancelled, params: { id: visit.id, locale: 'en' } }
 
     it_behaves_like 'disallows untrusted ips'
 


### PR DESCRIPTION
We used to serve the visit processing pages under `/prison/visits`, but last year (in 4b5f41b) we started including the locale in the path, so they're now under `/en|cy/prison/visits`. The old routes were marked as deprecated at the time but weren't removed soon afterwards - they can be removed now.

The controller specs need the locale param so that they use the new routes - they were still testing against the old routes.