### PR TITLE
Refactor Content Security Policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -3,7 +3,6 @@ Rails.application.config.content_security_policy do |config|
   config.font_src :self, :data
   config.img_src :self, :data, 'www.google-analytics.com'
   config.style_src :self, 'www.gstatic.com'
-  config.connect_src :self
   config.script_src :self,
     'www.google-analytics.com',
     'www.gstatic.com',
@@ -28,5 +27,6 @@ Rails.application.config.content_security_policy do |config|
     end
   else
     STDOUT.puts '[WARN] Sentry JS DSN is not set (SENTRY_JS_DSN)'
+    config.connect_src :self
   end
 end


### PR DESCRIPTION
At present we are setting the connect_src and then overwrite it if
a sentry_js_dsn is present.  This isn't very DRY and so we have
refactored the code to ensure we only set connect_src once.