### PR TITLE
Update cookie expiry

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_pvb2_session'
+Rails.application.config.session_store :cookie_store, expire_after: 1.hour,
+                                                      key: '_pvb2_session',
+                                                      secure: Rails.env.production?,
+                                                      httponly: true


### PR DESCRIPTION
Up until this point there has been no expiry time for the staff (pvb2)
cookie.  Following advice from the security team we have now set the
cookie to expire after an hour.  The way that Rails manages the
session_store means that active use of the site will keep extending the
expiry time and will therefore only timeout once a user closes the
browser, or doesn't use the site for an hour.