### PR TITLE
Remove unused database columns

### DIFF
--- a/db/migrate/20180515102519_remove_columns_from_visits.rb
+++ b/db/migrate/20180515102519_remove_columns_from_visits.rb
@@ -1,0 +1,6 @@
+class RemoveColumnsFromVisits < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :visits, :override_delivery_error, :boolean
+    remove_column :visits, :delivery_error_type, :string
+  end
+end

--- a/db/migrate/20180515110205_remove_password_from_users.rb
+++ b/db/migrate/20180515110205_remove_password_from_users.rb
@@ -1,0 +1,5 @@
+class RemovePasswordFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :encrypted_password, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171121152149) do
+ActiveRecord::Schema.define(version: 2018_05_15_110205) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -108,7 +108,6 @@ ActiveRecord::Schema.define(version: 20171121152149) do
 
   create_table "users", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
     t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
     t.datetime "remember_created_at"
     t.uuid "estate_id"
     t.datetime "created_at", null: false
@@ -155,8 +154,6 @@ ActiveRecord::Schema.define(version: 20171121152149) do
     t.string "processing_state", default: "requested", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "override_delivery_error", default: false
-    t.string "delivery_error_type"
     t.string "reference_no"
     t.boolean "closed"
     t.uuid "prisoner_id", null: false

--- a/spec/models/staff_response_spec.rb
+++ b/spec/models/staff_response_spec.rb
@@ -236,8 +236,6 @@ RSpec.describe StaffResponse, type: :model do
         'contact_email_address'  => nil,
         'contact_phone_no'       => nil,
         'processing_state'       => 'requested',
-        'override_delivery_error' => false,
-        'delivery_error_type'    => nil,
         'reference_no'           => 'A1234BC',
         'closed'                 => params[:closed],
         'prisoner_id'            => visit.prisoner_id,


### PR DESCRIPTION
As part of GDPR we have identified the following unused columns in our
database:
Visits:
  - override_delivery_error
  - delivery_error_type
Users:
  - encrypted_password

Therefore we need to remove them, and any data held in them.