### PR TITLE
Only send request_acknowledged email once

### DIFF
--- a/app/mailers/visitor_mailer.rb
+++ b/app/mailers/visitor_mailer.rb
@@ -7,11 +7,7 @@ class VisitorMailer < ApplicationMailer
   layout 'email'
 
   def request_acknowledged(visit)
-    template_id = 'd9beed43-e310-4875-807d-ffe9f833ad66'
     I18n.locale = visit.locale
-
-    @gov_notify_email = GovNotifyEmailer.new
-    @gov_notify_email.send_email(visit, template_id)
 
     mail_visitor visit,
                  receipt_date: format_date_without_year(visit.first_date)

--- a/app/services/booking_request_creator.rb
+++ b/app/services/booking_request_creator.rb
@@ -16,6 +16,10 @@ private
       human_id = HumanReadableId.update_unique_id(Visit, visit.id, :human_id)
       visit.human_id = human_id
       create_visitors(visitors_step, visit)
+
+      @gov_notify_email = GovNotifyEmailer.new
+      @gov_notify_email.send_email(visit, 'd9beed43-e310-4875-807d-ffe9f833ad66')
+
       visit
     end
   end


### PR DESCRIPTION
During testing there is a bug in production that when a user submits a request, they get numerous `request_acknowledged` emails confirming their request has been received, over a sporadic period of time. 

This may be because where the email code sat before, was called here `VisitorMailer.request_acknowledged(visit).deliver_later` that `deliver_later` queues up the emails which with the old set up made sense, but with GovNotify we can delegate the processing of sending an email to the GovNotify service, so we don't need to queue this.

Moving the email code to the `create_visit` function should mean it will only send this email once.