### PR TITLE
Bind prometheus exporter to all network interfaces

### DIFF
--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -91,7 +91,7 @@ spec:
         - name: prison-visits-booking-staff-metrics
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/prison-visits-booking/prison-visits-staff:latest
           imagePullPolicy: Always
-          command: ['sh', '-c', "bundle exec prometheus_exporter"]
+          command: ['sh', '-c', "bundle exec prometheus_exporter --bind 0.0.0.0"]
           envFrom:
             - configMapRef:
                 name: shared-environment

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -91,7 +91,7 @@ spec:
         - name: prison-visits-booking-staff-metrics
           image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/prison-visits-booking/prison-visits-staff:latest
           imagePullPolicy: Always
-          command: ['sh', '-c', "bundle exec prometheus_exporter"]
+          command: ['sh', '-c', "bundle exec prometheus_exporter --bind 0.0.0.0"]
           envFrom:
             - configMapRef:
                 name: shared-environment


### PR DESCRIPTION
## Description
This commit uses the new runtime option `-b (--bind)` to tell prometheus exporter to bind to all interfaces. This re-implements the old behaviour, making it once again available within the kube pod for our rails app to communicate with.

## Motivation and Context
There was a breaking change introduced in version 0.5.0 of the `prometheus_exporter` gem. By default, prometheus exporter now only binds to the `localhost` interface to avoid insecure configurations. These changes happened in commit: discourse/prometheus_exporter@f83b4f4

In our setup (running as docker containers inside a kubernetes pod) we need prometheus exporter to bind to ALL interfaces (as it previously did) rather than only to `localhost`. Without this, our rails application is unable to communicate with prometheus exporter, outputting messages like this in the log:

```
Prometheus Exporter, failed to send message Cannot assign requested address - connect(2) for "localhost" port 9394
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Prison details update (e.g. slot updates)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask! -->
- [x] [My commit message follows the GDS git style standards we have adopted](https://github.com/alphagov/styleguides/blob/master/git.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the deployment repo accordingly.
- [ ] I have added tests to cover my changes.
