### PR TITLE
Update database credentials for kubernetes

### DIFF
--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -48,6 +48,12 @@ spec:
                 name: shared-environment
             - secretRef:
                 name: secrets
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: prison-visits-rds-instance-output
+                  key: url
           resources:
             limits:
               memory: "2Gi"


### PR DESCRIPTION
Our staging environment is not working correctly, it seems this is due to our credentials for the database not being in the correct location. This commit attempts to correct it.