### PR TITLE
Re-enable Heroku review apps

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bundle exec puma -C config/puma_prod.rb
-bundle exec sidekiq -C config/sidekiq.yml
+worker: bundle exec sidekiq -C config/sidekiq.yml
 release: bundle exec rails db:migrate

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -C config/puma_prod.rb
-worker: bundle exec sidekiq -c 5
+bundle exec sidekiq -C config/sidekiq.yml

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec puma -C config/puma_prod.rb
 bundle exec sidekiq -C config/sidekiq.yml
+release: bundle exec rails db:migrate

--- a/app.json
+++ b/app.json
@@ -1,8 +1,8 @@
 {
   "name": "prison-visits-2",
   "scripts": {
-    "postdeploy": "bundle exec rake db:migrate db:seed heroku:post_deploy pvb:populate:visits pvb:metrics:refresh",
-    "pr-predestroy": "bundle exec rake heroku:pr_destroy"
+    "postdeploy": "bundle exec rails db:migrate db:seed heroku:post_deploy pvb:populate:visits pvb:metrics:refresh",
+    "pr-predestroy": "bundle exec rails heroku:pr_destroy"
   },
   "env": {
     "SSO_REVIEW_PARENT_ID": {

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "prison-visits-2",
   "scripts": {
-    "postdeploy": "bundle exec rails db:migrate db:seed heroku:post_deploy pvb:populate:visits pvb:metrics:refresh",
+    "postdeploy": "bundle exec rails db:seed heroku:post_deploy pvb:populate:visits pvb:metrics:refresh",
     "pr-predestroy": "bundle exec rails heroku:pr_destroy"
   },
   "env": {

--- a/config/initializers/kubernetes_sidekiq_configuration.rb
+++ b/config/initializers/kubernetes_sidekiq_configuration.rb
@@ -1,7 +1,7 @@
 if Rails.env.production?
   Sidekiq.configure_server do |config|
     config.redis = {
-      url: "rediss://#{Rails.configuration.redis_url}:6379",
+      url: Rails.configuration.redis_url.to_s,
       network_timeout: 5,
       password: Rails.configuration.redis_password
     }
@@ -9,7 +9,7 @@ if Rails.env.production?
 
   Sidekiq.configure_client do |config|
     config.redis = {
-      url: "rediss://#{Rails.configuration.redis_url}:6379",
+      url: Rails.configuration.redis_url.to_s,
       network_timeout: 5,
       password: Rails.configuration.redis_password
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We are in the process of completing some work on PVB e.g. Google Analytics, which will need testing and so we have decided to reinstate Heroku review apps to assist with this.  

This PR makes a couple of adjustments for the setup, including removing the hardcoded port as this is provided by default and was causing issues for Heroku. I have also moved the DB migration to the release step of the deployment, and updated the command to get the sidekiq worker started.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? Required if your PR is not a slot update -->
<!--- Please add a link to any relevant Trello cards, Jira pages, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Prison details update (e.g. slot updates)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask! -->
- [ ] [My commit message follows the GDS git style standards we have adopted](https://github.com/alphagov/styleguides/blob/master/git.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the deployment repo accordingly.
- [ ] I have added tests to cover my changes.
