### PR TITLE
Update Docker registry location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ministryofjustice/ruby:2.5.3-webapp-onbuild
+FROM registry.service.dsd.io/ruby:2.5.3-webapp-onbuild
 
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" >  /etc/apt/sources.list.d/pgdg.list && \
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -


### PR DESCRIPTION
- part of the work to fix the ruby v2.5.3 upgrade
- Cloud Platform have requested we change the Docker registry location