### PR TITLE
Add suffix attribute to Offender details

### DIFF
--- a/app/services/nomis/offender/details.rb
+++ b/app/services/nomis/offender/details.rb
@@ -20,6 +20,7 @@ module Nomis
       attribute :nationalities, :string
       attribute :pnc_number, :string
       attribute :religion
+      attribute :suffix
       attribute :surname, :string
       attribute :title, :string
 


### PR DESCRIPTION
Following the deployment of the other offender attributes it was
discovered that there is also a "suffix" attribute that was missed due
to it not being in the api docs.