### PR TITLE
Remove Monday visit slot for Werrington

### DIFF
--- a/db/seeds/prisons/WNI-werrington.yml
+++ b/db/seeds/prisons/WNI-werrington.yml
@@ -12,8 +12,6 @@ private: false
 closed: false
 adult_age: 10
 recurring:
-  mon:
-  - 1415-1615
   tue:
   - 1415-1615
   wed:


### PR DESCRIPTION
Removing the Monday visit slot for HMP Werrington (information via APVU). 