### PR TITLE
Add jasmine tests to CI - to at least make them visible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,10 @@ jobs:
             ./cc-test-reporter before-build
             bundle exec rake
             ./cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
+      - run:
+          name: Run jasmine tests
+          command: |
+            bundle exec rake jasmine:ci
       - store_test_results:
           path: coverage
       - store_artifacts:


### PR DESCRIPTION
##  Description
Dependabot just raised an upgrade for Jasmine - but we didn't have any jasmine tests running in circle:ci. Turns out we have 56 jasmine tests - so this PR enables them in Circle to hopefully increase their visibility

## Motivation and Context
Tidy up project for newer developers

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Prison details update (e.g. slot updates)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask! -->
- [ ] [My commit message follows the GDS git style standards we have adopted](https://github.com/alphagov/styleguides/blob/master/git.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the deployment repo accordingly.
- [ ] I have added tests to cover my changes.
