### PR TITLE
Delete job before deploy so that new job is created

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,6 +202,7 @@ jobs:
       - deploy:
           name: Deploy to staging
           command: |
+            kubectl delete job pvb-staff-migration --ignore-not-found
             sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/staging/deployment.yaml
             sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/staging/cronjob.yaml
             sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/staging/migration_job.yaml


### PR DESCRIPTION
Rather than try and update the job, by deleting it before we start we
are ensuring that we will be creating another job.