### PR TITLE
Fix stats for rejection reasons

### DIFF
--- a/app/models/rejection.rb
+++ b/app/models/rejection.rb
@@ -15,6 +15,7 @@ class Rejection < ApplicationRecord
   PRISONER_OUT_OF_PRISON = 'prisoner_out_of_prison'.freeze
   OTHER_REJECTION_REASON = 'other'.freeze
   VISITOR_OTHER_REASON = 'visitor_other_reason'.freeze
+  PRISONER_BANNED = 'prisoner_banned'.freeze
 
   REASONS = [
     CHILD_PROTECTION_ISSUES,
@@ -30,7 +31,8 @@ class Rejection < ApplicationRecord
     'duplicate_visit_request',
     PRISONER_OUT_OF_PRISON,
     OTHER_REJECTION_REASON,
-    VISITOR_OTHER_REASON
+    VISITOR_OTHER_REASON,
+    PRISONER_BANNED
   ].freeze
 
   belongs_to :visit, inverse_of: :rejection

--- a/spec/models/metrics/rejection_percentage_spec.rb
+++ b/spec/models/metrics/rejection_percentage_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Metrics::RejectionPercentage do
       expect(subject.as_json).to eq(child_protection_issues:    0,
                                     no_adult:                   0,
                                     no_allowance:               0,
+                                    prisoner_banned:            0,
                                     prisoner_details_incorrect: 0,
                                     prisoner_moved:             0,
                                     prisoner_non_association:   0,

--- a/spec/presenters/graph_metrics_presenter_spec.rb
+++ b/spec/presenters/graph_metrics_presenter_spec.rb
@@ -271,6 +271,7 @@ RSpec.describe GraphMetricsPresenter do
                                    duplicate_visit_request:    16.67,
                                    no_adult:                   3.03,
                                    no_allowance:               4.55,
+                                   prisoner_banned:            0,
                                    prisoner_details_incorrect: 6.06,
                                    prisoner_moved:             7.58,
                                    prisoner_non_association:   9.09,


### PR DESCRIPTION
Following the removal of the 'prisoner banned' rejection reason for staff
there has been a knock on impact for the stats page as the rejection
percentages rely on the rejection reasons; without 'prisoner_banned'
being in that list it fails with the error message, "undefined method
prisoner_banned=".  This is because we're creating methods based on that
list, and as we need to display historical data we cannot get rid of the
reason entirely.