### PR TITLE
Fix part of the weekly metrics CSV exporter

### DIFF
--- a/app/metrics/weekly_metrics_confirmed_csv_exporter.rb
+++ b/app/metrics/weekly_metrics_confirmed_csv_exporter.rb
@@ -53,7 +53,7 @@ private
 
   def ordered_counts
     min_date = @dates.min
-    max_date = @dates.max
+    max_date = @dates.max + 6.days
 
     if min_date.year != max_date.year
       min_counts = Counters::CountVisitsByPrisonAndCalendarWeek.


### PR DESCRIPTION
## Description, Motivation and Context

We found this week (7th Jan 2019) that this CSV export has zeroes for
everything.

The `CountVisitsByPrisonAndCalendarWeek` view has a fundamental problem which
this commit does not fix: it uses year and calendar week independently to
group visit data, so weeks which cover a January 1st which falls on a Tuesday,
Wednesday or Thursday will be wrongly grouped into the first week of the old
year, leaving that week with no data.

The exporter needs to be reimplemented to not depend on using calendar weeks
to fix this bug. I haven't done that here.

This commit does fix the data for the other surrounding weeks, though. The
query to retrieve data from the view had this WHERE clause:

    WHERE (year = 2018 AND week >= 42) AND (year = 2018 AND week <= 1)

Using the last day of the last week we're interested in as the `max_date` for
this query means that we get the right year, so the query is able to return
the right data for other weeks (except for the one over the new year explained
above).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Prison details update (e.g. slot updates)

## Checklist:

- [x] [My commit message follows the GDS git style standards we have adopted](https://github.com/alphagov/styleguides/blob/master/git.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the deployment repo accordingly.
- [x] I have added tests to cover my changes.
