### PR TITLE
VB-1344, added service down message so no page will render

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
   <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
+        <h1 class="govuk-heading">Sorry, the service is unavailable</h1>
         <p class="govuk-body">
           You will not be able to use the service on Wednesday 2 November 2022/
         </p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,43 +41,30 @@
   </div>
 <% end %>
 
-<% content_for :content do %>
-
-  <!--[if lte IE 8]>
-    <%= t('.unsupported_content_html') %>
-  <![endif]-->
-
-  <main id="content">
-    <p class="phase-banner push-top--half push--none font-xsmall">
-      <%= t('.contact_banner_html', url: new_prison_feedback_path) %>
-    </p>
-    <%= yield :banner %>
-    <%= yield :navigation %>
-    <% if content_for?(:header) %>
-      <header>
-        <h1 class="heading-large">
-          <%= yield :header %>
-        </h1>
-      </header>
-    <% end %>
-
-    <% if notice.present? %>
-      <p class="notification">
-        <%= notice %>
-      </p>
-    <% end %>
-
-    <% if alert.present? %>
-      <div class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">
-        <%= alert.html_safe %>
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
+        <p class="govuk-body">
+          You will not be able to use the service on Wednesday 2 November 2022/
+        </p>
+        <p class="govuk-body">
+          This is due to scheduled maintenance. 
+        </p>
+        <p class="govuk-body">
+          You may receive more phone calls than usual as visitors will not be able to submit online requests for visits. 
+        </p>
+        <p class="govuk-body">
+          The service will be available again on Thursday 3 November 2022.
+        </p>
+        <p class="govuk-body">
+          You can <a class="govuk-link" href="https://digital.prison.service.justice.gov.uk/">use other services on Digital Prison Services.</a>
+        </p>
       </div>
-    <% end %>
-    <%= yield :prison_switcher %>
-
-    <%= yield %>
-
+    </div>
   </main>
-<% end %>
+</div>
 
 <% content_for :footer_support_links do %>
   <ul>


### PR DESCRIPTION
## Description
Removed the 'yield' tag and some surrounding code which renders the content on the page, this will ensure no matter which page the users have bookmarks for, they will only be displayed the service down page

## Types of changes
- [x] Temporary service down page

