### PR TITLE
Update liveness and readiness probes to do different things.

### DIFF
--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           livenessProbe:
             failureThreshold: 6
             httpGet:
-              path: /healthcheck
+              path: /ping
               port: 3000
             initialDelaySeconds: 10
             periodSeconds: 60

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           livenessProbe:
             failureThreshold: 6
             httpGet:
-              path: /healthcheck
+              path: /ping
               port: 3000
             initialDelaySeconds: 10
             periodSeconds: 60


### PR DESCRIPTION
During startup, we want the liveness probe to tell k8s our application
is live, as quickly as possible.  By changing the livenessProbe to point
at the NOP /ping endpoint we will respond as soon as we are handling
HTTP requests.

The readinessProbe is still connected to healthcheck because we want to
check that we _can_ still connect to the database, so that if we cannot
them K8s will not route to that POD if during its regular checks it does
not receive a response.
