### PR TITLE
VB-1100, remove Huntercombe number from emails

### DIFF
--- a/db/seeds/prisons/HCI-huntercombe.yml
+++ b/db/seeds/prisons/HCI-huntercombe.yml
@@ -5,7 +5,7 @@ address: |-
   Huntercombe Place
 postcode: RG9 5SB
 email_address: socialvisits.huntercombe@hmps.gsi.gov.uk
-phone_no: 01491 643195
+phone_no: Not Currently Available
 enabled: true
 private: false
 closed: false


### PR DESCRIPTION
## Description
HMP Huntercombe currently has no working phone line for visits booking, so this change removes their phone number from the Email's we send out.
This may be a temporary change, the Comms team are contacting them to see if this will be permanent

## Types of changes
- [x] Removal of Prison's phone number
