### PR TITLE
FIX - Staff cancelled visits

### DIFF
--- a/app/controllers/prison/cancellations_controller.rb
+++ b/app/controllers/prison/cancellations_controller.rb
@@ -32,7 +32,10 @@ private
   end
 
   def cancellation_params
-    params.require(:cancellation).permit(reasons: [])
+    params.
+      require(:cancellation).
+      permit(reasons: []).
+      merge(nomis_cancelled: true)
   end
 
   def check_visit_cancellable

--- a/app/views/prison/visits/_cancel_visit.html.erb
+++ b/app/views/prison/visits/_cancel_visit.html.erb
@@ -1,5 +1,4 @@
 <%= form_for [:prison, @visit, @visit.cancellation], class: 'form' do |f| -%>
-  <%= hidden_field_tag :cancel_to_nomis_optout, true %>
   <h3 class="heading-medium"><%= t(".title") %></h3>
   <%= error_container(f, :reasons, class: 'form-group') do %>
     <div class="grid-row">

--- a/spec/services/estate_visit_query_spec.rb
+++ b/spec/services/estate_visit_query_spec.rb
@@ -166,6 +166,7 @@ RSpec.describe EstateVisitQuery do
     let!(:visit1) do
       create(:visit, :requested, prison: prison)
     end
+
     let!(:visit2) do
       create(:visit, :requested, prison: prison)
     end


### PR DESCRIPTION
Make sure that nomis_cancelled is set to true when processing a
cancellation made by a staff member so that it is not returned in the
cancellations requests view (only visitor cancellations should
appear in this view)

https://trello.com/c/60qfHJLF/168-staff-cancellation-bug