### PR TITLE
REMOVE Prisoner Location validation for PVB Public

### DIFF
--- a/app/services/api_prisoner_checker.rb
+++ b/app/services/api_prisoner_checker.rb
@@ -15,16 +15,12 @@ class ApiPrisonerChecker
   end
 
   def error
-    prisoner_validation.errors[:base].first || prisoner_location.errors[:base].first
+    prisoner_validation.errors[:base].first
   end
 
 private
 
   def prisoner_validation
     @prisoner_validation ||= PrisonerValidation.new(@prisoner).tap(&:valid?)
-  end
-
-  def prisoner_location
-    @prisoner_location ||= PrisonerLocationValidation.new(@prisoner).tap(&:valid?)
   end
 end

--- a/spec/services/api_prisoner_checker_spec.rb
+++ b/spec/services/api_prisoner_checker_spec.rb
@@ -18,41 +18,27 @@ RSpec.describe ApiPrisonerChecker, :expect_exception do
     end
 
     context 'when the api is enabled' do
-      context 'when the api call is successful' do
+      let(:prisoner) { Nomis::Prisoner.new(id: 'some_id', noms_id: 'a_noms_id') }
+
+      context 'when the prisoner is found' do
         before do
           mock_nomis_with(:lookup_active_prisoner, prisoner)
         end
 
-        describe 'when the prisoner is found' do
-          let(:prisoner) { Nomis::Prisoner.new(id: 'some_id', noms_id: 'a_noms_id') }
-
-          context 'with a valid establishment' do
-            let(:establishment) { Nomis::Establishment.new(code: 'a_code') }
-
-            before do
-              mock_nomis_with(:lookup_prisoner_location, establishment)
-            end
-
-            it { is_expected.to be_valid }
-          end
-
-          context 'when fetching the establishment returns an APIError' do
-            before do
-              simulate_api_error_for(:lookup_prisoner_location)
-            end
-
-            it { is_expected.not_to be_valid }
-          end
-        end
-
-        describe 'when the prisoner is not found' do
-          let(:prisoner) { Nomis::NullPrisoner.new(api_call_successful: true) }
-
-          it { is_expected.not_to be_valid }
-        end
+        it { is_expected.to be_valid }
       end
 
-      describe 'when the api call fails' do
+      context 'when the prisoner is not found' do
+        before do
+          mock_nomis_with(:lookup_active_prisoner, null_prisoner)
+        end
+
+        let(:null_prisoner) { Nomis::NullPrisoner.new(api_call_successful: true) }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context 'when the api call fails' do
         before do
           expect_any_instance_of(Nomis::Client).
             to receive(:get).and_raise(Nomis::APIError)


### PR DESCRIPTION
PVB2 is making a call to the Nomis API offender location  endpoint on
behalf of PVB Public endpoint when it does not need to. In addition, the
Nomis offender location end point is currently problematic (ticket has been raised for
possible database contention) and resulting in time outs.

Prisoner location validation is therefore removed from the
ApiPrisonerChecker class.

https://trello.com/c/BbQwKPsF/174-review-calls-to-nomis-offender-location-end-point