### PR TITLE
Remove Wednesday slot for Woodhill

### DIFF
--- a/db/seeds/prisons/WHI-woodhill.yml
+++ b/db/seeds/prisons/WHI-woodhill.yml
@@ -17,8 +17,6 @@ lead_days: 3
 recurring:
   tue:
   - 1400-1600
-  wed:
-  - 1400-1600
   thu:
   - 1400-1600
   sat:


### PR DESCRIPTION
To remove the Wednesday visit slot for HMP Woodhill from the calendar at the prison's request. 