### PR TITLE
POM-222 auto slot updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,7 @@ group :test do
   gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'simplecov'
+  gem 'timecop'
   gem 'vcr'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,6 +369,7 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.9)
+    timecop (0.9.1)
     turnout (2.5.0)
       i18n (>= 0.7, < 2)
       rack (>= 1.3, < 3)
@@ -467,6 +468,7 @@ DEPENDENCIES
   sprockets (< 4)
   state_machines-activerecord
   string_scrubber
+  timecop
   turnout
   uglifier (~> 2.7.2)
   uri_template

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "prison-visits-2",
   "scripts": {
-    "postdeploy": "bundle exec rails db:seed heroku:post_deploy pvb:populate:visits pvb:metrics:refresh",
+    "postdeploy": "bundle exec rails db:seed heroku:post_deploy pvb:load_nomis_slots pvb:populate:visits pvb:metrics:refresh",
     "pr-predestroy": "bundle exec rails heroku:pr_destroy"
   },
   "env": {

--- a/app/controllers/api/slots_controller.rb
+++ b/app/controllers/api/slots_controller.rb
@@ -2,10 +2,14 @@ module Api
   class SlotsController < ApiController
     def index
       prison = Prison.enabled.find(params.require(:prison_id))
-      slot_availability = SlotAvailability.new(
-        prison, prisoner_number, date_of_birth, start_date..end_date)
 
-      @slots = slot_availability.slots
+      if prison.auto_slots_enabled?
+        api_slots = ApiSlotAvailability.new(prison: prison, use_nomis_slots: true, start_date: start_date, end_date: end_date)
+        prisoner_dates = api_slots.prisoner_available_dates(prisoner_number: prisoner_number, prisoner_dob: date_of_birth, start_date: start_date)
+        @slots = api_slots.slots.map { |slot| [slot.to_s, prisoner_dates.include?(slot.to_date) ? [] : [SlotAvailability::PRISONER_UNAVAILABLE]] }.to_h
+      else
+        @slots = SlotAvailability.new(prison, prisoner_number, date_of_birth, start_date..end_date).slots
+      end
     end
 
   private

--- a/app/models/api_slot_availability.rb
+++ b/app/models/api_slot_availability.rb
@@ -1,12 +1,12 @@
 class ApiSlotAvailability
   attr_reader :slots
 
-  def initialize(prison:, use_nomis_slots: true)
+  def initialize(prison:, use_nomis_slots: true, start_date: Time.zone.today, end_date: Time.zone.today + 30.days)
     @prison = prison
-    @slots = (use_nomis_slots && nomis_slots(prison)) || hardcoded_slots(prison)
+    @slots = (use_nomis_slots && nomis_slots(prison, prison.first_bookable_date(start_date), end_date)) || hardcoded_slots(prison)
   end
 
-  def prisoner_available_dates(prisoner_number:, prisoner_dob:)
+  def prisoner_available_dates(prisoner_number:, prisoner_dob:, start_date:)
     return unless Nomis::Api.enabled?
 
     prisoner = Nomis::Api.instance.lookup_active_prisoner(
@@ -16,8 +16,8 @@ class ApiSlotAvailability
 
     availability = Nomis::Api.instance.prisoner_visiting_availability(
       offender_id: prisoner.nomis_offender_id,
-      start_date: @prison.first_bookable_date,
-      end_date: @prison.last_bookable_date
+      start_date: @prison.first_bookable_date(start_date),
+      end_date: @prison.last_bookable_date(start_date)
     )
     availability.dates
   rescue Excon::Errors::Error => e
@@ -28,24 +28,23 @@ class ApiSlotAvailability
 
 private
 
+  def calculate_end_date(date_range)
+    # ensures the range does not go over the 28 days constraint
+    [date_range.min + 28.days, date_range.max].min
+  end
+
   def hardcoded_slots(prison)
     prison.available_slots.to_a
   end
 
-  def nomis_slots(prison)
-    return nil if !Nomis::Api.enabled? || !public_prison_slots_enabled?(prison)
-
+  def nomis_slots(prison, start_date, end_date)
     Nomis::Api.instance.fetch_bookable_slots(
       prison: prison,
-      start_date: prison.first_bookable_date,
-      end_date: prison.last_bookable_date
+      start_date: start_date,
+      end_date: calculate_end_date(start_date..end_date)
     ).slots.map(&:time)
   rescue Excon::Errors::Error => e
     Rails.logger.warn "Error calling the NOMIS API: #{e.inspect}"
     nil
-  end
-
-  def public_prison_slots_enabled?(prison)
-    Rails.configuration.public_prisons_with_slot_availability&.include?(prison.name)
   end
 end

--- a/app/models/nomis_concrete_slot.rb
+++ b/app/models/nomis_concrete_slot.rb
@@ -1,0 +1,3 @@
+class NomisConcreteSlot < ApplicationRecord
+  belongs_to :prison, inverse_of: :nomis_concrete_slots
+end

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -88,11 +88,11 @@ class Prison < ApplicationRecord
     attempt_translation(:address, super)
   end
 
-private
-
   def auto_slots_enabled?
     Rails.configuration.public_prisons_with_slot_availability&.include?(name)
   end
+
+private
 
   def attempt_translation(key, fallback)
     translations.fetch(I18n.locale.to_s, {}).fetch(key.to_s, fallback)

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -5,6 +5,7 @@ class Prison < ApplicationRecord
 
   has_many :visits, dependent: :destroy
   belongs_to :estate
+  has_many :nomis_concrete_slots, dependent: :destroy
 
   validates :estate, :name, :slot_details, presence: true
   validates :enabled, inclusion: { in: [true, false] }
@@ -24,11 +25,22 @@ class Prison < ApplicationRecord
     where(enabled: true).order(name: :asc)
   })
 
+  # This method represents the 'fallback position' i.e. the slots to use if the API is unavailable
   def available_slots(today = Time.zone.today)
-    AvailableSlotEnumerator.new(
-      first_bookable_date(today), last_bookable_date(today),
-      recurring_slots, anomalous_slots, unbookable_dates
-    )
+    if auto_slots_enabled?
+      nomis_concrete_slots.order(:date).
+        where('date >= ?', first_bookable_date(today)).
+        where('date <= ?', last_bookable_date(today)).
+        reject { |cs| unbookable_dates.include?(cs.date) }.
+        map do |ncs|
+        ConcreteSlot.new(ncs.date.year, ncs.date.month, ncs.date.day, ncs.start_hour, ncs.start_minute, ncs.end_hour, ncs.end_minute)
+      end
+    else
+      AvailableSlotEnumerator.new(
+        first_bookable_date(today), last_bookable_date(today),
+        recurring_slots, anomalous_slots, unbookable_dates
+      )
+    end
   end
 
   def first_bookable_date(today = Time.zone.today)
@@ -77,6 +89,10 @@ class Prison < ApplicationRecord
   end
 
 private
+
+  def auto_slots_enabled?
+    Rails.configuration.public_prisons_with_slot_availability&.include?(name)
+  end
 
   def attempt_translation(key, fallback)
     translations.fetch(I18n.locale.to_s, {}).fetch(key.to_s, fallback)

--- a/app/services/slot_availability.rb
+++ b/app/services/slot_availability.rb
@@ -23,11 +23,11 @@ class SlotAvailability
     end
   end
 
+private
+
   def all_slots
     @all_slots ||= Hash[prison_slots.map { |slot| [slot.to_s, []] }]
   end
-
-private
 
   attr_reader :prison, :noms_id, :date_of_birth, :start_date, :end_date
 

--- a/db/migrate/20200821073052_create_nomis_concrete_slots.rb
+++ b/db/migrate/20200821073052_create_nomis_concrete_slots.rb
@@ -1,0 +1,14 @@
+class CreateNomisConcreteSlots < ActiveRecord::Migration[5.2]
+  def change
+    create_table :nomis_concrete_slots, id: :uuid, default: -> { "uuid_generate_v4()" } do |t|
+      t.references :prison, type: :uuid, null: false
+      t.date :date, null: false
+      t.integer :start_hour, null: false
+      t.integer :start_minute, null: false
+      t.integer :end_hour, null: false
+      t.integer :end_minute, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_14_122432) do
+ActiveRecord::Schema.define(version: 2020_08_21_073052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,18 @@ ActiveRecord::Schema.define(version: 2018_06_14_122432) do
     t.uuid "visit_state_change_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "nomis_concrete_slots", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
+    t.uuid "prison_id", null: false
+    t.date "date", null: false
+    t.integer "start_hour", null: false
+    t.integer "start_minute", null: false
+    t.integer "end_hour", null: false
+    t.integer "end_minute", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["prison_id"], name: "index_nomis_concrete_slots_on_prison_id"
   end
 
   create_table "prisoners", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|

--- a/deploy/production/load-nomis-slots.yaml
+++ b/deploy/production/load-nomis-slots.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: load-nomis-slots
+spec:
+  schedule: "0 0 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: prison-visits-booking-staff-load-nomis-slots
+              image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/prison-visits-booking/prison-visits-staff:latest
+              imagePullPolicy: Always
+              command: ['sh', '-c', "bundle exec rake pvb:load_nomis_slots"]
+              envFrom:
+                - configMapRef:
+                    name: shared-environment
+                - secretRef:
+                    name: secrets
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: prison-visits-rds-instance-output
+                      key: url
+            restartPolicy: OnFailure

--- a/deploy/staging/load-nomis-slots.yaml
+++ b/deploy/staging/load-nomis-slots.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: load-nomis-slots
+spec:
+  schedule: "0 0 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: prison-visits-booking-staff-load-nomis-slots
+              image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/prison-visits-booking/prison-visits-staff:latest
+              imagePullPolicy: Always
+              command: ['sh', '-c', "bundle exec rake pvb:load_nomis_slots"]
+              envFrom:
+                - configMapRef:
+                    name: shared-environment
+                - secretRef:
+                    name: secrets
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: prison-visits-rds-instance-output
+                      key: url
+            restartPolicy: OnFailure

--- a/lib/tasks/load_nomis_slots.rake
+++ b/lib/tasks/load_nomis_slots.rake
@@ -1,0 +1,15 @@
+namespace :pvb do
+  desc 'load the backup nomis slots from NOMIS API'
+  task load_nomis_slots: :environment do
+    Prison.where(name: Rails.configuration.public_prisons_with_slot_availability).each do |prison|
+      prison.nomis_concrete_slots.clear
+      ApiSlotAvailability.new(prison: prison, use_nomis_slots: true).slots.each do |slot|
+        prison.nomis_concrete_slots.create!(date: slot.to_date,
+                                           start_hour: slot.begin_hour,
+                                           start_minute: slot.begin_minute,
+                                           end_hour: slot.end_hour,
+                                           end_minute: slot.end_minute)
+      end
+    end
+  end
+end

--- a/spec/controllers/api/slots_controller_spec.rb
+++ b/spec/controllers/api/slots_controller_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Api::SlotsController do
 
   let(:parsed_body) { JSON.parse(response.body) }
   let(:prisoner)    { create(:prisoner) }
-  let(:prison)      { create(:prison) }
 
   describe '#index' do
     let(:params) {
@@ -14,31 +13,83 @@ RSpec.describe Api::SlotsController do
         prison_id: prison.id,
         prisoner_number: prisoner.number,
         prisoner_dob: prisoner.date_of_birth,
-        start_date: '2016-02-15',
+        start_date: '2016-02-09',
         end_date: '2016-04-15'
       }
     }
 
     let(:slots) {
-      [
-        { '2016-02-15T13:30/14:30' => [] },
-        { '2016-03-22T13:30/14:30' => ['prisoner_unavailable'] },
-        { '2016-04-29T13:30/14:30' => ['prisoner_unavailable'] }
-      ]
+      {
+        '2016-02-15T13:30/14:30' => [],
+        '2016-03-02T13:30/14:30' => ['prisoner_unavailable'],
+        '2016-03-03T13:30/14:30' => ['prisoner_unavailable']
+      }
     }
-
-    let(:prisoner_slot_availability) {
-      double(SlotAvailability, slots: slots)
-    }
+    let(:offender_id) { 1502035 }
 
     before do
-      expect(SlotAvailability).to receive(:new).
-        and_return(prisoner_slot_availability)
+      stub_auth_token
     end
 
-    it 'returns the list of slots with their availabilities' do
-      get :index, params: params
-      expect(parsed_body).to eq('slots' => slots)
+    context 'with auto slots enabled' do
+      let(:prison) {
+        create(:prison,
+               booking_window: 28,
+               lead_days: 3,
+                     nomis_concrete_slots: [
+                       build(:nomis_concrete_slot, date: Date.new(2016, 2, 15), start_hour: 13, start_minute: 30, end_hour: 14, end_minute: 30),
+                       build(:nomis_concrete_slot, date: Date.new(2016, 3, 2), start_hour: 13, start_minute: 30, end_hour: 14, end_minute: 30),
+                       build(:nomis_concrete_slot, date: Date.new(2016, 3, 3), start_hour: 13, start_minute: 30, end_hour: 14, end_minute: 30)
+                     ]).tap { |prison|
+          switch_feature_flag_with(:public_prisons_with_slot_availability, [prison.name])
+        }
+      }
+
+      before do
+        stub_request(:get, "#{AuthHelper::API_PREFIX}/lookup/active_offender?date_of_birth=#{prisoner.date_of_birth}&noms_id=#{prisoner.number}").
+          to_return(body: { found: true, offender: { id: offender_id } }.to_json)
+
+        stub_request(:get, "#{AuthHelper::API_PREFIX}/offenders/#{offender_id}/visits/available_dates?end_date=2016-03-08&start_date=2016-02-09").
+          to_return(body: { dates: ['2016-02-15'] }.to_json)
+
+        switch_feature_flag_with(:public_prisons_with_slot_availability, [prison.name])
+      end
+
+      it 'returns the list of slots with their availabilities' do
+        get :index, params: params
+        expect(parsed_body).to eq('slots' => slots)
+      end
+    end
+
+    context 'with auto slots disabled' do
+      let(:prison)      { create(:prison) }
+
+      before do
+        stub_request(:get, "#{AuthHelper::API_PREFIX}/offenders/#{offender_id}/visits/available_dates?end_date=2016-03-08&start_date=2016-02-09").
+            to_return(body: { dates: ['2016-02-15'] }.to_json)
+
+        stub_request(:get, "#{AuthHelper::API_PREFIX}/lookup/active_offender?date_of_birth=#{prisoner.date_of_birth}&noms_id=#{prisoner.number}").
+            to_return(body: { found: true, offender: { id: offender_id } }.to_json)
+
+        switch_feature_flag_with(:public_prisons_with_slot_availability, [])
+      end
+
+      it 'returns the list of slots with their availabilities' do
+        get :index, params: params
+        expect(parsed_body).to eq('slots' => { "2016-02-15T14:00/16:10" => [],
+                                              "2016-02-16T09:00/10:00" => ["prisoner_unavailable"],
+                                              "2016-02-16T14:00/16:10" => ["prisoner_unavailable"],
+                                              "2016-02-22T14:00/16:10" => ["prisoner_unavailable"],
+                                              "2016-02-23T09:00/10:00" => ["prisoner_unavailable"],
+                                              "2016-02-23T14:00/16:10" => ["prisoner_unavailable"],
+                                              "2016-02-29T14:00/16:10" => ["prisoner_unavailable"],
+                                              "2016-03-01T09:00/10:00" => ["prisoner_unavailable"],
+                                              "2016-03-01T14:00/16:10" => ["prisoner_unavailable"],
+                                              "2016-03-07T14:00/16:10" => ["prisoner_unavailable"],
+                                              "2016-03-08T09:00/10:00" => ["prisoner_unavailable"],
+                                              "2016-03-08T14:00/16:10" => ["prisoner_unavailable"]
+        })
+      end
     end
   end
 end

--- a/spec/controllers/api/slots_controller_spec.rb
+++ b/spec/controllers/api/slots_controller_spec.rb
@@ -49,8 +49,15 @@ RSpec.describe Api::SlotsController do
         stub_request(:get, "#{AuthHelper::API_PREFIX}/lookup/active_offender?date_of_birth=#{prisoner.date_of_birth}&noms_id=#{prisoner.number}").
           to_return(body: { found: true, offender: { id: offender_id } }.to_json)
 
-        stub_request(:get, "#{AuthHelper::API_PREFIX}/offenders/#{offender_id}/visits/available_dates?end_date=2016-03-08&start_date=2016-02-09").
+        stub_request(:get, "#{AuthHelper::API_PREFIX}/offenders/#{offender_id}/visits/available_dates?end_date=2016-03-08&start_date=2016-02-13").
           to_return(body: { dates: ['2016-02-15'] }.to_json)
+
+        stub_request(:get, "#{AuthHelper::API_PREFIX}/prison/#{prison.nomis_id}/slots?end_date=2016-03-12&start_date=2016-02-13").
+            to_return(body: { slots: [
+                { time: "2016-02-15T13:30/14:30" },
+                { time: "2016-03-02T13:30/14:30" },
+                { time: "2016-03-03T13:30/14:30" },
+            ] }.to_json)
 
         switch_feature_flag_with(:public_prisons_with_slot_availability, [prison.name])
       end

--- a/spec/factories/nomis_concrete_slots.rb
+++ b/spec/factories/nomis_concrete_slots.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :nomis_concrete_slot do
+    prison
+    date { Time.zone.today }
+    start_hour { 14 }
+    start_minute { 10 }
+    end_hour { 16 }
+    end_minute { 30 }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,6 +37,12 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:truncation, except: %w(public.ar_internal_metadata))
   end
 
+  config.around(:each, :vcr) do |example|
+    WebMock.enable_net_connect!
+    example.run
+    WebMock.disable_net_connect!(allow: 'codeclimate.com', allow_localhost: true)
+  end
+
   config.before(:each) do
     I18n.locale = I18n.default_locale
     RequestStore.clear!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,7 @@ RSpec.configure do |config|
   config.include ConfigurationHelpers
   config.include ServiceHelpers
   config.include JWTHelper
+  config.include AuthHelper
 
   config.infer_spec_type_from_file_location!
 

--- a/spec/services/slot_availability_spec.rb
+++ b/spec/services/slot_availability_spec.rb
@@ -1,7 +1,34 @@
 require "rails_helper"
 
 RSpec.describe SlotAvailability do
-  let(:prison)        { create(:prison) }
+  let(:default_prison_slots) {
+    [
+      "2017-02-07T09:00/10:00",
+      "2017-02-07T14:00/16:10",
+      "2017-02-13T14:00/16:10",
+      "2017-02-14T09:00/10:00",
+      "2017-02-14T14:00/16:10",
+      "2017-02-20T14:00/16:10",
+      "2017-02-21T09:00/10:00",
+      "2017-02-21T14:00/16:10",
+      "2017-02-27T14:00/16:10",
+      "2017-02-28T09:00/10:00",
+      "2017-02-28T14:00/16:10"
+    ]
+  }
+
+  let(:prison) {
+    create(:prison,
+           nomis_concrete_slots: default_prison_slots.map { |s| ConcreteSlot.parse(s) }.map { |cs|
+                                   build(:nomis_concrete_slot,
+                                         date: Date.new(cs.year, cs.month, cs.day),
+                                         start_hour: cs.begin_hour,
+                                         start_minute: cs.begin_minute,
+                                         end_hour: cs.end_hour,
+                                         end_minute: cs.end_minute)
+                                 })
+  }
+
   let(:offender_id)   { 'A1410AE' }
   let(:date_of_birth) { '1960-06-01' }
   let(:start_date)    { Date.parse('2017-02-01') }
@@ -172,24 +199,6 @@ RSpec.describe SlotAvailability do
 
         it { expect(subject.slots).to eq(all_slots_available) }
       end
-    end
-  end
-
-  describe '#all_slots' do
-    it 'returns a hash without unavailability reasons' do
-      expect(subject.all_slots).to eq(
-        "2017-02-07T09:00/10:00" => [],
-        "2017-02-07T14:00/16:10" => [],
-        "2017-02-13T14:00/16:10" => [],
-        "2017-02-14T09:00/10:00" => [],
-        "2017-02-14T14:00/16:10" => [],
-        "2017-02-20T14:00/16:10" => [],
-        "2017-02-21T09:00/10:00" => [],
-        "2017-02-21T14:00/16:10" => [],
-        "2017-02-27T14:00/16:10" => [],
-        "2017-02-28T09:00/10:00" => [],
-        "2017-02-28T14:00/16:10" => []
-      )
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,10 +65,22 @@ end
 
 require 'vcr'
 
+# set VCR=1 when you wish to record new interactions with T3
+vcr_mode = ENV.fetch('VCR', '0').to_i.freeze
+
 VCR.configure do |config|
   config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
-  config.hook_into :webmock
+  if vcr_mode.zero?
+    config.hook_into :webmock
+  else
+    config.hook_into :faraday
+  end
   config.configure_rspec_metadata!
+  # config.allow_http_connections_when_no_cassette = true
+  config.default_cassette_options = {
+    # by default, all T3 interactions are already recorded
+    record: vcr_mode.zero? ? :none : :new_episodes,
+  }
 
   # Uncomment out the line below when recording/re-recording cassettes
   # config.default_cassette_options = { record: :new_episodes }

--- a/spec/support/helpers/auth_helper.rb
+++ b/spec/support/helpers/auth_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module AuthHelper
+  ACCESS_TOKEN = Struct.new(:access_token).new('an-access-token')
+
+  API_PREFIX = "#{ENV.fetch('PRISON_API_HOST')}/api/v1"
+
+  def stub_auth_token
+    allow(Nomis::Oauth::TokenService).to receive(:valid_token).and_return(ACCESS_TOKEN)
+
+    stub_request(:post, "#{ENV.fetch('NOMIS_OAUTH_HOST')}/auth/oauth/token?grant_type=client_credentials").
+      to_return(body: {
+        "access_token": ACCESS_TOKEN.access_token,
+        "token_type": "bearer",
+        "expires_in": 1199,
+        "scope": "readwrite"
+      }.to_json)
+  end
+end


### PR DESCRIPTION
## Description
This PR enables the PVB team to switch on 'auto-slot-updates' for certain prisons. 

## Motivation and Context
The current 'workflow' for PVB is a constant stream of YAML file updates in response to prisons changing their visiting hours. This change allows us to obtain this data from the NOMIS API, which should make us capable of stopping this annoying repetitive time-consuming task

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Prison details update (e.g. slot updates)

## Checklist:
- [x] [My commit message follows the GDS git style standards we have adopted](https://github.com/alphagov/styleguides/blob/master/git.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
