### PR TITLE
refactor processed_by and visitor_id for visit state changes

### DIFF
--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -39,7 +39,7 @@ class Prison::VisitsController < ApplicationController
 
   def show
     visit = Visit.
-             includes(:visitors, messages: :user, visit_state_changes: :processed_by).
+             includes(:visitors, messages: :user, visit_state_changes: :creator).
              find(memoised_visit.id)
 
     @visit = visit.decorate

--- a/app/models/staff_response.rb
+++ b/app/models/staff_response.rb
@@ -4,6 +4,8 @@ class StaffResponse
   ADULT_AGE = 18
   attr_accessor :visit, :user
 
+  alias :creator :user
+
   before_validation :check_slot_available
   before_validation :check_principal_visitor
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,2 @@
 class User < ApplicationRecord
-  # TODO: Delete me when the column has dropped
-  def self.columns
-    super.reject { |c| c.name == 'estate_id' }
-  end
 end

--- a/app/models/visit_state_change.rb
+++ b/app/models/visit_state_change.rb
@@ -1,13 +1,11 @@
 class VisitStateChange < ApplicationRecord
   belongs_to :visit
+  belongs_to :visitor
+  belongs_to :processed_by, class_name: 'User'
   belongs_to :creator, polymorphic: true
 
   scope :booked,    -> { where(visit_state: 'booked') }
   scope :rejected,  -> { where(visit_state: 'rejected') }
   scope :withdrawn, -> { where(visit_state: 'withdrawn') }
   scope :cancelled, -> { where(visit_state: 'cancelled') }
-
-  def actioned_by
-    visitor || processed_by
-  end
 end

--- a/app/models/visit_state_change.rb
+++ b/app/models/visit_state_change.rb
@@ -1,10 +1,9 @@
 class VisitStateChange < ApplicationRecord
   belongs_to :visit
-  belongs_to :visitor
-  belongs_to :processed_by, class_name: 'User'
+  belongs_to :creator, polymorphic: true
 
-  scope :booked, -> { where(visit_state: 'booked') }
-  scope :rejected, -> { where(visit_state: 'rejected') }
+  scope :booked,    -> { where(visit_state: 'booked') }
+  scope :rejected,  -> { where(visit_state: 'rejected') }
   scope :withdrawn, -> { where(visit_state: 'withdrawn') }
   scope :cancelled, -> { where(visit_state: 'cancelled') }
 

--- a/app/services/booking_responder/booking_request_processor.rb
+++ b/app/services/booking_responder/booking_request_processor.rb
@@ -16,7 +16,7 @@ class BookingResponder
           create_message(message_for_visitor, visit.last_visit_state)
         end
 
-        record_visitor_or_user
+        record_creator
       end
 
       booking_response
@@ -31,15 +31,8 @@ class BookingResponder
     delegate :rejection, to: :visit
     private :visit
 
-    # Responses are either initiated by a user or visitor, but never both
-    def record_visitor_or_user
-      if staff_response.respond_to?(:user)
-        visit.last_visit_state.update!(processed_by: staff_response.user)
-      end
-
-      if staff_response.respond_to?(:visitor)
-        visit.last_visit_state.update!(visitor: staff_response.visitor)
-      end
+    def record_creator
+      visit.last_visit_state.update!(creator: staff_response.creator)
     end
 
     def create_message(message, visit_state_change)

--- a/app/services/cancellation_response.rb
+++ b/app/services/cancellation_response.rb
@@ -2,6 +2,7 @@ class CancellationResponse
   include PersistToNomisResponse
 
   attr_reader :visit, :user
+  alias :creator :user
 
   def initialize(visit, cancellation_attributes, user: nil, persist_to_nomis: false)
     self.visit                   = visit

--- a/app/services/visit_timeline.rb
+++ b/app/services/visit_timeline.rb
@@ -52,6 +52,6 @@ private
       state:      state.visit_state,
       created_at: state.created_at,
       last:       last,
-      creator:    state.creator)
+      user:       state.creator)
   end
 end

--- a/app/services/visit_timeline.rb
+++ b/app/services/visit_timeline.rb
@@ -52,6 +52,6 @@ private
       state:      state.visit_state,
       created_at: state.created_at,
       last:       last,
-      user:       state.actioned_by)
+      creator:    state.creator)
   end
 end

--- a/app/services/visitor_cancellation_response.rb
+++ b/app/services/visitor_cancellation_response.rb
@@ -13,7 +13,7 @@ class VisitorCancellationResponse
     processor.process_request
   end
 
-  def visitor
+  def creator
     visit.principal_visitor
   end
 

--- a/app/services/visitor_withdrawal_response.rb
+++ b/app/services/visitor_withdrawal_response.rb
@@ -13,7 +13,7 @@ class VisitorWithdrawalResponse
     processor.process_request
   end
 
-  def visitor
+  def creator
     visit.principal_visitor
   end
 

--- a/db/migrate/20180531094251_add_creator_references_to_visit_state_changes.rb
+++ b/db/migrate/20180531094251_add_creator_references_to_visit_state_changes.rb
@@ -1,0 +1,5 @@
+class AddCreatorReferencesToVisitStateChanges < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :visit_state_changes, :creator, type: :uuid, polymorphic: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_21_133256) do
+ActiveRecord::Schema.define(version: 2018_05_31_094251) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -133,6 +133,9 @@ ActiveRecord::Schema.define(version: 2018_05_21_133256) do
     t.datetime "updated_at", null: false
     t.uuid "processed_by_id"
     t.uuid "visitor_id"
+    t.string "creator_type"
+    t.uuid "creator_id"
+    t.index ["creator_type", "creator_id"], name: "index_visit_state_changes_on_creator_type_and_creator_id"
     t.index ["visit_id"], name: "index_visit_state_changes_on_visit_id"
   end
 

--- a/lib/tasks/one_off.rake
+++ b/lib/tasks/one_off.rake
@@ -117,6 +117,15 @@ namespace :pvb do
 
     AdminMailer.slot_availability(prison_data).deliver_now!
   end
+
+  desc 'Migrate processed_by and visitor to creator'
+  task migrate_visit_state_creator: :environment do
+    VisitStateChange.find_each do |visit_state_change|
+      visit_state_change.update!(
+        creator: visit_state_change.processed_by || visit_state_change.visitor
+      )
+    end
+  end
 end
 
 class SlotAvailabilityCounter

--- a/spec/models/visit_state_change_spec.rb
+++ b/spec/models/visit_state_change_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe VisitStateChange, type: :model do
   it { should belong_to(:visit) }
 
+  it { is_expected.to belong_to(:creator) }
+
   describe 'scopes' do
     let(:visit) { create(:visit) }
 

--- a/spec/services/booking_responder/booking_request_processor_spec.rb
+++ b/spec/services/booking_responder/booking_request_processor_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe BookingResponder::BookingRequestProcessor do
           visit.messages.find_by(body: message.body)
         }.from(nil).to(message)
 
-        expect(visit.last_visit_state.processed_by).to eq(staff_response.user)
+        expect(visit.last_visit_state.creator).to eq(staff_response.user)
       end
 
       it 'returns a sucessful booking response' do

--- a/spec/services/visit_timeline_spec.rb
+++ b/spec/services/visit_timeline_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe VisitTimeline do
   let(:instance) { described_class.new(visit) }
-  let(:visit) { FactoryBot.create(:visit) }
+  let(:visit) { create(:visit) }
 
   describe '#events' do
     subject(:events) { instance.events }
@@ -22,7 +22,7 @@ RSpec.describe VisitTimeline do
 
       before do
         visit.accept
-        VisitStateChange.last.update!(processed_by: user)
+        VisitStateChange.last.update!(creator: user)
 
         CancellationResponse.new(
           visit, reasons: [Cancellation::BOOKED_IN_ERROR]
@@ -52,7 +52,7 @@ RSpec.describe VisitTimeline do
     describe 'for a withdrawn visit' do
       before do
         visit.withdraw
-        VisitStateChange.last.update!(visitor: visit.principal_visitor)
+        VisitStateChange.last.update!(creator: visit.principal_visitor)
         visit.reload
       end
 

--- a/spec/services/visitor_cancellation_response_spec.rb
+++ b/spec/services/visitor_cancellation_response_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.describe VisitorCancellationResponse do
   subject(:instance) { described_class.new(visit: visit) }
 
-  let(:visit) { FactoryBot.create(:booked_visit) }
+  let(:visit) { create(:booked_visit) }
 
   describe '#visitor_can_cancel?' do
     subject(:visitor_can_cancel?) { instance.visitor_can_cancel? }
 
     context "when it can't be withdrawn" do
-      let(:visit) { FactoryBot.create(:withdrawn_visit) }
+      let(:visit) { create(:withdrawn_visit) }
 
       it { is_expected.to eq(false) }
     end
@@ -28,7 +28,7 @@ RSpec.describe VisitorCancellationResponse do
 
       context 'when it has already started' do
         let(:visit) do
-          FactoryBot.create(
+          create(
             :booked_visit,
             slot_granted: ConcreteSlot.new(2015, 11, 6, 16, 0, 17, 0))
         end

--- a/spec/services/visitor_withdrawal_response_spec.rb
+++ b/spec/services/visitor_withdrawal_response_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 RSpec.describe VisitorWithdrawalResponse do
   subject(:instance) { described_class.new(visit: visit) }
 
-  let(:visit) { FactoryBot.create(:visit) }
+  let(:visit) { create(:visit) }
 
   describe '#visitor_can_withdraw?' do
     subject(:visitor_can_withdraw?) { instance.visitor_can_withdraw? }
 
     context "when it can't be withdrawn" do
-      let(:visit) { FactoryBot.create(:withdrawn_visit) }
+      let(:visit) { create(:withdrawn_visit) }
 
       it { is_expected.to eq(false) }
     end


### PR DESCRIPTION
**CHANGES:**

Quick refactor to identify who triggered a visit state change. There was a lot of if/else statements for to switch actions to perform base of the type of creator.
This uses rails to seemlessly handle the creator being either a `User` or a `Visitor`

