### PR TITLE
Fix sentry CSP error

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -20,7 +20,7 @@ Rails.application.config.content_security_policy do |config|
   if sentry_js_dsn.present?
     if sentry_js_dsn.match? URI.regexp(%w[http https])
       host = URI.parse(sentry_js_dsn).host
-      config.connect_src host
+      config.connect_src :self, host
     else
       raise '[FATAL] Sentry JS DSN (SENTRY_JS_DSN) is an invalid URI ' \
         '(we were expecting a valid URI with an http or https scheme): ' +


### PR DESCRIPTION
After changing to Rails 5.2 CSP, staff users were getting an error when previewing the email.

_Refused to connect to 'https://staff.prisonvisits.service.gov.uk/en/prison/visits/ab167bf7-99dd-4ee3-b9b0-6db933cd0ff1/email_preview' because it violates the following Content Security Policy directive: "connect-src sentry.service.dsd.io"._