### PR TITLE
Revert "Set the host header for the liveness probe"

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,4 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)
-use Rack::CanonicalHost, ENV['CANONICAL_HOST'] if ENV['CANONICAL_HOST']
 run Rails.application

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -31,18 +31,12 @@ spec:
             - containerPort: 3000
           livenessProbe:
             httpGet:
-              httpHeaders:
-                - name: Host
-                  value: prison-visits-booking-staff-staging.apps.live-1.cloud-platform.service.justice.gov.uk
               path: /healthcheck
               port: 3000
             initialDelaySeconds: 10
             periodSeconds: 60
           readinessProbe:
             httpGet:
-              httpHeaders:
-                - name: Host
-                  value: prison-visits-booking-staff-staging.apps.live-1.cloud-platform.service.justice.gov.uk
               path: /healthcheck
               port: 3000
             initialDelaySeconds: 10

--- a/deploy/staging/shared-environment.yaml
+++ b/deploy/staging/shared-environment.yaml
@@ -3,7 +3,6 @@ kind: ConfigMap
 metadata:
   name: shared-environment
 data:
-  CANONICAL_HOST: prison-visits-public-staging.apps.live-1.cloud-platform.service.justice.gov.uk
   KUBERNETES_DEPLOYMENT: "true"
   MOJSSO_URL: "https://signon.service.justice.gov.uk"
   NOMIS_API_HOST: "https://gateway.preprod.nomis-api.service.hmpps.dsd.io/"


### PR DESCRIPTION
Reverts ministryofjustice/prison-visits-2#2355

Setting the host header simply causes the probe to fail with 
```
Liveness probe failed: Get http://100.96.36.122:3000/healthcheck: dial tcp 100.96.36.122:3000: connect: connection refused
```