### PR TITLE
Remove Sheppey Cluster group

### DIFF
--- a/db/seeds/estates.yml
+++ b/db/seeds/estates.yml
@@ -72,7 +72,6 @@ EEI:
 EHI:
   name: Standford Hill
   finder_slug: sheppey-cluster-standford-hill
-  group: sheppey_cluster.noms.moj
 ESI:
   name: East Sutton Park
   group: apvu.noms.moj
@@ -86,7 +85,6 @@ EXI:
 EYI:
   name: Elmley
   finder_slug: sheppey-cluster-elmley
-  group: sheppey_cluster.noms.moj
 FBI:
   name: Forest Bank
 FDI:
@@ -239,7 +237,6 @@ SKI:
   name: Stocken
 SLI:
   name: Swaleside
-  group: sheppey_cluster.noms.moj
 SNI:
   name: Swinfen Hall
   group: apvu.noms.moj

--- a/spec/services/estate_sso_mapper_spec.rb
+++ b/spec/services/estate_sso_mapper_spec.rb
@@ -46,26 +46,6 @@ RSpec.describe EstateSSOMapper do
       end
     end
 
-    context 'when it is for the sheppey cluster' do
-      let!(:elmley) do
-        create(:estate,
-          sso_organisation_name: 'elmley.prisons.noms.moj',
-          group: 'sheppey_cluster.noms.moj')
-      end
-      let(:orgs) { ['sheppey_cluster.noms.moj'] }
-
-      before do
-        allow(described_class).
-          to receive(:grouped_estates).
-          and_return('sheppey_cluster.noms.moj' => ['elmley.prisons.noms.moj'])
-      end
-
-      it 'includes sheppey cluster estates' do
-        is_expected.to include(elmley)
-        is_expected.not_to include(other_estate)
-      end
-    end
-
     context 'when for grendon and springhill' do
       let!(:grendon) do
         create(:estate,


### PR DESCRIPTION
As part of this Trello card:
https://trello.com/c/94sDa4Nd/1379-clean-up-team-staff-access-to-pvb-via-sign-on
we have made contact with various admins within the groups we have under
Sign On.  As a result we have been informed that the Sheppey Cluster is
no longer an entity, and all three prisons are back to working independently.
We have removed the Sheppey Cluster group from the estates file so that
staff will go back to only being able to access PVB for the prison they
work in.

There is also the finder_slug which references the cluster, but this is
related to Prison Finder; so until that has been updated we cannot remove
this.