### PR TITLE
Remove 'prisoner banned' checkbox

### DIFF
--- a/app/decorators/rejection_decorator.rb
+++ b/app/decorators/rejection_decorator.rb
@@ -4,7 +4,6 @@ class RejectionDecorator < Draper::Decorator
   RESTRICTON_REASONS = [
     Rejection::PRISONER_NON_ASSOCIATION,
     Rejection::CHILD_PROTECTION_ISSUES,
-    Rejection::PRISONER_BANNED,
     Rejection::PRISONER_OUT_OF_PRISON
   ].freeze
 
@@ -73,7 +72,6 @@ class RejectionDecorator < Draper::Decorator
   def apply_nomis_reasons
     if unbookable?
       reasons << Rejection::NO_ALLOWANCE if no_allowance?
-      reasons << Rejection::PRISONER_BANNED if prisoner_banned?
       if prisoner_out_of_prison?
         reasons << Rejection::PRISONER_OUT_OF_PRISON
       end
@@ -124,10 +122,6 @@ private
 
   def no_allowance?
     visit.slots.any? { |slot| nomis_checker.no_allowance?(slot) }
-  end
-
-  def prisoner_banned?
-    visit.slots.any? { |slot| nomis_checker.prisoner_banned?(slot) }
   end
 
   def prisoner_out_of_prison?

--- a/app/models/prisoner_availability_validation.rb
+++ b/app/models/prisoner_availability_validation.rb
@@ -2,7 +2,6 @@ class PrisonerAvailabilityValidation
   include MemoryModel
 
   PRISONER_ERRORS = [
-    Nomis::PrisonerDateAvailability::BANNED,
     Nomis::PrisonerDateAvailability::OUT_OF_VO,
     Nomis::PrisonerDateAvailability::EXTERNAL_MOVEMENT,
     Nomis::PrisonerDateAvailability::BOOKED_VISIT

--- a/app/models/rejection.rb
+++ b/app/models/rejection.rb
@@ -12,7 +12,6 @@ class Rejection < ApplicationRecord
     'prisoner_non_association'.freeze
   CHILD_PROTECTION_ISSUES =
     'child_protection_issues'.freeze
-  PRISONER_BANNED = 'prisoner_banned'.freeze
   PRISONER_OUT_OF_PRISON = 'prisoner_out_of_prison'.freeze
   OTHER_REJECTION_REASON = 'other'.freeze
   VISITOR_OTHER_REASON = 'visitor_other_reason'.freeze
@@ -29,7 +28,6 @@ class Rejection < ApplicationRecord
     BANNED,
     NOT_ON_THE_LIST,
     'duplicate_visit_request',
-    PRISONER_BANNED,
     PRISONER_OUT_OF_PRISON,
     OTHER_REJECTION_REASON,
     VISITOR_OTHER_REASON

--- a/app/services/nomis/prisoner_date_availability.rb
+++ b/app/services/nomis/prisoner_date_availability.rb
@@ -4,7 +4,6 @@ module Nomis
 
     BOOKED_VISIT = 'booked_visit'.freeze
     EXTERNAL_MOVEMENT = 'external_movement'.freeze
-    BANNED = 'prisoner_banned'.freeze
     OUT_OF_VO = 'out_of_vo'.freeze
 
     attribute :date, :date

--- a/app/services/staff_nomis_checker.rb
+++ b/app/services/staff_nomis_checker.rb
@@ -35,10 +35,6 @@ class StaffNomisChecker
     errors_for(slot).include?(Nomis::PrisonerDateAvailability::OUT_OF_VO)
   end
 
-  def prisoner_banned?(slot)
-    errors_for(slot).include?(Nomis::PrisonerDateAvailability::BANNED)
-  end
-
   def prisoner_out_of_prison?(slot)
     errors_for(slot).include?(Nomis::PrisonerDateAvailability::EXTERNAL_MOVEMENT)
   end

--- a/app/views/prison/visits/_rejection_nomis.html.erb
+++ b/app/views/prison/visits/_rejection_nomis.html.erb
@@ -29,11 +29,6 @@
     <div class="column-one-half">
       <%= error_container(rf, :reasons) do %>
         <div class="multiple-choice">
-          <%= render 'rejection_reason', rf: rf, id: :prisoner_banned %>
-        </div>
-      <% end %>
-      <%= error_container(rf, :reasons) do %>
-        <div class="multiple-choice">
           <%= render 'rejection_reason', rf: rf, id: :prisoner_out_of_prison %>
         </div>
       <% end %>
@@ -49,8 +44,7 @@
     <%= t('.overriding_restrictions') %>:
     <ul class="list list-bullet font-small">
       <li id="prisoner-details-incorrect"><%= t('.prisoner_details_incorrect') %></li>
-      <li id="prisoner-banned"><%= t('.prisoner_banned') %></li>
-      <li id="no-allowance"><%= t('.no_allowance') %>  </li>
+      <li id="no-allowance"><%= t('.nro_allowance') %>  </li>
       <li id="prisoner-out-of-prison"><%= t('.prisoner_out_of_prison') %></li>
     </ul>
     <%= t('.update_nomis') %>

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -138,7 +138,6 @@ en:
         email_preview: Preview email
         prisoner_available: Prisoner available
         slot_available: Space available
-        prisoner_banned: Visits banned
         out_of_vo: No visiting allowance
         external_movement: Prisoner on movement
         booked_visit: Booked on another visit
@@ -241,12 +240,10 @@ en:
         update_nomis: Please update any incorrect restrictions in NOMIS
         visiting_allowance: Visiting allowance
         allowance_renews_on: Allowance renews on
-        prisoner_banned: Prisoner banned from receiving visits
         prisoner_out_of_prison: Prisoner on external movement
         no_allowance: Prisoner does not have any visiting allowance
         prisoner_details_incorrect: Prisoner details are incorrect
       rejection_reason:
-        prisoner_banned: Prisoner banned from receiving visits
         prisoner_out_of_prison: Prisoner on external movement
         no_allowance: Prisoner does not have any visiting allowance
         prisoner_details_incorrect: Prisoner details are incorrect

--- a/spec/decorators/concrete_slot_decorator_spec.rb
+++ b/spec/decorators/concrete_slot_decorator_spec.rb
@@ -60,13 +60,13 @@ RSpec.describe ConcreteSlotDecorator do
 
         context 'when a prisoner is not available' do
           context 'with a date in the future' do
-            let(:slot_errors) { ['prisoner_banned'] }
+            let(:slot_errors) { ['external_movement'] }
 
             it 'renders the checkbox with errors' do
               expect(html_fragment).to have_css('label.date-box__label.date-box--error')
               expect(html_fragment).to have_css('span.date-box__day',    text: date.strftime('%A'))
               expect(html_fragment).to have_text("#{slot.to_date.strftime('%d %b %Y')} 14:00–15:30")
-              expect(html_fragment).to have_css('span.tag--error', text: 'Visits banned')
+              expect(html_fragment).to have_css('span.tag--error', text: 'Prisoner on movement')
             end
           end
 
@@ -178,7 +178,7 @@ RSpec.describe ConcreteSlotDecorator do
     end
 
     context 'when the prisoner is not avaliable' do
-      let(:slot_errors) { ['prisoner_banned'] }
+      let(:slot_errors) { ['external_movement'] }
 
       context 'when the slot is avaliable' do
         before do

--- a/spec/decorators/rejection_decorator_spec.rb
+++ b/spec/decorators/rejection_decorator_spec.rb
@@ -246,7 +246,6 @@ RSpec.describe RejectionDecorator do
   end
 
   describe 'prisoner unvisitable checkboxes' do
-    let(:prisoner_banned)          { nil }
     let(:no_allowance)             { nil }
     let(:prisoner_out_of_prison)   { nil }
     let(:details_incorrect)        { nil }
@@ -286,11 +285,6 @@ RSpec.describe RejectionDecorator do
         and_return(no_allowance)
 
       allow(nomis_checker).
-        to receive(:prisoner_banned?).
-        with(anything).
-        and_return(prisoner_banned)
-
-      allow(nomis_checker).
         to receive(:prisoner_out_of_prison?).
         with(anything).
         and_return(prisoner_out_of_prison)
@@ -320,7 +314,6 @@ RSpec.describe RejectionDecorator do
       let(:visit_bookable)         { true }
       let(:details_incorrect)      { false }
       let(:no_allowance)           { false }
-      let(:prisoner_banned)        { false }
       let(:prisoner_out_of_prison) { false }
 
       before do
@@ -329,7 +322,6 @@ RSpec.describe RejectionDecorator do
 
       it_behaves_like 'unchecked', :prisoner_details_incorrect
       it_behaves_like 'unchecked', :no_allowance
-      it_behaves_like 'unchecked', :prisoner_banned
       it_behaves_like 'unchecked', :prisoner_out_of_prison
     end
 
@@ -337,7 +329,6 @@ RSpec.describe RejectionDecorator do
       let(:visit_bookable) { false }
       let(:details_incorrect) { false }
       let(:no_allowance) { false }
-      let(:prisoner_banned) { false }
       let(:prisoner_out_of_prison) { false }
 
       before do
@@ -346,7 +337,6 @@ RSpec.describe RejectionDecorator do
 
       it_behaves_like 'unchecked', :prisoner_details_incorrect
       it_behaves_like 'unchecked', :no_allowance
-      it_behaves_like 'unchecked', :prisoner_banned
       it_behaves_like 'unchecked', :prisoner_out_of_prison
     end
 
@@ -416,28 +406,6 @@ RSpec.describe RejectionDecorator do
       let(:no_allowance) { true }
 
       it_behaves_like 'checked', :no_allowance
-    end
-
-    context 'when prisoner banned and bookable slots' do
-      before do
-        subject.apply_nomis_reasons
-      end
-
-      let(:visit_bookable) { true }
-      let(:prisoner_banned) { true }
-
-      it_behaves_like 'unchecked', :prisoner_banned
-    end
-
-    context 'when prisoner banned and unbookable slots' do
-      before do
-        subject.apply_nomis_reasons
-      end
-
-      let(:visit_bookable) { false }
-      let(:prisoner_banned) { true }
-
-      it_behaves_like 'checked', :prisoner_banned
     end
 
     context 'when prisoner out of prison and bookable slots' do

--- a/spec/features/process_a_request_reject_spec.rb
+++ b/spec/features/process_a_request_reject_spec.rb
@@ -167,7 +167,6 @@ RSpec.feature 'Processing a request', :expect_exception, :js do
     end
 
     scenario 'rejecting a booking with multiple rejection reasons' do
-      check 'Prisoner banned from receiving visits', visible: false
       check 'Prisoner on external movement', visible: false
       check 'Duplicate visit request'
 
@@ -177,7 +176,7 @@ RSpec.feature 'Processing a request', :expect_exception, :js do
 
       vst.reload
       expect(vst.rejection_reasons).
-        to include('prisoner_banned', 'prisoner_out_of_prison', 'duplicate_visit_request')
+        to include('prisoner_out_of_prison', 'duplicate_visit_request')
 
       expect(vst).to be_rejected
 

--- a/spec/models/metrics/rejection_percentage_spec.rb
+++ b/spec/models/metrics/rejection_percentage_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe Metrics::RejectionPercentage do
       expect(subject.as_json).to eq(child_protection_issues:    0,
                                     no_adult:                   0,
                                     no_allowance:               0,
-                                    prisoner_banned:            0,
                                     prisoner_details_incorrect: 0,
                                     prisoner_moved:             0,
                                     prisoner_non_association:   0,

--- a/spec/models/prisoner_availability_validation_spec.rb
+++ b/spec/models/prisoner_availability_validation_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe PrisonerAvailabilityValidation, type: :model do
       let(:date1_availability) do
         {
           date: slot1.to_date,
-          banned: false,
           out_of_vo: false,
           external_movement: false,
           existing_visits: []
@@ -69,7 +68,6 @@ RSpec.describe PrisonerAvailabilityValidation, type: :model do
       let(:date2_availability) do
         {
           date: slot2.to_date,
-          banned: true,
           out_of_vo: true,
           external_movement: false,
           existing_visits: []
@@ -79,7 +77,6 @@ RSpec.describe PrisonerAvailabilityValidation, type: :model do
       let(:date3_availability) do
         {
           date: slot3.to_date,
-          banned: false,
           out_of_vo: false,
           external_movement: false,
           existing_visits: []

--- a/spec/models/rejection/reason_spec.rb
+++ b/spec/models/rejection/reason_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Rejection::Reason, model: true do
   end
 
   context 'when there is another reason with a different explanation' do
-    let(:second_reason) { described_class.new(explanation: 'prisoner_banned') }
+    let(:second_reason) { described_class.new(explanation: 'external_movement') }
 
     it { is_expected.not_to eql(second_reason) }
 

--- a/spec/presenters/graph_metrics_presenter_spec.rb
+++ b/spec/presenters/graph_metrics_presenter_spec.rb
@@ -271,7 +271,6 @@ RSpec.describe GraphMetricsPresenter do
                                    duplicate_visit_request:    16.67,
                                    no_adult:                   3.03,
                                    no_allowance:               4.55,
-                                   prisoner_banned:            0,
                                    prisoner_details_incorrect: 6.06,
                                    prisoner_moved:             7.58,
                                    prisoner_non_association:   9.09,

--- a/spec/services/nomis/prisoner_date_availability_spec.rb
+++ b/spec/services/nomis/prisoner_date_availability_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Nomis::PrisonerDateAvailability do
   subject(:instance) do
     described_class.new(
       date: date,
-      banned: banned,
       out_of_vo: out_of_vo,
       external_movement: external_movement,
       existing_visits: existing_visits
@@ -12,7 +11,6 @@ RSpec.describe Nomis::PrisonerDateAvailability do
   end
 
   let(:date) { Time.zone.today }
-  let(:banned) { false }
   let(:out_of_vo) { false }
   let(:external_movement) { false }
   let(:existing_visits) { [] }

--- a/spec/services/nomis/prisoner_detailed_availability_spec.rb
+++ b/spec/services/nomis/prisoner_detailed_availability_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Nomis::PrisonerDetailedAvailability do
     let(:response_body) do
       {
         '2017-01-01' => {
-          'banned' => false,
           'out_of_vo' => true,
           'external_movement' => false,
           'existing_visits' => [{ 'id' => 123, slot: api_slot.to_s }]
@@ -21,7 +20,6 @@ RSpec.describe Nomis::PrisonerDetailedAvailability do
       expect(object.dates.count).to eq(1)
       date_info = object.dates.first
 
-      expect(date_info.banned).to eq(false)
       expect(date_info.out_of_vo).to eq(true)
       expect(date_info.external_movement).to eq(false)
       expect(date_info.existing_visits.first.id).to eq('123')
@@ -33,7 +31,6 @@ RSpec.describe Nomis::PrisonerDetailedAvailability do
     described_class.new(
       dates: [{
         date: date,
-        banned: banned,
         out_of_vo: out_of_vo,
         external_movement: external_movement,
         existing_visits: existing_visits
@@ -47,7 +44,6 @@ RSpec.describe Nomis::PrisonerDetailedAvailability do
     let(:date) { requested_slot.to_date }
 
     context 'when unavailable' do
-      let(:banned) { false }
       let(:out_of_vo) { false }
       let(:external_movement) { false }
       let(:existing_visits) { [{ 'slot' => api_slot.to_s, 'id' => 123 }] }
@@ -56,7 +52,6 @@ RSpec.describe Nomis::PrisonerDetailedAvailability do
     end
 
     context 'when available' do
-      let(:banned) { false }
       let(:out_of_vo) { false }
       let(:external_movement) { false }
       let(:existing_visits) { [] }
@@ -71,7 +66,6 @@ RSpec.describe Nomis::PrisonerDetailedAvailability do
     let(:date) { requested_slot.to_date }
 
     context 'when available on that day' do
-      let(:banned) { false }
       let(:out_of_vo) { false }
       let(:external_movement) { false }
       let(:existing_visits) { [] }
@@ -80,7 +74,6 @@ RSpec.describe Nomis::PrisonerDetailedAvailability do
     end
 
     context 'when unavailable on that day for all the reasons' do
-      let(:banned) { true }
       let(:out_of_vo) { true }
       let(:external_movement) { true }
       let(:existing_visits) { [{ 'slot' => api_slot.to_s, 'id' => 123 }] }

--- a/spec/services/staff_nomis_checker_spec.rb
+++ b/spec/services/staff_nomis_checker_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe StaffNomisChecker do
         end
 
         context 'with an error' do
-          let(:messages) { [Nomis::PrisonerDateAvailability::BANNED] }
+          let(:messages) { [Nomis::PrisonerDateAvailability::EXTERNAL_MOVEMENT] }
 
           it { expect(subject.errors_for(slot)).to eq(messages) }
         end
@@ -294,26 +294,6 @@ RSpec.describe StaffNomisChecker do
       let(:errors) { [] }
 
       it { is_expected.not_to be_no_allowance(slot) }
-    end
-  end
-
-  describe '#prisoner_banned?' do
-    let(:slot) { ConcreteSlot.new(2015, 11, 6, 18, 0, 19, 0) }
-
-    before do
-      is_expected.to receive(:errors_for).with(slot).and_return(errors)
-    end
-
-    context 'when there is a prisoner banned error' do
-      let(:errors) { [Nomis::PrisonerDateAvailability::BANNED] }
-
-      it { is_expected.to be_prisoner_banned(slot) }
-    end
-
-    context "when there isn't prisoner banned error" do
-      let(:errors) { [] }
-
-      it { is_expected.not_to be_prisoner_banned(slot) }
     end
   end
 


### PR DESCRIPTION
We are in the process of getting a change made to one of the API endpoints
as it is incorrectly preventing visitors from being able to request online
visits if the prisoner is banned.  In anticipation of this we are also
removing the prisoner banned checkbox on the staff site as this should
also not be an option to reject a visit.