### PR TITLE
bullet proof visit show for unknown offender number

### DIFF
--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -79,7 +79,7 @@ module Nomis
       response = @connection.request(options)
 
       JSON.parse(response.body)
-    rescue Excon::Errors::HTTPStatusError => e
+    rescue Excon::Error::HTTPStatus => e
       body = e.response.body
 
       # API errors should be returned as JSON, but there are many scenarios

--- a/app/services/nomis/null_offender.rb
+++ b/app/services/nomis/null_offender.rb
@@ -6,6 +6,10 @@ module Nomis
       false
     end
 
+    def iep_level; end
+
+    def imprisonment_status; end
+
     def api_call_successful?
       api_call_successful
     end

--- a/lib/excon/middleware/custom_idempotent.rb
+++ b/lib/excon/middleware/custom_idempotent.rb
@@ -30,7 +30,7 @@ module Excon
         end
 
         if datum[:idempotent] && [Excon::Errors::SocketError,
-                                  Excon::Errors::HTTPStatusError].any? { |ex| datum[:error].is_a?(ex) } && datum[:retries_remaining] > 1
+                                  Excon::Error::HTTPStatus].any? { |ex| datum[:error].is_a?(ex) } && datum[:retries_remaining] > 1
           # reduces remaining retries, reset connection, and restart request_call
           datum[:retries_remaining] -= 1
           connection = datum.delete(:connection)

--- a/spec/features/nomis_disabled_spec.rb
+++ b/spec/features/nomis_disabled_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+require 'shared_process_setup_context'
+
+RSpec.feature 'When NOMIS API was disabled' do
+  include_context 'with a process request setup'
+
+  let(:vst) { create(:visit) }
+
+  let(:sso_response) do
+    {
+      'uid' => '1234-1234-1234-1234',
+      'provider' => 'mojsso',
+      'info' => {
+        'first_name' => 'Joe',
+        'last_name' => 'Goldman',
+        'email' => 'joe@example.com',
+        'permissions' => [
+          { 'organisation' => vst.prison.estate.sso_organisation_name, roles: [] }
+        ],
+        'links' => {
+          'profile' => 'http://example.com/profile',
+          'logout' => 'http://example.com/logout'
+        }
+      }
+    }
+  end
+
+  before do
+    OmniAuth.config.add_mock(:mojsso, sso_response)
+    vst.prisoner.update!(number: 'zzzzzzz')
+  end
+
+  scenario "a prisoner is not found", :expect_exception, vcr: { cassette_name: :nomis_disabled_invalid_prisoner_number } do
+    visit prison_visit_path(vst, locale: 'en')
+
+    expect(page).to have_css('h1', text: 'Check visit request')
+  end
+end

--- a/spec/fixtures/vcr_cassettes/nomis_disabled_invalid_prisoner_number.yml
+++ b/spec/fixtures/vcr_cassettes/nomis_disabled_invalid_prisoner_number.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://noms-api-dev.dsd.io/nomisapi/lookup/active_offender?date_of_birth=1970-01-01&noms_id=ZZZZZZZ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Authorization:
+      - authorisation_header
+      X-Request-Id:
+      - eee052a8-ea08-4cd9-8097-19b22f0f8732
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 01 May 2018 11:24:41 GMT
+      Server:
+      - nginx/1.13.8
+      Server-Timing:
+      - total=0
+      Url-Template:
+      - "/lookup/active_offender"
+      Content-Length:
+      - '54'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error":{"message":"Invalid or missing NOMS Number"}}'
+    http_version: 
+  recorded_at: Tue, 01 May 2018 11:24:41 GMT
+- request:
+    method: get
+    uri: https://noms-api-dev.dsd.io/nomisapi/lookup/active_offender?date_of_birth=1970-01-01&noms_id=ZZZZZZZ
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.62.0
+      Accept:
+      - application/json
+      Authorization:
+      - authorisation_header
+      X-Request-Id:
+      - eee052a8-ea08-4cd9-8097-19b22f0f8732
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 01 May 2018 11:24:41 GMT
+      Server:
+      - nginx/1.13.8
+      Server-Timing:
+      - total=0
+      Url-Template:
+      - "/lookup/active_offender"
+      Content-Length:
+      - '54'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error":{"message":"Invalid or missing NOMS Number"}}'
+    http_version: 
+  recorded_at: Tue, 01 May 2018 11:24:41 GMT
+recorded_with: VCR 4.0.0

--- a/spec/services/nomis/client_spec.rb
+++ b/spec/services/nomis/client_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Nomis::Client do
 
   context 'when there is an http status error' do
     let(:error) do
-      Excon::Errors::HTTPStatusError.new('error',
+      Excon::Error::HTTPStatus.new('error',
         double('request'),
         double('response', status: 422, body: '<html>'))
     end
@@ -77,7 +77,7 @@ RSpec.describe Nomis::Client do
 
   describe 'with an error' do
     let(:error) do
-      Excon::Errors::HTTPStatusError.new('error',
+      Excon::Error::HTTPStatus.new('error',
         double('request'),
         double('response', status: 422, body: '<html>'))
     end

--- a/spec/services/nomis/null_offender_spec.rb
+++ b/spec/services/nomis/null_offender_spec.rb
@@ -1,0 +1,6 @@
+require "rails_helper"
+
+RSpec.describe Nomis::NullOffender do
+  it { expect(subject.iep_level).to eq(nil) }
+  it { expect(subject.imprisonment_status).to eq(nil) }
+end


### PR DESCRIPTION
**CHANGES:**

When  NOMIS API is disabled (e.g: scheduled downtime) no automatic validation is performed on the public side against the API. 
However when the staff tries to process the request NOMIS API might be back up.
There was 2 issues I've resolved in this PR:

1. At first the our API client was supposed to rescue any HTTP error hence trying to catch `Excon::Errors::HTTPStatusError` howver excon has change that superclass (and made a buggy patch). We now rescue the proper superclass error (until they change it again and break our stuff :trollface: - how seriously now commited to rip excon)

2. `NullOffender` class, subclassing `Offender`, would still make a request to the get the offender details even if obviosusly its prisoner number was not correct. This now doesn't happen anymore.

