### PR TITLE
Delete a form submission if a ticket is successfully raised with Zendesk

### DIFF
--- a/app/jobs/zendesk_tickets_job.rb
+++ b/app/jobs/zendesk_tickets_job.rb
@@ -14,9 +14,7 @@ class ZendeskTicketsJob < ActiveJob::Base
       fail 'Cannot create Zendesk ticket since Zendesk not configured'
     end
 
-    ZendeskAPI::Ticket.create!(
-      Rails.configuration.zendesk_client,
-      ticket_attrs(feedback))
+    feedback.destroy! if ticket_raised?(feedback)
   end
 
 private
@@ -24,6 +22,13 @@ private
   # We have 2 Zendesk inboxes configured, one for the public that matches that
   # the service field is 'prison_visits' and another one for staff that matches
   # tickets tagged with 'staff.prison.visits'.
+
+  def ticket_raised?(feedback)
+    ZendeskAPI::Ticket.create!(
+      Rails.configuration.zendesk_client,
+      ticket_attrs(feedback))
+  end
+
   def ticket_attrs(feedback)
     attrs = {
       description: feedback.body,

--- a/app/jobs/zendesk_tickets_job.rb
+++ b/app/jobs/zendesk_tickets_job.rb
@@ -14,7 +14,7 @@ class ZendeskTicketsJob < ActiveJob::Base
       fail 'Cannot create Zendesk ticket since Zendesk not configured'
     end
 
-    feedback.destroy! if ticket_raised?(feedback)
+    feedback.destroy! if ticket_raised!(feedback)
   end
 
 private
@@ -23,7 +23,7 @@ private
   # the service field is 'prison_visits' and another one for staff that matches
   # tickets tagged with 'staff.prison.visits'.
 
-  def ticket_raised?(feedback)
+  def ticket_raised!(feedback)
     ZendeskAPI::Ticket.create!(
       Rails.configuration.zendesk_client,
       ticket_attrs(feedback))


### PR DESCRIPTION
- Form submission is deleted if ticket successfully raised with Zendesk
- Form submission not deleted if problem occurs with raising a ticket

**Trello ticket**
https://trello.com/c/mBXoVNiQ/1337-gdpr-create-task-to-remove-public-feedback-a-month-after-its-marked-resolved-closed