### PR TITLE
upgrade to non-broken brakeman gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ end
 
 group :development, :test do
   gem 'awesome_print', require: 'ap'
-  gem 'brakeman'
+  gem 'brakeman', '>= 5.0.4'
   gem 'byebug'
   gem 'dotenv-rails'
   gem 'jasmine-jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
     ast (2.4.2)
     awesome_print (1.8.0)
     base32-crockford (0.1.0)
-    brakeman (5.0.1)
+    brakeman (5.0.4)
     builder (3.2.4)
     business (1.17.1)
     byebug (11.1.3)
@@ -442,7 +442,7 @@ DEPENDENCIES
   activerecord-safer_migrations
   awesome_print
   base32-crockford
-  brakeman
+  brakeman (>= 5.0.4)
   business
   byebug
   capybara
@@ -513,6 +513,9 @@ DEPENDENCIES
   vcr
   webmock
   zendesk_api
+
+RUBY VERSION
+   ruby 2.6.7p197
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
Brakeman 5.0.1 was completely broken - this upgrades to 5.0.4 which is the first non-broken release of the 5.x series