### PR TITLE
Update amend visit email copy

### DIFF
--- a/config/locales/en/pvb2-mailers.yml
+++ b/config/locales/en/pvb2-mailers.yml
@@ -43,7 +43,7 @@ en:
         <a href="%{url}">you can cancel this visit</a>.
       want_to_change: >-
         If you want to change anything about your visit, like dates or visitors
-        coming, contact the prison.
+        coming, you should cancel your visit and request another one.
       questions_about_your_visit: Questions about your visit
       dont_reply: >-
         Please don’t reply to this email if you have any other questions about


### PR DESCRIPTION
Change email content to clarify that visitors can't contact the prison to change their visit.