### PR TITLE
Tidy up rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,23 +27,6 @@ AllCops:
     - 'lib/tasks/elasticsearch.rake'
     - 'spec/dummy/db/**/*'
 
-#  DisplayCopNames: true
-
-Rails:
-  Enabled: true
-
-# private/protected/public
-Layout/AccessModifierIndentation:
-  EnforcedStyle: outdent
-
-# Just indent parameters by two spaces. It's less volatile if methods change,
-# and there's less busy work lining things up.
-Layout/ParameterAlignment:
-  EnforcedStyle: with_fixed_indentation
-
-Style/AsciiComments:
-  Enabled: false
-
 # Use Weirich style
 Style/BlockDelimiters:
   EnforcedStyle: semantic
@@ -55,31 +38,6 @@ Style/BlockDelimiters:
     - watch
     - expect
 
-# Allow ===. It's useful.
-Style/CaseEquality:
-  Enabled: false
-
-Style/CollectionMethods:
-  PreferredMethods:
-    inject: 'inject'
-    reduce: 'inject'
-
-# Chain methods with trailing dots.
-Layout/DotPosition:
-  EnforcedStyle: trailing
-
-# Percent-formatting and hash interpolation both have their place. Don't
-# enforce any particular one.
-Style/FormatString:
-  Enabled: false
-
-Style/FormatStringToken:
-  Enabled: false
-
-# It's not really clearer to replace every if with a return if.
-Style/GuardClause:
-  Enabled: false
-
 Style/SymbolArray:
   Enabled: false
 
@@ -90,18 +48,6 @@ Style/SymbolProc:
 # You can't use attr_reader to define a foo? method from @foo.
 Style/TrivialAccessors:
   AllowPredicates: true
-
-Naming/FileName:
-  Enabled: false
-
-# Default is 100
-Metrics/ClassLength:
-  Max: 200
-
-Layout/LineLength:
-  Max: 90
-  Exclude:
-    - 'spec/**/*'
 
 # Don't worry about long methods in specs.
 Metrics/MethodLength:
@@ -125,9 +71,6 @@ Style/Documentation:
   Description: Document classes and non-namespace modules.
   Enabled: false
 
-Style/DoubleNegation:
-  Enabled: false
-
 # Would enforce do_y if x over if x / do y / end. As with GuardClause above,
 # this enforces code organisation that doesn't necesarily make things clearer.
 Style/IfUnlessModifier:
@@ -145,9 +88,6 @@ Style/PercentLiteralDelimiters:
     '%W': '[]'
     '%': '{}'
 
-Style/ClassAndModuleChildren:
-  Enabled: false
-
 # This encourages bad style IMHO
 Rails/Delegate:
   Enabled: false
@@ -156,9 +96,6 @@ RSpec/AnyInstance:
   Enabled: false
 
 Bundler/OrderedGems:
-  Enabled: false
-
-Metrics/AbcSize:
   Enabled: false
 
 Metrics/BlockLength:
@@ -177,7 +114,7 @@ RSpec/EmptyExampleGroup:
   Enabled: false
 
 RSpec/ExampleLength:
-  Enabled: false
+  Max: 48
 
 RSpec/HookArgument:
   Enabled: false
@@ -198,7 +135,7 @@ RSpec/MessageSpies:
   Enabled: false
 
 RSpec/MultipleExpectations:
-  Enabled: false
+  Max: 27
 
 RSpec/NamedSubject:
   Enabled: false
@@ -227,18 +164,13 @@ Rails/HttpPositionalArguments:
 Rails/OutputSafety:
   Enabled: false
 
-Rails/SkipsModelValidations:
-  Enabled: false
-
 Rails/ApplicationRecord:
   Enabled: false
+
 Rails/ApplicationJob:
   Enabled: false
 
 Security/YAMLLoad:
-  Enabled: false
-
-Style/Alias:
   Enabled: false
 
 Layout/ClosingParenthesisIndentation:
@@ -287,9 +219,6 @@ Style/NumericPredicate:
   Enabled: false
 
 Style/SignalException:
-  Enabled: false
-
-Layout/SpaceAroundKeyword:
   Enabled: false
 
 Layout/SpaceBeforeBlockBraces:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,8 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rails.yml
+
 require:
   - rubocop-performance
   - rubocop-rails
@@ -22,7 +27,7 @@ AllCops:
     - 'lib/tasks/elasticsearch.rake'
     - 'spec/dummy/db/**/*'
 
-  DisplayCopNames: true
+#  DisplayCopNames: true
 
 Rails:
   Enabled: true
@@ -306,4 +311,35 @@ Lint/AmbiguousBlockAssociation:
   Enabled: false
 
 Capybara/FeatureMethods:
+  Enabled: false
+
+# Below here are failing GovUk styles
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false
+
+Style/MethodCalledOnDoEndBlock:
+  Enabled: false
+
+Layout/TrailingWhitespace:
+  Enabled: false
+
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: false
+
+Layout/TrailingEmptyLines:
+  Enabled: false
+
+Layout/EmptyLineBetweenDefs:
+  Enabled: false
+
+Layout/EmptyLinesAroundAccessModifier:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -328,18 +328,3 @@ Style/WordArray:
 
 Style/MethodCalledOnDoEndBlock:
   Enabled: false
-
-Layout/TrailingWhitespace:
-  Enabled: false
-
-Layout/EmptyLinesAroundModuleBody:
-  Enabled: false
-
-Layout/TrailingEmptyLines:
-  Enabled: false
-
-Layout/EmptyLineBetweenDefs:
-  Enabled: false
-
-Layout/EmptyLinesAroundAccessModifier:
-  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'rspec-rails'
+  gem 'rubocop-govuk'
   gem 'rubocop'
   gem 'rubocop-performance'
   gem 'rubocop-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,6 +298,10 @@ GEM
       rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (3.3.2)
+      rubocop (= 0.80.1)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-performance (1.6.1)
       rubocop (>= 0.71.0)
     rubocop-rails (2.5.2)
@@ -449,6 +453,7 @@ DEPENDENCIES
   rspec-collection_matchers
   rspec-rails
   rubocop
+  rubocop-govuk
   rubocop-performance
   rubocop-rails
   rubocop-rspec

--- a/app/controllers/concerns/staff_response_context.rb
+++ b/app/controllers/concerns/staff_response_context.rb
@@ -75,8 +75,6 @@ private
       staff_response,
       message: message)
   end
-
-  # rubocop:disable Metrics/MethodLength
   def visit_params
     params.require(:visit).permit(
       :reference_no, :slot_granted, :closed, :slot_option_0,
@@ -101,5 +99,5 @@ private
       prisoner_attributes: [:nomis_offender_id, :id]
     )
   end
-  # rubocop:enable Metrics/MethodLength
+  
 end

--- a/app/controllers/concerns/staff_response_context.rb
+++ b/app/controllers/concerns/staff_response_context.rb
@@ -75,6 +75,7 @@ private
       staff_response,
       message: message)
   end
+
   def visit_params
     params.require(:visit).permit(
       :reference_no, :slot_granted, :closed, :slot_option_0,
@@ -99,5 +100,4 @@ private
       prisoner_attributes: [:nomis_offender_id, :id]
     )
   end
-  
 end

--- a/app/controllers/prison/cancellations_controller.rb
+++ b/app/controllers/prison/cancellations_controller.rb
@@ -4,8 +4,6 @@ class Prison::CancellationsController < ApplicationController
   before_action :authorize_prison_request
   before_action :authenticate_user
   before_action :check_visit_cancellable
-
-  # rubocop:disable Metrics/MethodLength
   def create
     if cancellation_response.valid?
       cancellation_response.cancel!
@@ -19,7 +17,7 @@ class Prison::CancellationsController < ApplicationController
       render :new
     end
   end
-# rubocop:enable Metrics/MethodLength
+
 
 private
 

--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -25,7 +25,6 @@ class Prison::VisitsController < ApplicationController
       render :show
     end
   end
-  
 
   def nomis_cancelled
     memoised_visit.confirm_nomis_cancelled

--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -9,8 +9,6 @@ class Prison::VisitsController < ApplicationController
 
   GA_HIT_TYPE_VISIT_PROCESSED = '/visit-processed'.freeze
   GA_HIT_TYPE_VISIT_REQUESTED = '/visit-requested'.freeze
-
-  # rubocop:disable Metrics/MethodLength
   def update
     memoised_visit.assign_attributes(visit_params)
     @booking_response = booking_responder.respond!
@@ -27,7 +25,7 @@ class Prison::VisitsController < ApplicationController
       render :show
     end
   end
-  # rubocop:enable Metrics/MethodLength
+  
 
   def nomis_cancelled
     memoised_visit.confirm_nomis_cancelled

--- a/app/decorators/concrete_slot_decorator.rb
+++ b/app/decorators/concrete_slot_decorator.rb
@@ -81,7 +81,6 @@ class ConcreteSlotDecorator < Draper::Decorator
 
     nil
   end
-  
 
   def bookable?
     prisoner_available? && slot_available?

--- a/app/decorators/concrete_slot_decorator.rb
+++ b/app/decorators/concrete_slot_decorator.rb
@@ -7,8 +7,6 @@ class ConcreteSlotDecorator < Draper::Decorator
       'conditional-val' => 'slot_option_0,slot_option_1,slot_option2'
     }.freeze
   }.freeze
-
-  # rubocop:disable Metrics/MethodLength
   def slot_picker(form_builder)
     h.concat(
       h.content_tag(
@@ -83,7 +81,7 @@ class ConcreteSlotDecorator < Draper::Decorator
 
     nil
   end
-  # rubocop:enable Metrics/MethodLength
+  
 
   def bookable?
     prisoner_available? && slot_available?

--- a/app/decorators/rejection_decorator.rb
+++ b/app/decorators/rejection_decorator.rb
@@ -163,6 +163,7 @@ private
       day: date.day
     }
   end
+
   def email_translated_explanations_for(reason)
     case reason
     when Rejection::SLOT_UNAVAILABLE
@@ -179,7 +180,6 @@ private
       )]
     end
   end
-  
 
   def email_visitor_rejection_reasons
     visit.banned_visitors.map do |visitor|

--- a/app/decorators/rejection_decorator.rb
+++ b/app/decorators/rejection_decorator.rb
@@ -163,8 +163,6 @@ private
       day: date.day
     }
   end
-
-  # rubocop:disable Metrics/MethodLength
   def email_translated_explanations_for(reason)
     case reason
     when Rejection::SLOT_UNAVAILABLE
@@ -181,7 +179,7 @@ private
       )]
     end
   end
-  # rubocop:enable Metrics/MethodLength
+  
 
   def email_visitor_rejection_reasons
     visit.banned_visitors.map do |visitor|

--- a/app/decorators/visitor_decorator.rb
+++ b/app/decorators/visitor_decorator.rb
@@ -20,7 +20,6 @@ class VisitorDecorator < Draper::Decorator
       )
     end
   end
-  
 
   def exact_match?
     exact_matches.contact.present?

--- a/app/decorators/visitor_decorator.rb
+++ b/app/decorators/visitor_decorator.rb
@@ -2,8 +2,6 @@ class VisitorDecorator < Draper::Decorator
   delegate_all
 
   NO_VISITORS_IN_NOMIS = 'no_visitor_in_nomis'.freeze
-
-  # rubocop:disable Metrics/MethodLength
   def contact_list_matching(form_build)
     return I18n.t(".#{NO_VISITORS_IN_NOMIS}") unless contact_list_matcher.any?
 
@@ -22,7 +20,7 @@ class VisitorDecorator < Draper::Decorator
       )
     end
   end
-  # rubocop:enable Metrics/MethodLength
+  
 
   def exact_match?
     exact_matches.contact.present?

--- a/app/models/api_slot_availability.rb
+++ b/app/models/api_slot_availability.rb
@@ -5,8 +5,6 @@ class ApiSlotAvailability
     @prison = prison
     @slots = (use_nomis_slots && nomis_slots(prison)) || hardcoded_slots(prison)
   end
-
-  # rubocop:disable Metrics/MethodLength
   def restrict_by_prisoner(prisoner_number:, prisoner_dob:)
     return unless Nomis::Api.enabled?
 
@@ -29,7 +27,7 @@ class ApiSlotAvailability
     # Skip restriction if NOMIS API is misbehaving
     Rails.logger.warn "Error calling the NOMIS API: #{e.inspect}"
   end
-# rubocop:enable Metrics/MethodLength
+
 
 private
 

--- a/app/models/api_slot_availability.rb
+++ b/app/models/api_slot_availability.rb
@@ -5,6 +5,7 @@ class ApiSlotAvailability
     @prison = prison
     @slots = (use_nomis_slots && nomis_slots(prison)) || hardcoded_slots(prison)
   end
+
   def restrict_by_prisoner(prisoner_number:, prisoner_dob:)
     return unless Nomis::Api.enabled?
 

--- a/app/models/staff_response.rb
+++ b/app/models/staff_response.rb
@@ -43,7 +43,6 @@ class StaffResponse
     attrs['visitors_attributes']  = visitors_attributes  if visitors_attributes
     attrs
   end
-  
 
   # rubocop:disable Naming/MemoizedInstanceVariableName
   def validate_visitors_nomis_ready=(val)

--- a/app/models/staff_response.rb
+++ b/app/models/staff_response.rb
@@ -18,8 +18,6 @@ class StaffResponse
 
   after_validation :clear_allowance_renews_on_date
   after_validation :sanitise_reasons
-
-  # rubocop:disable Metrics/MethodLength
   def email_attrs
     attrs = visit.serializable_hash(
       except: [
@@ -45,7 +43,7 @@ class StaffResponse
     attrs['visitors_attributes']  = visitors_attributes  if visitors_attributes
     attrs
   end
-  # rubocop:enable Metrics/MethodLength
+  
 
   # rubocop:disable Naming/MemoizedInstanceVariableName
   def validate_visitors_nomis_ready=(val)

--- a/app/services/booked_visits_csv_exporter.rb
+++ b/app/services/booked_visits_csv_exporter.rb
@@ -35,8 +35,6 @@ private
   def csv_row(visit)
     visit_attrs(visit).merge(additional_visitor_attrs(visit.visitors))
   end
-
-  # rubocop:disable Metrics/MethodLength
   def visit_attrs(visit)
     {
       'Status' => visit.processing_state,
@@ -52,7 +50,7 @@ private
       'Email address' => visit.contact_email_address
     }
   end
-  # rubocop:enable Metrics/MethodLength
+  
 
   def additional_visitor_attrs(visitors)
     attrs = {}

--- a/app/services/booked_visits_csv_exporter.rb
+++ b/app/services/booked_visits_csv_exporter.rb
@@ -35,6 +35,7 @@ private
   def csv_row(visit)
     visit_attrs(visit).merge(additional_visitor_attrs(visit.visitors))
   end
+
   def visit_attrs(visit)
     {
       'Status' => visit.processing_state,
@@ -50,7 +51,6 @@ private
       'Email address' => visit.contact_email_address
     }
   end
-  
 
   def additional_visitor_attrs(visitors)
     attrs = {}

--- a/app/services/nomis/api.rb
+++ b/app/services/nomis/api.rb
@@ -19,6 +19,7 @@ module Nomis
           Rails.configuration.nomis_oauth_host)
       end
     end
+
     # Looks for an active offender with the provided details
     #
     #  noms_id: A nomis number (e.g. A1234AA)
@@ -40,7 +41,6 @@ module Nomis
       PVB::ExceptionHandler.capture_exception(e, fingerprint: %w[nomis api_error])
       NullPrisoner.new(api_call_successful: false)
     end
-    
 
     # Returns offenders details given a noms_id
     #

--- a/app/services/nomis/api.rb
+++ b/app/services/nomis/api.rb
@@ -19,8 +19,6 @@ module Nomis
           Rails.configuration.nomis_oauth_host)
       end
     end
-
-    # rubocop:disable Metrics/MethodLength
     # Looks for an active offender with the provided details
     #
     #  noms_id: A nomis number (e.g. A1234AA)
@@ -42,7 +40,7 @@ module Nomis
       PVB::ExceptionHandler.capture_exception(e, fingerprint: %w[nomis api_error])
       NullPrisoner.new(api_call_successful: false)
     end
-    # rubocop:enable Metrics/MethodLength
+    
 
     # Returns offenders details given a noms_id
     #

--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -44,6 +44,7 @@ module Nomis
     end
 
   private
+
     def request(method, route, params, idempotent:, options: {})
       path = "/elite2api/api/v1/#{route}"
 
@@ -84,7 +85,6 @@ module Nomis
       PVB::ExceptionHandler.capture_exception(e, fingerprint: excon_fingerprint)
       raise APIError, "Exception #{e.class} calling #{api_method}: #{e}"
     end
-    
 
     # Returns excon options which put params in either the query string or body.
     def params_options(_method, params)

--- a/app/services/nomis/client.rb
+++ b/app/services/nomis/client.rb
@@ -44,8 +44,6 @@ module Nomis
     end
 
   private
-
-    # rubocop:disable Metrics/MethodLength
     def request(method, route, params, idempotent:, options: {})
       path = "/elite2api/api/v1/#{route}"
 
@@ -86,7 +84,7 @@ module Nomis
       PVB::ExceptionHandler.capture_exception(e, fingerprint: excon_fingerprint)
       raise APIError, "Exception #{e.class} calling #{api_method}: #{e}"
     end
-    # rubocop:enable Metrics/MethodLength
+    
 
     # Returns excon options which put params in either the query string or body.
     def params_options(_method, params)

--- a/app/services/nomis/oauth/client.rb
+++ b/app/services/nomis/oauth/client.rb
@@ -19,14 +19,12 @@ module Nomis
       end
 
     private
-
-      # rubocop:disable Layout/LineLength
       def authorisation
         'Basic ' + Base64.urlsafe_encode64(
           "#{Rails.configuration.nomis_oauth_client_id}:#{Rails.configuration.nomis_oauth_client_secret}"
         )
       end
-      # rubocop:enable Layout/LineLength
+      
     end
   end
 end

--- a/app/services/nomis/oauth/client.rb
+++ b/app/services/nomis/oauth/client.rb
@@ -19,12 +19,12 @@ module Nomis
       end
 
     private
+
       def authorisation
         'Basic ' + Base64.urlsafe_encode64(
           "#{Rails.configuration.nomis_oauth_client_id}:#{Rails.configuration.nomis_oauth_client_secret}"
         )
       end
-      
     end
   end
 end

--- a/app/services/slot_availability.rb
+++ b/app/services/slot_availability.rb
@@ -56,8 +56,6 @@ private
       prison: prison,
       requested_slots: prison_slots).tap(&:valid?)
   end
-
-  # rubocop:disable Metrics/MethodLength
   def prisoner_availability
     @prisoner_availability ||=
       begin
@@ -71,7 +69,7 @@ private
         Nomis::PrisonerAvailability.new(dates: all_slots.keys.uniq)
       end
   end
-  # rubocop:enable Metrics/MethodLength
+  
 
   def prisoner_availability_dates
     @prisoner_availability_dates ||= prisoner_availability.dates

--- a/app/services/slot_availability.rb
+++ b/app/services/slot_availability.rb
@@ -56,6 +56,7 @@ private
       prison: prison,
       requested_slots: prison_slots).tap(&:valid?)
   end
+
   def prisoner_availability
     @prisoner_availability ||=
       begin
@@ -69,7 +70,6 @@ private
         Nomis::PrisonerAvailability.new(dates: all_slots.keys.uniq)
       end
   end
-  
 
   def prisoner_availability_dates
     @prisoner_availability_dates ||= prisoner_availability.dates

--- a/config/initializers/turnout.rb
+++ b/config/initializers/turnout.rb
@@ -8,4 +8,3 @@ Turnout.configure do |config|
   config.default_response_code = 503
   config.default_retry_after = 7200
 end
-

--- a/config/initializers/turnout.rb
+++ b/config/initializers/turnout.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Layout/LineLength
 Turnout.configure do |config|
   config.app_root = '.'
   config.named_maintenance_file_paths = { default: config.app_root.join('tmp', 'maintenance.yml').to_s }
@@ -9,4 +8,4 @@ Turnout.configure do |config|
   config.default_response_code = 503
   config.default_retry_after = 7200
 end
-# rubocop:enable Layout/LineLength
+

--- a/lib/excon/middleware/custom_idempotent.rb
+++ b/lib/excon/middleware/custom_idempotent.rb
@@ -9,10 +9,6 @@
 module Excon
   module Middleware
     class CustomIdempotent < Excon::Middleware::Base
-      # rubocop:disable Metrics/MethodLength
-      # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/PerceivedComplexity
-      # rubocop:disable Layout/LineLength
       def error_call(datum)
         if datum[:idempotent]
           if datum.key?(:request_block)
@@ -41,9 +37,9 @@ module Excon
         end
       end
     end
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/PerceivedComplexity
-    # rubocop:enable Layout/LineLength
+    
+    
+    
+    
   end
 end

--- a/lib/excon/middleware/custom_idempotent.rb
+++ b/lib/excon/middleware/custom_idempotent.rb
@@ -37,9 +37,5 @@ module Excon
         end
       end
     end
-    
-    
-    
-    
   end
 end

--- a/lib/excon/middleware/custom_instrumentor.rb
+++ b/lib/excon/middleware/custom_instrumentor.rb
@@ -44,5 +44,3 @@ module Excon
     end
   end
 end
-
-

--- a/lib/excon/middleware/custom_instrumentor.rb
+++ b/lib/excon/middleware/custom_instrumentor.rb
@@ -2,8 +2,6 @@
 
 #
 # :nocov:
-# rubocop:disable Layout/LineLength
-# rubocop:disable Metrics/MethodLength
 module Excon
   module Middleware
     class CustomInstrumentor < Excon::Middleware::Base
@@ -46,5 +44,5 @@ module Excon
     end
   end
 end
-# rubocop:enable Layout/LineLength
-# rubocop:enable Metrics/MethodLength
+
+

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -1,4 +1,3 @@
-# rubocop:disable Metrics/MethodLength
 namespace :pvb do
   namespace :populate do
     def generate_prisoner_number
@@ -155,4 +154,4 @@ namespace :pvb do
     end
   end
 end
-# rubocop:enable Metrics/MethodLength
+

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -154,4 +154,3 @@ namespace :pvb do
     end
   end
 end
-


### PR DESCRIPTION
## Description
Seeing rubocop warnings while using the PVB codebase is annoying. This PR brings in rubocop-govuk (just like MOIC) and removes the noise as a result.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Prison details update (e.g. slot updates)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask! -->
- [x] [My commit message follows the GDS git style standards we have adopted](https://github.com/alphagov/styleguides/blob/master/git.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the deployment repo accordingly.
- [ ] I have added tests to cover my changes.
