### PR TITLE
Restrict print visits search to 6 months

### DIFF
--- a/app/controllers/prison/print_visits_controller.rb
+++ b/app/controllers/prison/print_visits_controller.rb
@@ -8,7 +8,7 @@ class Prison::PrintVisitsController < ApplicationController
 
   def create
     @print_visits = ::PrintVisits.new(permitted_visit_date_params)
-    create_visit_date
+    validate_visit_date
 
     @data = EstateVisitQuery.new(current_estates).visits_to_print_by_slot(@submitted_date)
 
@@ -23,10 +23,11 @@ class Prison::PrintVisitsController < ApplicationController
 
 private
 
-  def create_visit_date
+  def validate_visit_date
     @submitted_date = AccessibleDate.new(
       date_to_accessible_date(@print_visits.visit_date)
       ).to_date
+    @print_visits.valid? unless @submitted_date.nil?
   end
 
   def date_to_accessible_date(date)

--- a/app/models/print_visits.rb
+++ b/app/models/print_visits.rb
@@ -2,4 +2,19 @@ class PrintVisits
   include MemoryModel
 
   attribute :visit_date, :accessible_date
+
+  validate :check_date
+
+  def check_date
+    today = Time.zone.today
+    six_months_ago = 6.months.ago.to_date
+    date_to_check = visit_date.to_date
+
+    unless date_to_check.between?(six_months_ago, today)
+      errors.add(
+        :base,
+        I18n.t('search_date_invalid_html',
+          scope: %i[print_visits errors]))
+    end
+  end
 end

--- a/app/views/prison/print_visits/create.html.erb
+++ b/app/views/prison/print_visits/create.html.erb
@@ -7,7 +7,9 @@
 <%= render 'visit_date' %>
 
 <% if !@submitted_date.nil? %>
-  <% if @data.any? %>
+  <% if !@print_visits.valid? %>
+    <p class="error-message"><%= t('search_date_invalid_html', scope: [:print_visits, :errors], url: new_prison_feedback_path) %></p>
+  <% elsif @data.any? %>
     <div class="js-print-visits">
       <span class="hidden--print">
         <%= link_to t('.download_csv_html'), prison_print_visits_path(print_visits: params[:visit_date] ,format: :csv) %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -59,6 +59,9 @@ en:
     errors:
       must_reject_or_accept_visit: "A visit must either be accepted by choosing a date or at least one rejection reason"
   no_visitor_in_nomis: No record of this visitor in NOMIS
+  print_visits:
+    errors:
+      search_date_invalid_html: Please choose a date within the last six months, or <a href='%<url>s'>contact us</a> if you would like to see older visits.
 
   age_validator:
     errors:

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -72,7 +72,7 @@ en:
         year: Year
         visit_date: Visit Date
         show: Show
-        visit_date_hint: Enter a date to view the visits eg 01/12/2016
+        visit_date_hint: For example 01 03 2018.  We can only show visits within the last 6 months. Please contact us if you would like to see older visits.
       create:
         download_csv_html: |
           Download CSV <span class="visuallyhidden">(link opens in a new browser window)</span>

--- a/spec/features/print_visits_spec.rb
+++ b/spec/features/print_visits_spec.rb
@@ -61,6 +61,15 @@ RSpec.feature 'Printing a list of visits' do
       expect(page).to have_css('h3', text: 'Visit date 21/12/2017')
       expect(page).to have_css('h3', text: 'Visit time 14:00–16:00')
     end
+
+    it 'is for a date more than six months ago' do
+      visit new_prison_print_visit_path
+      fill_in 'Day', with: '21'
+      fill_in 'Month', with: '12'
+      fill_in 'Year', with: '2016'
+      click_button('Show')
+      expect(page).to have_css('p', text: "Please choose a date within the last six months, or contact us if you would like to see older visits.")
+    end
   end
 
   context 'when searching for visits without any date params' do

--- a/spec/models/print_visits_spec.rb
+++ b/spec/models/print_visits_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe PrintVisits, type: :model do
+  let(:error_message) { "Please choose a date within the last six months, or <a href='%<url>s'>contact us</a> if you would like to see older visits." }
+
+  context 'with validations' do
+    context 'when the date is out of the the given range' do
+      it 'has an error on the field' do
+        subject.visit_date = '2017-01-01'
+        subject.validate
+        expect(subject.errors.messages[:base]).to include(error_message)
+      end
+    end
+
+    context 'when the date is within the the given range' do
+      it 'has no error on the field' do
+        subject.visit_date = 3.months.ago.strftime("%F")
+        subject.validate
+        expect(subject.errors.messages[:base]).not_to include(error_message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
At present staff are able to enter a date into the print visits and it
will return any visits as far back as they want to search.  However, we
want to establish whether or not staff actually need to search for
visits from further back than 6 months.  As such we are going to restrict
their searches to the last 6 months and advise them to contact us if
they need more historical visits data.