### PR TITLE
VB-1103, disable Pentonville's public access

### DIFF
--- a/db/seeds/prisons/PVI-pentonville.yml
+++ b/db/seeds/prisons/PVI-pentonville.yml
@@ -6,7 +6,7 @@ address: |-
 postcode: N7 8TT
 email_address: socialvisits.pentonville@hmps.gsi.gov.uk
 phone_no: 020 70237251
-enabled: true
+enabled: false
 private: false
 closed: false
 adult age: 11


### PR DESCRIPTION
## Description
HMP Pentonville have requested that we disable their prison as the current system no longer supports their timetable.
This is being followed up separately, but they wish to make this change, at this time

## Types of changes
- [x] Disable public access
