### PR TITLE
Implement failure threshold for containers

### DIFF
--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -30,6 +30,7 @@ spec:
           ports:
             - containerPort: 3000
           livenessProbe:
+            failureThreshold: 6
             httpGet:
               path: /healthcheck
               port: 3000

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -30,6 +30,7 @@ spec:
           ports:
             - containerPort: 3000
           livenessProbe:
+            failureThreshold: 6
             httpGet:
               path: /healthcheck
               port: 3000


### PR DESCRIPTION
We recently experienced an issue where pods weren't starting as they'd
fail their liveness probe too many times and get killed.  By
introducing a failure limit of 6 we believe that will give all
containers the time they need to complete their tasks e.g. db:migrate &
db:seed and get to a ready state before hitting the failure threshold

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? Required if your PR is not a slot update -->
<!--- Please add a link to any relevant Trello cards, Jira pages, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Prison details update (e.g. slot updates)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask! -->
- [ ] [My commit message follows the GDS git style standards we have adopted](https://github.com/alphagov/styleguides/blob/master/git.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the deployment repo accordingly.
- [ ] I have added tests to cover my changes.
