### PR TITLE
Fix inbox not showing old records

### DIFF
--- a/app/services/estate_visit_query.rb
+++ b/app/services/estate_visit_query.rb
@@ -28,26 +28,27 @@ class EstateVisitQuery
 
   def requested(query: nil)
     visits = Visit.
-             less_than_six_months_old.
              preload(:prisoner, :visitors, :prison).
              with_processing_state(:requested).
              from_estates(@estates).
              order('created_at asc')
-
-    visits = search(visits, query) if query
+    if query
+      visits = search(visits.less_than_six_months_old, query)
+    end
     visits.to_a
   end
 
   def cancelled(query: nil)
     visits = Visit.
-             less_than_six_months_old.
              preload(:prisoner, :visitors, :cancellation, :prison).
              joins(:cancellation).
              from_estates(@estates).
              where(cancellations: { nomis_cancelled: false }).
              order('created_at asc')
 
-    visits = search(visits, query) if query
+    if query
+      visits = search(visits.less_than_six_months_old, query)
+    end
     visits.to_a
   end
 

--- a/spec/services/estate_visit_query_spec.rb
+++ b/spec/services/estate_visit_query_spec.rb
@@ -118,22 +118,12 @@ RSpec.describe EstateVisitQuery do
     end
   end
 
-  shared_examples_for 'returns recent only' do
-    context 'when visits have not been updated in six months' do
-      let(:query) { nil }
-
-      it 'does not return them' do
-        expect(subject).not_to include(old_visit)
-      end
-    end
-  end
-
   shared_examples_for 'finds all' do
     context 'with no query' do
       let(:query) { nil }
 
-      it 'returns all requested' do
-        expect(subject).to eq([visit1, visit2])
+      it 'returns all requested ordered' do
+        expect(subject).to eq([old_visit, visit1, visit2])
       end
     end
   end
@@ -144,6 +134,16 @@ RSpec.describe EstateVisitQuery do
 
       it 'returns only those matching prisoner number' do
         expect(subject).to eq([visit1])
+      end
+    end
+  end
+
+  shared_examples_for "doesn't find old records" do
+    context 'with prisoner number query from an old visit' do
+      let(:query) { old_visit.prisoner.number }
+
+      it 'returns only those matching prisoner number' do
+        expect(subject).to be_empty
       end
     end
   end
@@ -178,7 +178,7 @@ RSpec.describe EstateVisitQuery do
     it_behaves_like 'finds all'
     it_behaves_like 'finds by prisoner number'
     it_behaves_like 'finds by human id'
-    it_behaves_like 'returns recent only'
+    it_behaves_like "doesn't find old records"
   end
 
   describe '#cancelled' do
@@ -200,7 +200,7 @@ RSpec.describe EstateVisitQuery do
     it_behaves_like 'finds all'
     it_behaves_like 'finds by prisoner number'
     it_behaves_like 'finds by human id'
-    it_behaves_like 'returns recent only'
+    it_behaves_like "doesn't find old records"
   end
 
   describe '#inbox_count' do


### PR DESCRIPTION
This change only hides the visits when searching, instead of always
hiding them.

Staff should be able to clear the inbox, even if it is for very old
records that are unbookable, otherwise the metrics will keep accounting
for them.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Prison details update (e.g. slot updates)

## Checklist:
- [ ] [My commit message follows the GDS git style standards we have adopted](https://github.com/alphagov/styleguides/blob/master/git.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the deployment repo accordingly.
- [ ] I have added tests to cover my changes.
