### PR TITLE
Prevent indexing of the site

### DIFF
--- a/app/middleware/robots_tag.rb
+++ b/app/middleware/robots_tag.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class RobotsTag
+  X_ROBOT_TAG_HEADER_VALUE = 'none'
+  X_ROBOT_TAG_HEADER = 'X-Robots-Tag'
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, response = @app.call(env)
+    headers[X_ROBOT_TAG_HEADER] = X_ROBOT_TAG_HEADER_VALUE
+
+    [status, headers, response]
+  end
+end

--- a/config/initializers/robots_blocker.rb
+++ b/config/initializers/robots_blocker.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Rails.application.config.middleware.use RobotsTag

--- a/spec/requests/robots_tag_spec.rb
+++ b/spec/requests/robots_tag_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe RobotsTag do
+  it "blocks all crawlers" do
+    get '/'
+    expect(response.headers["X-Robots-Tag"]).to eq "none"
+  end
+end


### PR DESCRIPTION
The service manual says that all services must tell search engines not
to index pages on their domain so that users start from GOV.UK rather
going directly to the service domain. This PR implements the
X-Robots-Tag header, which applies to all content types in the app (e.g.
images, scripts, styles), not only HTML files.