### PR TITLE
Re-add dev deploy to CircleCI workflow, update deployment commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,6 @@ workflows:
             type: approval
             requires:
               - deploy_development
-              - build_and_push_docker_image
       - deploy_staging:
           requires:
             - request-staging-approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
       - deploy:
           name: Deploy to development
           command: |
-            kubectl delete job pvb-staff-migration --ignore-not-found
+            kubectl delete job pvb-staff-migration-dev --ignore-not-found
             sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/development/deployment.yaml
             sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/development/cronjob.yaml
             sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/development/migration-job.yaml
@@ -254,13 +254,13 @@ workflows:
       - build_and_push_docker_image:
           requires:
             - test
-      # - deploy_development:
-      #     requires:
-      #       - build_and_push_docker_image
+      - deploy_development:
+          requires:
+            - build_and_push_docker_image
       - request-staging-approval:
             type: approval
             requires:
-              # - deploy_development
+              - deploy_development
               - build_and_push_docker_image
       - deploy_staging:
           requires:


### PR DESCRIPTION
## Description
Change the deployment to development CircleCI commands to account for the new migration naming.
Add the dev deployment back into the workflow.
