### PR TITLE
add DATABASE_URL to sidekiq pod for processing visitor rejection etc

### DIFF
--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -73,6 +73,11 @@ spec:
           env:
             - name: "SCRIPT_NAME"
               value: "/sidekiq-admin"
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: prison-visits-rds-instance-output
+                  key: url
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -73,6 +73,11 @@ spec:
           env:
             - name: "SCRIPT_NAME"
               value: "/sidekiq-admin"
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: prison-visits-rds-instance-output
+                  key: url
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
#1663  Description
Populate DATABASE_URL for the sidekiq container.

## Motivation and Context
Sometime around 25th March 2020, a change appears to have occurred that resulted in the DATABASE_URL not being populated. This was fixed for the main container, but not for the sidekiq one. The result is that queued actions (such as visitor rejections) cannot be processed as the sidekiq pod doesn't have access to the database. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Prison details update (e.g. slot updates)

## Checklist:
- [ ] [My commit message follows the GDS git style standards we have adopted](https://github.com/alphagov/styleguides/blob/master/git.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the deployment repo accordingly.
- [ ] I have added tests to cover my changes.
