### PR TITLE
Remove deprecated API for Kubernetes version 1.16

### DIFF
--- a/deploy/production/ingress-of-justice.yaml
+++ b/deploy/production/ingress-of-justice.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
  name: prison-visits-booking-staff-justice


### PR DESCRIPTION
I missed this from my previous commit Pull Request #2745. We have another Kubernetes ingress which I didn't see before.

I suspect the two ingress definitions could be merged into one – this would make it more obvious when looking for ingress configuration in the future. But for now I'm just fixing the use of APIs which aren't compatible with Kubernetes 1.16.