### PR TITLE
Add flash alert re: service downtime

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,6 +5,10 @@ class SessionsController < ApplicationController
     if identity
       session[:sso_data] = identity.to_session
       redirect_to session.delete(:redirect_path) || prison_inbox_path
+
+      # Temporarily display flash notice ahead of PVB migration 25/7/19;
+      # it will removed once the migration has been completed
+      flash[:alert] = t('.service_update')
     else
       flash[:notice] = t('.cannot_sign_in')
       redirect_to root_path

--- a/config/locales/en/prison_views.yml
+++ b/config/locales/en/prison_views.yml
@@ -303,6 +303,7 @@ en:
         duplicate_visit_request: Duplicate visit request
   sessions:
     create:
+      service_update: This service will be unavailable from 10am - 2pm Thursday 25th July 2019
       cannot_sign_in: You cannot be signed in
   metrics:
     summary:

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe SessionsController, type: :controller do
 
         it 'clears the redirect from the session and redirects' do
           expect(create).to redirect_to(redirect_path)
+          expect(request.flash[:alert]).to eq "This service will be unavailable from 10am - 2pm Thursday 25th July 2019"
           expect(session[:redirect_path]).to be_nil
         end
       end
@@ -55,6 +56,7 @@ RSpec.describe SessionsController, type: :controller do
       context 'with no redirect_path set on the session' do
         it 'redirects to the inbox by default' do
           expect(create).to redirect_to(prison_inbox_path)
+          expect(request.flash[:alert]).to eq "This service will be unavailable from 10am - 2pm Thursday 25th July 2019"
         end
       end
     end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We are due to migrate PVB from template deploy to kubernetes by the end
of the week.  An email is being sent out to staff to alert them to this
news, however we are also going to add a flash alert that will be
displayed at the start of each session for that user.  This will
disappear as soon as they move on to another page, so not to be a
constant distraction.

This flash alert PR will need to be reverted as part of the migration
tasks to ensure staff do not see it once the work has been completed.

<img width="1066" alt="Screen Shot 2019-07-22 at 12 21 46" src="https://user-images.githubusercontent.com/20423761/61630099-bc81f100-ac7e-11e9-8743-200a68f9dd5e.png">


## Motivation and Context
<!--- Why is this change required? What problem does it solve? Required if your PR is not a slot update -->
<!--- Please add a link to any relevant Trello cards, Jira pages, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Prison details update (e.g. slot updates)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask! -->
- [ ] [My commit message follows the GDS git style standards we have adopted](https://github.com/alphagov/styleguides/blob/master/git.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the deployment repo accordingly.
- [ ] I have added tests to cover my changes.
