### PR TITLE
Use rubocop-performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
+require: rubocop-performance
 require: rubocop-rspec
 
 AllCops:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
-require: rubocop-performance
-require: rubocop-rspec
+require:
+  - rubocop-performance
+  - rubocop-rspec
 
 AllCops:
   # Exclude anything that isn't really part of our code.
@@ -61,11 +62,6 @@ Style/CollectionMethods:
 Layout/DotPosition:
   EnforcedStyle: trailing
 
-# The holidays file has extra spaces for ease of reading and comparison
-Layout/ExtraSpacing:
-  Exclude:
-    - 'config/initializers/holidays.rb'
-
 # Percent-formatting and hash interpolation both have their place. Don't
 # enforce any particular one.
 Style/FormatString:
@@ -105,11 +101,6 @@ Metrics/MethodLength:
     - 'spec/**/*'
     - 'app/helpers/form_elements_helper.rb'
     - 'app/metrics/**/*' # Some very long SQL based methods there.
-
-# Don't worry about the complexity of spec methods
-Metrics/AbcSize:
-  Exclude:
-    - 'spec/**/*'
 
 # Enforce single quotes everywhere except in specs (because there's a lot of
 # human text with apostrophes in spec names, and using double quotes for all

--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ group :development, :test do
   gem 'pry-rails'
   gem 'rspec-rails'
   gem 'rubocop'
+  gem 'rubocop-performance'
   gem 'rubocop-rspec'
   gem 'awesome_print', require: 'ap'
   gem 'spring-commands-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,6 +287,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.6)
+    rubocop-performance (1.1.0)
+      rubocop (>= 0.67.0)
     rubocop-rspec (1.32.0)
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
@@ -421,6 +423,7 @@ DEPENDENCIES
   rspec-collection_matchers
   rspec-rails
   rubocop
+  rubocop-performance
   rubocop-rspec
   sass-rails
   scenic


### PR DESCRIPTION
## Description
The performance cops are being deprecated, and so now we need to use the
rubocop-performance gem.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? Required if your PR is not a slot update -->
<!--- Please add a link to any relevant Trello cards, Jira pages, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Prison details update (e.g. slot updates)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask! -->
- [X] [My commit message follows the GDS git style standards we have adopted](https://github.com/alphagov/styleguides/blob/master/git.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the deployment repo accordingly.
- [ ] I have added tests to cover my changes.
