### PR TITLE
VB-1030, remove monday slot

### DIFF
--- a/db/seeds/prisons/BNI-bullingdon-convicted-only.yml
+++ b/db/seeds/prisons/BNI-bullingdon-convicted-only.yml
@@ -10,8 +10,6 @@ enabled: true
 private: false
 closed: false
 recurring:
-  mon:
-  - 1345-1615
   tue:
   - 1345-1615
   wed:

--- a/db/seeds/prisons/BNI-bullingdon-remand-only.yml
+++ b/db/seeds/prisons/BNI-bullingdon-remand-only.yml
@@ -10,8 +10,6 @@ enabled: true
 private: false
 closed: false
 recurring:
-  mon:
-  - 1345-1615
   tue:
   - 1345-1615
   wed:


### PR DESCRIPTION
## Description
HMP Bullingdon
Monday timeslot removed permanently at the prisons requests for both remand and convicted.

## Types of changes
- [x] Prison details update (e.g. slot updates)
