### PR TITLE
VB-1996, remove contact centre email addresses

### DIFF
--- a/db/seeds/prisons/AGI-askham-grange.yml
+++ b/db/seeds/prisons/AGI-askham-grange.yml
@@ -3,7 +3,7 @@ name: Askham Grange
 nomis_id: AGI
 address: Askham Richard
 postcode: YO23 3FT
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 060 6513
 enabled: true
 private: false

--- a/db/seeds/prisons/BLI-bristol.yml
+++ b/db/seeds/prisons/BLI-bristol.yml
@@ -5,7 +5,7 @@ address: |-
   19 Cambridge Road
   Bristol
 postcode: BS7 8PS
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 060 6510
 enabled: true
 private: false

--- a/db/seeds/prisons/BSI-brinsford.yml
+++ b/db/seeds/prisons/BSI-brinsford.yml
@@ -6,7 +6,7 @@ address: |-
   Featherstone
   Wolverhampton
 postcode: WV10 7PY
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 060 6500
 enabled: true
 private: false

--- a/db/seeds/prisons/CFI-cardiff.yml
+++ b/db/seeds/prisons/CFI-cardiff.yml
@@ -11,7 +11,7 @@ translations:
     address: |-
       Knox Road
       Caerdydd
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 303 2301
 enabled: true
 private: false

--- a/db/seeds/prisons/DHI-drake-hall.yml
+++ b/db/seeds/prisons/DHI-drake-hall.yml
@@ -5,7 +5,7 @@ address: |-
   Eccleshall
   Staffordshire
 postcode: ST21 6LQ
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 060 6501
 enabled: true
 private: false

--- a/db/seeds/prisons/DMI-durham.yml
+++ b/db/seeds/prisons/DMI-durham.yml
@@ -5,7 +5,7 @@ address: |-
   Old Elvet
   Durham
 postcode: DH1 3HU
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 303 2300
 enabled: true
 private: false

--- a/db/seeds/prisons/DWI-downview.yml
+++ b/db/seeds/prisons/DWI-downview.yml
@@ -6,7 +6,7 @@ address: |-
   Sutton
   Surrey
 postcode: SM2 5PD
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 303 0633
 enabled: true
 private: false

--- a/db/seeds/prisons/EEI-erlestoke.yml
+++ b/db/seeds/prisons/EEI-erlestoke.yml
@@ -4,7 +4,7 @@ nomis_id: EEI
 address: |-
   Devizes
 postcode: SN10 5TU
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 303 0634
 enabled: true
 private: false

--- a/db/seeds/prisons/ESI-east-sutton-park.yml
+++ b/db/seeds/prisons/ESI-east-sutton-park.yml
@@ -6,7 +6,7 @@ address: |-
   Maidstone
   Kent
 postcode: ME17 3DF
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 060 6513
 enabled: true
 private: false

--- a/db/seeds/prisons/EWI-eastwood-park.yml
+++ b/db/seeds/prisons/EWI-eastwood-park.yml
@@ -4,7 +4,7 @@ nomis_id: EWI
 address: |-
   Falfield
 postcode: GL12 8DB
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 303 0631
 enabled: true
 private: false

--- a/db/seeds/prisons/FHI-foston-hall.yml
+++ b/db/seeds/prisons/FHI-foston-hall.yml
@@ -6,7 +6,7 @@ address: |-
   Derby
   Foston
 postcode: DE65 5DN
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 060 6516
 enabled: true
 private: false

--- a/db/seeds/prisons/FSI-featherstone.yml
+++ b/db/seeds/prisons/FSI-featherstone.yml
@@ -6,7 +6,7 @@ address: |-
   Featherstone
   Wolverhampton
 postcode: WV10 7PU
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 060 6502
 enabled: true
 private: false

--- a/db/seeds/prisons/HEI-hewell.yml
+++ b/db/seeds/prisons/HEI-hewell.yml
@@ -6,7 +6,7 @@ address: |-
   Redditch
   Worcestershire
 postcode: B97 6QS
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 060 6503
 enabled: true
 private: false

--- a/db/seeds/prisons/LNI-low-newton.yml
+++ b/db/seeds/prisons/LNI-low-newton.yml
@@ -4,7 +4,7 @@ nomis_id: LNI
 address: |-
   Brasside
 postcode: DH1 5YA
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 303 0632
 enabled: true
 private: false

--- a/db/seeds/prisons/NHI-new-hall.yml
+++ b/db/seeds/prisons/NHI-new-hall.yml
@@ -4,7 +4,7 @@ nomis_id: NHI
 address: |-
   Dial Wood
 postcode: WF4 4XX
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 060 6515
 enabled: true
 private: false

--- a/db/seeds/prisons/PNI-preston.yml
+++ b/db/seeds/prisons/PNI-preston.yml
@@ -4,7 +4,7 @@ nomis_id: PNI
 address: |-
   2 Ribbleton Lane
 postcode: PR1 5AB
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0330 058 8224
 enabled: true
 private: false

--- a/db/seeds/prisons/RCI-rochester.yml
+++ b/db/seeds/prisons/RCI-rochester.yml
@@ -6,7 +6,7 @@ address: |-
   Rochester
   Kent
 postcode: ME1 3QS
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 060 6513
 enabled: true
 private: false

--- a/db/seeds/prisons/SDI-send.yml
+++ b/db/seeds/prisons/SDI-send.yml
@@ -4,7 +4,7 @@ nomis_id: SDI
 address: |-
   Ripley Road
 postcode: GU23 7LJ
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no:  0300 060 6514
 enabled: true
 private: false

--- a/db/seeds/prisons/SFI-stafford.yml
+++ b/db/seeds/prisons/SFI-stafford.yml
@@ -5,7 +5,7 @@ address: |-
   54 Gaol Road
   Stafford
 postcode: ST16 3AW
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 060 6505
 enabled: true
 private: false

--- a/db/seeds/prisons/SHI-stoke-heath.yml
+++ b/db/seeds/prisons/SHI-stoke-heath.yml
@@ -5,7 +5,7 @@ address: |-
   Market Drayton
   Shropshire
 postcode: TF9 2JL
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 060 6506
 enabled: true
 private: false

--- a/db/seeds/prisons/SNI-swinfen-hall.yml
+++ b/db/seeds/prisons/SNI-swinfen-hall.yml
@@ -6,7 +6,7 @@ address: |-
   FLichfield
   Staffordshire
 postcode: WS14 9QS
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 060 6507
 enabled: true
 private: false

--- a/db/seeds/prisons/STI-styal.yml
+++ b/db/seeds/prisons/STI-styal.yml
@@ -4,7 +4,7 @@ nomis_id: STI
 address: |-
   Wilmslow
 postcode: SK9 4HR
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 060 6512
 enabled: true
 private: false

--- a/db/seeds/prisons/WNI-werrington.yml
+++ b/db/seeds/prisons/WNI-werrington.yml
@@ -5,7 +5,7 @@ address: |-
   Werrington
   Stoke-On-Trent
 postcode: ST9 0DX
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 060 6508
 enabled: true
 private: false

--- a/db/seeds/prisons/WSI-wormwood-scrubs.yml
+++ b/db/seeds/prisons/WSI-wormwood-scrubs.yml
@@ -4,7 +4,7 @@ nomis_id: WSI
 address: |-
   Du Cane Road
 postcode: W12 0AE
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 060 6511
 enabled: true
 private: false

--- a/db/seeds/prisons/WWI-wandsworth.yml
+++ b/db/seeds/prisons/WWI-wandsworth.yml
@@ -5,7 +5,7 @@ address: |-
   Heathfield Rd
   PO Box 757
 postcode: SW18 3HS
-email_address: hmppsvisitbooking@justice.gov.uk
+email_address: Unavailable
 phone_no: 0300 060 6509
 enabled: true
 private: false


### PR DESCRIPTION
## Description
The contact centre have requested that their email address be removed for all prisons that they serve.
This PR changes all instances of their email address to `Unavailable` as a value has to be entered.

## Types of changes
- [x] Contact detail change - Contact Centre prisons
