### PR TITLE
Make pods safely moveable

### DIFF
--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -12,8 +12,9 @@ spec:
   minReadySeconds: 10
   strategy:
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 2
+      maxSurge: 100%
+      maxUnavailable: 20%
+    type: RollingUpdate
   selector:
     matchLabels:
       app: prison-visits-booking-staff

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -12,8 +12,9 @@ spec:
   minReadySeconds: 10
   strategy:
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 2
+      maxSurge: 100%
+      maxUnavailable: 20%
+    type: RollingUpdate
   selector:
     matchLabels:
       app: prison-visits-booking-staff


### PR DESCRIPTION
Cloudplatform are making changes to ensure that pods don't get too old,
and to do this they will be randomly killing older pods from time to
time (and/or migrating them to other nodes).

This PR makes the recommended changes to ensure the system can safely
stay up and running during this process.
