### PR TITLE
POM-781 allow nomis slot testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ workflows:
            branches:
              only:
               - main
-              - add-k8s-ips-to-internal-list
+              - pom781-allow-nomis-slot-testing
      - deploy_staging:
          requires:
            - build_and_push_docker_image
@@ -230,7 +230,7 @@ workflows:
            branches:
              only:
                - main
-               - add-k8s-ips-to-internal-list
+               - pom781-allow-nomis-slot-testing
      - deploy_production_approval:
          type: approval
          requires:

--- a/app/models/api_slot_availability.rb
+++ b/app/models/api_slot_availability.rb
@@ -44,7 +44,7 @@ private
       prison: prison,
       start_date: prison.first_bookable_date,
       end_date: prison.last_bookable_date
-    )
+    ).slots.map(&:time)
   rescue Excon::Errors::Error => e
     Rails.logger.warn "Error calling the NOMIS API: #{e.inspect}"
     nil

--- a/app/models/api_slot_availability.rb
+++ b/app/models/api_slot_availability.rb
@@ -51,6 +51,6 @@ private
   end
 
   def public_prison_slots_enabled?(_prison)
-    false
+    true
   end
 end

--- a/spec/models/api_slot_availability_spec.rb
+++ b/spec/models/api_slot_availability_spec.rb
@@ -60,19 +60,19 @@ RSpec.describe ApiSlotAvailability, type: :model do
       subject { described_class.new(prison: prison, use_nomis_slots: true) }
 
       context 'when the prison slots feature is disabled' do
+        before do
+          allow_any_instance_of(described_class).
+            to receive(:public_prison_slots_enabled?).
+              with(prison).
+              and_return(false)
+        end
+
         it 'fetches slot availability from the prison defaults' do
           expect(subject.slots.map(&:iso8601)).to eq(default_prison_slots)
         end
       end
 
       context 'when the prison slots feature is enabled' do
-        before do
-          allow_any_instance_of(described_class).
-            to receive(:public_prison_slots_enabled?).
-            with(prison).
-            and_return(true)
-        end
-
         it 'requests slots from NOMIS' do
           expect(Nomis::Api.instance).to receive(:fetch_bookable_slots).
             with(

--- a/spec/models/api_slot_availability_spec.rb
+++ b/spec/models/api_slot_availability_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe ApiSlotAvailability, type: :model do
               start_date: Date.parse('2016-04-06'),
               end_date: Date.parse('2016-04-28')
             ).
-            and_return([ConcreteSlot.parse('2016-04-12T09:00/10:00')])
+            and_return(Struct.new(:slots).new([Struct.new(:time).new(ConcreteSlot.parse('2016-04-12T09:00/10:00'))]))
 
           expect(subject.slots.map(&:iso8601)).to eq(['2016-04-12T09:00/10:00'])
         end


### PR DESCRIPTION
## Description
The (currently unused) ApiSlotAvailability class needed tweaking in order for it to be usable for testing

## Motivation and Context
The ApiSlotAvailability class was effectively disabled as it was hard-coded to be 'false' for all prisons. This PR changes that default to 'true' to allow testing of the API return values

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Prison details update (e.g. slot updates)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask! -->
- [x] [My commit message follows the GDS git style standards we have adopted](https://github.com/alphagov/styleguides/blob/master/git.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the deployment repo accordingly.
- [x] I have added tests to cover my changes.
