### PR TITLE
Set the host header for the liveness probe

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,5 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)
+use Rack::CanonicalHost, ENV['CANONICAL_HOST'] if ENV['CANONICAL_HOST']
 run Rails.application

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -31,12 +31,18 @@ spec:
             - containerPort: 3000
           livenessProbe:
             httpGet:
+              httpHeaders:
+                - name: Host
+                  value: prison-visits-booking-staff-staging.apps.live-1.cloud-platform.service.justice.gov.uk
               path: /healthcheck
               port: 3000
             initialDelaySeconds: 10
             periodSeconds: 60
           readinessProbe:
             httpGet:
+              httpHeaders:
+                - name: Host
+                  value: prison-visits-booking-staff-staging.apps.live-1.cloud-platform.service.justice.gov.uk
               path: /healthcheck
               port: 3000
             initialDelaySeconds: 10

--- a/deploy/staging/shared-environment.yaml
+++ b/deploy/staging/shared-environment.yaml
@@ -3,6 +3,7 @@ kind: ConfigMap
 metadata:
   name: shared-environment
 data:
+  CANONICAL_HOST: prison-visits-public-staging.apps.live-1.cloud-platform.service.justice.gov.uk
   KUBERNETES_DEPLOYMENT: "true"
   MOJSSO_URL: "https://signon.service.justice.gov.uk"
   NOMIS_API_HOST: "https://gateway.preprod.nomis-api.service.hmpps.dsd.io/"


### PR DESCRIPTION
Set the host header for the liveness probe so that it is used by the app instead of the IP address 

The expectation is that livenessProbes will work because the HOST header in the config will be sent, allowing the CANONICAL_HOST match to succeed.