### PR TITLE
Revert back to ruby 2.5.3 image

### DIFF
--- a/Dockerfile.kubernetes
+++ b/Dockerfile.kubernetes
@@ -1,4 +1,4 @@
-FROM ruby:2.6.2-stretch
+FROM ruby:2.5.3-stretch
 
 RUN \
   set -ex \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Forgot to revert image back to Ruby 2.5.3 in last PR

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Prison details update (e.g. slot updates)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask! -->
- [ ] [My commit message follows the GDS git style standards we have adopted](https://github.com/alphagov/styleguides/blob/master/git.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the deployment repo accordingly.
- [ ] I have added tests to cover my changes.
