### PR TITLE
Reinstate print visits search for future dates

### DIFF
--- a/app/models/print_visits.rb
+++ b/app/models/print_visits.rb
@@ -10,7 +10,7 @@ class PrintVisits
     six_months_ago = 6.months.ago.to_date
     date_to_check = visit_date.to_date
 
-    unless date_to_check.between?(six_months_ago, today)
+    unless date_to_check.between?(six_months_ago, today) || date_to_check >= today
       errors.add(
         :base,
         I18n.t('search_date_invalid_html',

--- a/spec/models/print_visits_spec.rb
+++ b/spec/models/print_visits_spec.rb
@@ -12,9 +12,17 @@ RSpec.describe PrintVisits, type: :model do
       end
     end
 
-    context 'when the date is within the the given range' do
+    context 'when the date is within the past six months' do
       it 'has no error on the field' do
         subject.visit_date = 3.months.ago.strftime("%F")
+        subject.validate
+        expect(subject.errors.messages[:base]).not_to include(error_message)
+      end
+    end
+
+    context 'when the date is in the future' do
+      it 'has no error on the field' do
+        subject.visit_date = 3.months.from_now.strftime("%F")
         subject.validate
         expect(subject.errors.messages[:base]).not_to include(error_message)
       end


### PR DESCRIPTION
Whilst implementing this PR https://github.com/ministryofjustice/prison-visits-2/pull/1715
the print visits feature ended up only being able to search for dates in
last 6 months, whereas the functionality should also let staff search
for upcoming visits; this PR reinstates that functionality.