### PR TITLE
Only return results of visits that have been updated in the last six months

### DIFF
--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -33,6 +33,8 @@ class Visit < ApplicationRecord
   delegate :allowance_will_renew?, :allowance_renews_on,
     to: :rejection
 
+  scope :less_than_six_months_old, -> { where('visits.updated_at > ?', 6.months.ago) }
+
   scope :from_estates, lambda { |estates|
     joins(prison: :estate).where(estates: { id: estates.map(&:id) })
   }

--- a/app/services/estate_visit_query.rb
+++ b/app/services/estate_visit_query.rb
@@ -15,7 +15,9 @@ class EstateVisitQuery
   end
 
   def processed(limit:, query:)
-    visits = Visit.preload(:prisoner, :visitors, :prison).
+    visits = Visit.
+             less_than_six_months_old.
+             preload(:prisoner, :visitors, :prison).
              processed.
              from_estates(@estates).
              order('visits.updated_at desc').limit(limit)
@@ -25,7 +27,9 @@ class EstateVisitQuery
   end
 
   def requested(query: nil)
-    visits = Visit.preload(:prisoner, :visitors, :prison).
+    visits = Visit.
+             less_than_six_months_old.
+             preload(:prisoner, :visitors, :prison).
              with_processing_state(:requested).
              from_estates(@estates).
              order('created_at asc')
@@ -35,7 +39,9 @@ class EstateVisitQuery
   end
 
   def cancelled(query: nil)
-    visits = Visit.preload(:prisoner, :visitors, :cancellation, :prison).
+    visits = Visit.
+             less_than_six_months_old.
+             preload(:prisoner, :visitors, :cancellation, :prison).
              joins(:cancellation).
              from_estates(@estates).
              where(cancellations: { nomis_cancelled: false }).

--- a/app/views/prison/dashboards/_cancellations.html.erb
+++ b/app/views/prison/dashboards/_cancellations.html.erb
@@ -43,5 +43,5 @@
     </tbody>
   </table>
 <% else %>
-  <p><%= t('.no_cancellations') %></p>
+  <p class="lede"><%= t('.no_cancellations') %></p>
 <% end %>

--- a/app/views/prison/dashboards/search.html.erb
+++ b/app/views/prison/dashboards/search.html.erb
@@ -3,7 +3,7 @@
   <%= t('.title', prisoner_number: params[:query]) %>
 <% end %>
 
-<p class="text-secondary"><%= t('.search_total', number: @search_total) %></p>
+<%= t('.search_description_html') %>
 
 <h3 class="heading-medium"><%= t('.cancellations') %></h3>
 <%= render 'cancellations' %>

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -123,7 +123,9 @@ en:
         processed: Processed
         requests: Requests
         title: Search results for '%{prisoner_number}'
-        search_total: Displaying %{number} results
+        search_description_html: |
+          <p class="text-secondary">Below are visit requests made in the last 6 months.
+          Please <a href='/prison/feedbacks/new'>contact us</a> if you would like to see older visits.</p>
       print_visits:
         visit_list: Visit List
     visits:

--- a/spec/services/estate_visit_query_spec.rb
+++ b/spec/services/estate_visit_query_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe EstateVisitQuery do
   subject(:instance) { described_class.new(estates) }
 
-  let(:prison) { FactoryBot.create(:prison) }
+  let(:prison) { create(:prison) }
   let(:estates) { [prison.estate] }
 
   describe '#visits_to_print_by_slot' do
@@ -18,23 +18,23 @@ RSpec.describe EstateVisitQuery do
     let(:slot2) { ConcreteSlot.new(2016, 7, 19, 14, 30, 15, 30) }
     let(:date) { slot1.to_date }
     let!(:booked_visit1) do
-      FactoryBot.create(
+      create(
         :booked_visit,
         prison: prison,
         slot_granted: slot1)
     end
     let!(:booked_visit2) do
-      FactoryBot.create(:booked_visit,
+      create(:booked_visit,
         prison: prison,
         slot_granted: slot2)
     end
     let!(:cancelled_visit) do
-      FactoryBot.create(:cancelled_visit,
+      create(:cancelled_visit,
         prison: prison,
         slot_granted: slot1)
     end
     let!(:other_prison_visit) do
-      FactoryBot.create(
+      create(
         :booked_visit,
         slot_granted: slot1)
     end
@@ -66,25 +66,25 @@ RSpec.describe EstateVisitQuery do
 
     context 'with visits in all possible states' do
       let!(:requested) do
-        FactoryBot.create(:visit, :requested, prison: prison)
+        create(:visit, :requested, prison: prison)
       end
       let!(:withdrawn) do
-        FactoryBot.create(:withdrawn_visit, prison: prison)
+        create(:withdrawn_visit, prison: prison)
       end
       let!(:booked) do
-        FactoryBot.create(:booked_visit, prison: prison)
+        create(:booked_visit, prison: prison)
       end
       let!(:rejected) do
-        FactoryBot.create(:rejected_visit, prison: prison)
+        create(:rejected_visit, prison: prison)
       end
       let!(:nomis_cancelled) do
-        FactoryBot.create(:visit,
+        create(:visit,
           :nomis_cancelled,
           prison: prison,
           updated_at: 1.day.ago)
       end
       let!(:pending_nomis_cancellation) do
-        FactoryBot.create(:visit, :pending_nomis_cancellation, prison: prison)
+        create(:visit, :pending_nomis_cancellation, prison: prison)
       end
 
       it 'excludes visits pending nomis cancellation and requested visits' do
@@ -108,7 +108,7 @@ RSpec.describe EstateVisitQuery do
       end
 
       context 'when visits have not been updated within six months' do
-        let!(:old_booked) { FactoryBot.create(:booked_visit, prison: prison, updated_at: 7.months.ago) }
+        let!(:old_booked) { create(:booked_visit, prison: prison, updated_at: 7.months.ago) }
         let(:prisoner_number) { old_booked.prisoner.number.downcase + ' ' }
 
         it 'does not return visits in search results' do
@@ -164,14 +164,14 @@ RSpec.describe EstateVisitQuery do
     end
 
     let!(:visit1) do
-      FactoryBot.create(:visit, :requested, prison: prison)
+      create(:visit, :requested, prison: prison)
     end
     let!(:visit2) do
-      FactoryBot.create(:visit, :requested, prison: prison)
+      create(:visit, :requested, prison: prison)
     end
 
     let!(:old_visit) do
-      FactoryBot.create(:visit, :requested, prison: prison, created_at: 7.months.ago, updated_at: 7.months.ago)
+      create(:visit, :requested, prison: prison, created_at: 7.months.ago, updated_at: 7.months.ago)
     end
 
     it_behaves_like 'finds all'
@@ -186,14 +186,14 @@ RSpec.describe EstateVisitQuery do
     end
 
     let!(:visit1) do
-      FactoryBot.create(:visit, :pending_nomis_cancellation, prison: prison)
+      create(:visit, :pending_nomis_cancellation, prison: prison)
     end
     let!(:visit2) do
-      FactoryBot.create(:visit, :pending_nomis_cancellation, prison: prison)
+      create(:visit, :pending_nomis_cancellation, prison: prison)
     end
 
     let!(:old_visit) do
-      FactoryBot.create(:visit, :pending_nomis_cancellation, prison: prison, created_at: 7.months.ago, updated_at: 7.months.ago)
+      create(:visit, :pending_nomis_cancellation, prison: prison, created_at: 7.months.ago, updated_at: 7.months.ago)
     end
 
     it_behaves_like 'finds all'
@@ -207,15 +207,15 @@ RSpec.describe EstateVisitQuery do
 
     context 'with visits in different estates' do
       before do
-        FactoryBot.create(:visit, :requested, prison: prison)
-        FactoryBot.create(:visit, :requested, prison: prison)
-        FactoryBot.create(:booked_visit, prison: prison)
-        FactoryBot.create(:rejected_visit, prison: prison)
-        FactoryBot.create(:visit,
+        create(:visit, :requested, prison: prison)
+        create(:visit, :requested, prison: prison)
+        create(:booked_visit, prison: prison)
+        create(:rejected_visit, prison: prison)
+        create(:visit,
           :nomis_cancelled,
           prison: prison,
           updated_at: 1.day.ago)
-        FactoryBot.create(:visit, :pending_nomis_cancellation, prison: prison)
+        create(:visit, :pending_nomis_cancellation, prison: prison)
       end
 
       it 'returns the count of the visits that are in the inbox' do

--- a/spec/services/estate_visit_query_spec.rb
+++ b/spec/services/estate_visit_query_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe EstateVisitQuery do
       end
 
       context 'when providing a prisoner number' do
-        let(:prisoner_number) { booked.prisoner.number.downcase + ' ' }
+        let(:prisoner_number) { booked.prisoner.number.downcase }
 
         it 'returns processed visits matching the prisoner number' do
           is_expected.to eq([booked])
@@ -109,7 +109,7 @@ RSpec.describe EstateVisitQuery do
 
       context 'when visits have not been updated within six months' do
         let!(:old_booked) { create(:booked_visit, prison: prison, updated_at: 7.months.ago) }
-        let(:prisoner_number) { old_booked.prisoner.number.downcase + ' ' }
+        let(:prisoner_number) { old_booked.prisoner.number.downcase }
 
         it 'does not return visits in search results' do
           expect(instance.processed(limit: limit, query: prisoner_number)).to be_empty


### PR DESCRIPTION
https://trello.com/c/0E58iabh/1428-only-show-data-from-last-6-months-in-search-results