### PR TITLE
Delete the migration job on completion

### DIFF
--- a/deploy/staging/migration_job.yaml
+++ b/deploy/staging/migration_job.yaml
@@ -9,6 +9,7 @@ spec:
   parallelism: 1
   template:
     spec:
+      ttlSecondsAfterFinished: 30
       containers:
         - name: prison-visits-staff-migration
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/prison-visits-booking/prison-visits-staff:latest


### PR DESCRIPTION
If we delete the job 30s after completion, we are allowing for the next
deployment to run, but also cleaning up stray pods.
