### PR TITLE
Fix print visits feature spec

### DIFF
--- a/spec/features/print_visits_spec.rb
+++ b/spec/features/print_visits_spec.rb
@@ -52,21 +52,36 @@ RSpec.feature 'Printing a list of visits' do
       expect(page).to have_css('p', text: 'No visits on 23/01/2018')
     end
 
-    it 'is for a date with visits' do
-      visit new_prison_print_visit_path
-      fill_in 'Day', with: '21'
-      fill_in 'Month', with: '12'
-      fill_in 'Year', with: '2017'
-      click_button('Show')
-      expect(page).to have_css('h3', text: 'Visit date 21/12/2017')
-      expect(page).to have_css('h3', text: 'Visit time 14:00–16:00')
+    context 'when searching for visits' do
+      let(:requested_date) { 1.day.ago.to_date }
+      let(:slot) { ConcreteSlot.new(requested_date.year, requested_date.month, requested_date.day, 14, 0, 16, 0).to_s }
+      let!(:booked_visits)    { create_list(:booked_visit,    5, prison: swansea_prison, slot_granted: slot) }
+      let!(:cancelled_visits) { create_list(:cancelled_visit, 5, prison: swansea_prison, slot_granted: slot) }
+
+      it 'is for a date with visits' do
+        visit new_prison_print_visit_path
+        fill_in 'Day',   with: requested_date.day
+        fill_in 'Month', with: requested_date.month
+        fill_in 'Year',  with: requested_date.year
+
+        click_button('Show')
+
+        expect(page).to have_css('h3', text: "Visit date #{requested_date.to_s(:short_nomis)}")
+        expect(page).to have_css('h3', text: 'Visit time 14:00–16:00')
+        booked_visits.each do |v|
+          expect(page).to have_css('tr td', text: v.prisoner_number)
+        end
+        cancelled_visits.each do |v|
+          expect(page).to have_css('tr td', text: v.prisoner_number)
+        end
+      end
     end
 
     it 'is for a date more than six months ago' do
       visit new_prison_print_visit_path
-      fill_in 'Day', with: '21'
+      fill_in 'Day',   with: '21'
       fill_in 'Month', with: '12'
-      fill_in 'Year', with: '2016'
+      fill_in 'Year',  with: '2016'
       click_button('Show')
       expect(page).to have_css('p', text: "Please choose a date within the last six months, or contact us if you would like to see older visits.")
     end


### PR DESCRIPTION
We recently implemented a feature that only allows staff to print visits
either in the future, or up until six months in the past.  As a result
one of the print visits feature specs is failing as the date now falls
outside of this range.  The test is now more dynamic and should prevent
this from happening again in the future.