### PR TITLE
Do not redirect staging

### DIFF
--- a/deploy/staging/shared-environment.yaml
+++ b/deploy/staging/shared-environment.yaml
@@ -3,7 +3,6 @@ kind: ConfigMap
 metadata:
   name: shared-environment
 data:
-  CANONICAL_HOST: staff-staging.local
   KUBERNETES_DEPLOYMENT: "true"
   MOJSSO_URL: "https://signon.service.justice.gov.uk"
   NOMIS_API_HOST: "https://gateway.preprod.nomis-api.service.hmpps.dsd.io/"


### PR DESCRIPTION
Remove breaking change to staging, where we were redirecting to a non-existent host.