### PR TITLE
Remove ControllerTest#success? deprecation warning

### DIFF
--- a/spec/controllers/healthcheck_controller_spec.rb
+++ b/spec/controllers/healthcheck_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe HealthcheckController, type: :controller do
     end
 
     it 'returns an HTTP Success status' do
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'returns the healthcheck data as JSON' do


### PR DESCRIPTION
**CHANGES:**

Swap #be_success for #be_successful to remove the rails 6.0 deprecation warning