### PR TITLE
Ensure we use staff.prisonvisits.service.justice.gov.uk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'sidekiq'
 gem 'state_machines-activerecord'
 gem 'string_scrubber'
 gem 'turnout'
+gem 'rack-canonical-host'
 
 # Newer versions break ie8 js
 gem 'uglifier', '~> 2.7.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,6 +221,9 @@ GEM
     rack (2.0.7)
     rack-accept (0.4.5)
       rack (>= 0.4)
+    rack-canonical-host (0.2.3)
+      addressable (> 0, < 3)
+      rack (>= 1.0.0, < 3)
     rack-protection (2.0.5)
       rack
     rack-test (1.1.0)
@@ -427,6 +430,7 @@ DEPENDENCIES
   pry-rails
   puma
   pvb-instrumentation!
+  rack-canonical-host
   rails (~> 5.2)
   rails-controller-testing
   rake

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,5 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)
+use Rack::CanonicalHost, ENV['CANONICAL_HOST'] if ENV['CANONICAL_HOST']
 run Rails.application

--- a/deploy/production/shared-environment.yaml
+++ b/deploy/production/shared-environment.yaml
@@ -3,6 +3,7 @@ kind: ConfigMap
 metadata:
   name: shared-environment
 data:
+  CANONICAL_HOST: staff.prisonvisits.service.justice.gov.uk
   KUBERNETES_DEPLOYMENT: "true"
   MOJSSO_URL: "https://signon.service.justice.gov.uk"
   NOMIS_API_HOST: "https://gateway.nomis-api.service.justice.gov.uk/"

--- a/deploy/staging/shared-environment.yaml
+++ b/deploy/staging/shared-environment.yaml
@@ -3,6 +3,7 @@ kind: ConfigMap
 metadata:
   name: shared-environment
 data:
+  CANONICAL_HOST: staff-staging.local
   KUBERNETES_DEPLOYMENT: "true"
   MOJSSO_URL: "https://signon.service.justice.gov.uk"
   NOMIS_API_HOST: "https://gateway.preprod.nomis-api.service.hmpps.dsd.io/"


### PR DESCRIPTION
We don't want traffic to the old site, so if the site gets a request for
a non-canonical url it will redirect to the canonical host.

We need to ensure that public is also using the host name so that we don't get any requests redirected as part of the API call to staff.