### PR TITLE
Remove the manual prison IP check

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,9 +17,6 @@
     "LANG": {
       "required": true
     },
-    "PRISON_ESTATE_IPS": {
-      "required": true
-    },
     "NOMIS_STAFF_SLOT_AVAILABILITY_ENABLED": {
       "required": true
     },

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,13 +44,6 @@ private
 
   # :nocov:
 
-  def authorize_prison_request
-    unless Rails.configuration.prison_ip_matcher.include?(request.remote_ip)
-      Rails.logger.info "Unauthorized request from #{request.remote_ip}"
-      fail ActionController::RoutingError, 'Not Found'
-    end
-  end
-
   def authenticate_user
     unless sso_identity
       session[:redirect_path] = request.original_fullpath

--- a/app/controllers/concerns/prison_restriction.rb
+++ b/app/controllers/concerns/prison_restriction.rb
@@ -1,8 +1,0 @@
-module PrisonRestriction
-  extend ActiveSupport::Concern
-
-  included do
-    before_action :authorize_prison_request
-    skip_before_action :store_current_location, raise: false
-  end
-end

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -1,3 +1,2 @@
 class DownloadsController < ApplicationController
-  include PrisonRestriction
 end

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -1,5 +1,4 @@
 class MetricsController < ApplicationController
-  before_action :authorize_prison_request
   before_action :authenticate_user, only: :send_confirmed_bookings
 
   def index

--- a/app/controllers/prison/cancellations_controller.rb
+++ b/app/controllers/prison/cancellations_controller.rb
@@ -1,7 +1,6 @@
 class Prison::CancellationsController < ApplicationController
   include StaffResponseContext
 
-  before_action :authorize_prison_request
   before_action :authenticate_user
   before_action :check_visit_cancellable
   def create

--- a/app/controllers/prison/dashboards_controller.rb
+++ b/app/controllers/prison/dashboards_controller.rb
@@ -1,7 +1,6 @@
 class Prison::DashboardsController < ApplicationController
   NUMBER_VISITS = 101
 
-  before_action :authorize_prison_request
   before_action :authenticate_user
 
   def inbox

--- a/app/controllers/prison/feedbacks_controller.rb
+++ b/app/controllers/prison/feedbacks_controller.rb
@@ -1,5 +1,4 @@
 class Prison::FeedbacksController < ApplicationController
-  before_action :authorize_prison_request
 
   def new
     @feedback = FeedbackSubmission.new(email_address: current_user&.email)

--- a/app/controllers/prison/feedbacks_controller.rb
+++ b/app/controllers/prison/feedbacks_controller.rb
@@ -1,5 +1,4 @@
 class Prison::FeedbacksController < ApplicationController
-
   def new
     @feedback = FeedbackSubmission.new(email_address: current_user&.email)
   end

--- a/app/controllers/prison/messages_controller.rb
+++ b/app/controllers/prison/messages_controller.rb
@@ -1,7 +1,6 @@
 class Prison::MessagesController < ApplicationController
   include StaffResponseContext
 
-  before_action :authorize_prison_request
   before_action :authenticate_user
 
   def create

--- a/app/controllers/prison/print_visits_controller.rb
+++ b/app/controllers/prison/print_visits_controller.rb
@@ -1,5 +1,4 @@
 class Prison::PrintVisitsController < ApplicationController
-  before_action :authorize_prison_request
   before_action :authenticate_user
 
   def new

--- a/app/controllers/prison/switch_estates_controller.rb
+++ b/app/controllers/prison/switch_estates_controller.rb
@@ -1,5 +1,4 @@
 class Prison::SwitchEstatesController < ApplicationController
-  before_action :authorize_prison_request
   before_action :authenticate_user
   before_action :verify_switch_estates
 

--- a/app/controllers/prison/visits_controller.rb
+++ b/app/controllers/prison/visits_controller.rb
@@ -1,7 +1,6 @@
 class Prison::VisitsController < ApplicationController
   include StaffResponseContext
 
-  before_action :authorize_prison_request
   before_action :authenticate_user
   before_action :visit_is_processable, only: :update
   before_action :set_visit_processing_time_cookie, only: :show

--- a/app/controllers/staff_info_controller.rb
+++ b/app/controllers/staff_info_controller.rb
@@ -1,6 +1,4 @@
 class StaffInfoController < ApplicationController
-  include PrisonRestriction
-  before_action :authorize_prison_request
   before_action :authenticate_user
 
   def show

--- a/app/controllers/telephone_scripts_controller.rb
+++ b/app/controllers/telephone_scripts_controller.rb
@@ -1,3 +1,2 @@
 class TelephoneScriptsController < ApplicationController
-  include PrisonRestriction
 end

--- a/config/initializers/ip_filtering.rb
+++ b/config/initializers/ip_filtering.rb
@@ -1,2 +1,0 @@
-prison_estate_ips = ENV.fetch('PRISON_ESTATE_IPS', '0.0.0.0,127.0.0.1,::1')
-Rails.configuration.prison_ip_matcher = IpAddressMatcher.new(prison_estate_ips)

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -6,7 +6,5 @@ RSpec.describe DownloadsController, type: :controller  do
 
     it { expect(response.status).to eq(200) }
     it { is_expected.to render_template(:index) }
-
-    it_behaves_like 'disallows untrusted ips'
   end
 end

--- a/spec/controllers/metrics_controller_spec.rb
+++ b/spec/controllers/metrics_controller_spec.rb
@@ -23,8 +23,6 @@ RSpec.describe MetricsController, type: :controller do
 
       it { is_expected.to be_successful }
     end
-
-    it_behaves_like 'disallows untrusted ips'
   end
 
   describe 'summary' do

--- a/spec/controllers/prison/cancellations_controller_spec.rb
+++ b/spec/controllers/prison/cancellations_controller_spec.rb
@@ -75,8 +75,6 @@ RSpec.describe Prison::CancellationsController do
         expect(ga_tracker).not_to receive(:send_cancelled_visit_event)
       end
 
-      it_behaves_like 'disallows untrusted ips'
-
       it { is_expected.not_to be_successful }
     end
   end

--- a/spec/controllers/prison/dashboards_controller_spec.rb
+++ b/spec/controllers/prison/dashboards_controller_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe Prison::DashboardsController, type: :controller do
 
   subject { get :inbox, params: { estate_id: estate.finder_slug } }
 
-  it_behaves_like 'disallows untrusted ips'
-
   describe '#inbox' do
     let(:prison) { FactoryBot.create(:prison, estate: estate) }
 

--- a/spec/controllers/prison/feedbacks_controller_spec.rb
+++ b/spec/controllers/prison/feedbacks_controller_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe Prison::FeedbacksController, type: :controller do
       )
     end
 
-    it_behaves_like 'disallows untrusted ips'
-
     it { is_expected.to be_successful }
   end
 
@@ -29,8 +27,6 @@ RSpec.describe Prison::FeedbacksController, type: :controller do
     end
     let(:body) { 'My comment' }
     let(:prison) { FactoryBot.create(:prison) }
-
-    it_behaves_like 'disallows untrusted ips'
 
     context 'when it is successful' do
       it 'creates a feedback submission and enqueues it' do

--- a/spec/controllers/prison/messages_controller_spec.rb
+++ b/spec/controllers/prison/messages_controller_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe Prison::MessagesController do
 
     let(:message_body) { 'Hello' }
 
-    it_behaves_like 'disallows untrusted ips'
-
     context "when logged in" do
       before do
         login_user(user, current_estates: [estate])

--- a/spec/controllers/prison/visits_controller_spec.rb
+++ b/spec/controllers/prison/visits_controller_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe Prison::VisitsController, type: :controller do
 
     let(:staff_response) { { slot_granted: visit.slots.first.to_s } }
 
-    it_behaves_like 'disallows untrusted ips'
-
     context 'when there is no logged in user' do
       it { is_expected.not_to be_successful }
     end
@@ -60,8 +58,6 @@ RSpec.describe Prison::VisitsController, type: :controller do
 
     context 'with security' do
       subject { get :show, params: { id: 1, locale: 'en' } }
-
-      it_behaves_like 'disallows untrusted ips'
     end
 
     context "when logged in" do
@@ -97,8 +93,6 @@ RSpec.describe Prison::VisitsController, type: :controller do
     let(:visit) { cancellation.visit }
 
     subject { post :nomis_cancelled, params: { id: visit.id, locale: 'en' } }
-
-    it_behaves_like 'disallows untrusted ips'
 
     context 'when there is a user signed in' do
       let(:user) { FactoryBot.create(:user) }

--- a/spec/controllers/staff_info_controller_spec.rb
+++ b/spec/controllers/staff_info_controller_spec.rb
@@ -10,7 +10,5 @@ RSpec.describe StaffInfoController, type: :controller do
 
     it { expect(response.status).to eq(200) }
     it { is_expected.to render_template(:show) }
-
-    it_behaves_like 'disallows untrusted ips'
   end
 end

--- a/spec/controllers/telephone_scripts_controller_spec.rb
+++ b/spec/controllers/telephone_scripts_controller_spec.rb
@@ -6,7 +6,5 @@ RSpec.describe TelephoneScriptsController, type: :controller  do
 
     it { expect(response.status).to eq(200) }
     it { is_expected.to render_template(:show) }
-
-    it_behaves_like 'disallows untrusted ips'
   end
 end

--- a/spec/support/shared/untrusted_examples.rb
+++ b/spec/support/shared/untrusted_examples.rb
@@ -1,9 +1,0 @@
-RSpec.shared_examples 'disallows untrusted ips' do
-  context 'with an untrusted ip' do
-    before { request.headers['REMOTE_ADDR'] = '192.168.1.0' }
-
-    it 'raises a not found error' do
-      expect { subject }.to raise_error(ActionController::RoutingError)
-    end
-  end
-end


### PR DESCRIPTION
## Description

Removes the `authorize_prison_request` manual IP address check

## Motivation and Context

The `authorize_prison_request` function was used before many of the
controllers to ensure that the IP request of the caller was one of the
Prison IP addresses.  This functionality is a duplicate of the check
that is performed during K8s ingress and is therefore unnecessary.


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Removes a feature (non-breaking change which removes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Prison details update (e.g. slot updates)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask! -->
- [x] [My commit message follows the GDS git style standards we have adopted](https://github.com/alphagov/styleguides/blob/master/git.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the deployment repo accordingly.
- [ ] I have added tests to cover my changes.
