### PR TITLE
Update database credentials for prod environment

### DIFF
--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -48,6 +48,12 @@ spec:
                 name: shared-environment
             - secretRef:
                 name: secrets
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: prison-visits-rds-instance-output
+                  key: url
           resources:
             limits:
               memory: "2Gi"


### PR DESCRIPTION
Our staging environment was not working due to upgrade changes
made to k8s. Staging has been fixed by pointing our credentials
to the correct location. As the production environment is due
to be recycled also this commit is to point our credentials to
the correct location so we don't have the same problems we
encountered in staging.

