### PR TITLE
Add middle names to offender details

### DIFF
--- a/app/services/nomis/offender/details.rb
+++ b/app/services/nomis/offender/details.rb
@@ -5,6 +5,7 @@ module Nomis
 
       attribute :given_name, :string
       attribute :surname, :string
+      attribute :middle_names, :string
       attribute :title, :string
       attribute :nationalities, :string
       attribute :date_of_birth, :date

--- a/spec/services/nomis/offender/details_spec.rb
+++ b/spec/services/nomis/offender/details_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Nomis::Offender::Details do
   it { is_expected.to respond_to :given_name }
   it { is_expected.to respond_to :surname }
+  it { is_expected.to respond_to :middle_names }
   it { is_expected.to respond_to :date_of_birth }
   it { is_expected.to respond_to :aliases }
   it { is_expected.to respond_to :gender }


### PR DESCRIPTION
**CHANGES:**

After the swap from Virtus to ActiveModel::Types unknown attributes are no
longer ignored and raises exception upon serialisation to ActiveModel models