### PR TITLE
Use the keys from the jwks endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,4 @@ PUBLIC_PRISONS_WITH_SLOT_AVAILABILITY=Leeds
 NOMIS_OAUTH_CLIENT_ID="client-id"
 NOMIS_OAUTH_CLIENT_SECRET="secret"
 NOMIS_OAUTH_HOST="https://sign-in-dev.hmpps.service.justice.gov.uk"
-NOMIS_OAUTH_PUBLIC_KEY='base64-encoded public key from HMPPS SSO'
 PRISON_API_HOST="https://prison-api-dev.prison.service.justice.gov.uk"

--- a/app/services/nomis/oauth/client.rb
+++ b/app/services/nomis/oauth/client.rb
@@ -18,6 +18,15 @@ module Nomis
         JSON.parse(response.body)
       end
 
+      def get(route)
+        response = @connection.send(:get) { |req|
+          url = URI.join(@host, route).to_s
+          req.url(url)
+        }
+
+        JSON.parse(response.body)
+      end
+
     private
 
       def authorisation

--- a/app/services/nomis/oauth/jwks_service.rb
+++ b/app/services/nomis/oauth/jwks_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Nomis
+  module Oauth
+    class JwksService
+      include Singleton
+
+      HOST = Rails.configuration.nomis_oauth_host
+
+      attr_reader :oauth_client
+
+      def initialize(oauth_client: Nomis::Oauth::Client)
+        @oauth_client = oauth_client.new(HOST)
+      end
+
+      def fetch_keys
+        route = '/auth/.well-known/jwks.json'
+        oauth_client.get(route)
+      end
+    end
+  end
+end

--- a/lib/hmpps_sso.rb
+++ b/lib/hmpps_sso.rb
@@ -53,20 +53,21 @@ module OmniAuth
       end
 
       def decode_roles
-        public_key = Base64.urlsafe_decode64(
-          Rails.configuration.nomis_oauth_public_key
-        )
-
         decoded_token = JWT.decode(
           access_token.token,
-          OpenSSL::PKey::RSA.new(public_key),
+          nil,
           true,
-          algorithm: 'RS256'
+          algorithm: 'RS256',
+          jwks: jwks_keys
         )
 
         # decoded_token is a pair of hashes. Most of the useful data is in the first hash
         # the second just contains {"alg"=>"RS256", "typ"=>"JWT", "kid"=>"dev-jwk-kid"}
         decoded_token.first.fetch('authorities', [])
+      end
+
+      def jwks_keys
+        @jwks_keys ||= Nomis::Oauth::JwksService.instance.fetch_keys
       end
 
       def user_details

--- a/spec/fixtures/vcr_cassettes/nomis_oauth_jwks.yml
+++ b/spec/fixtures/vcr_cassettes/nomis_oauth_jwks.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://sign-in-dev.hmpps.service.justice.gov.uk/auth/.well-known/jwks.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 09 Oct 2023 13:16:10 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - max-age=43200, public
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"keys":[{"kty":"RSA","e":"ABQ","use":"sig","kid":"user-kid","alg":"RS256","n":"ZII/AvQAeYSKRaa77rvYP2U+8XrP4Tk0nN0gRE2i+pBqT1wNh1f3gDvdRAa5QZzQc9xY7tKD2WiTYaITjlC+hXObvQaYfsEZtZG+zd5pTtcf96ck0j44c9bdwQ23T9nKgWTMwA=="}]}'
+  recorded_at: Mon, 09 Oct 2023 13:16:10 GMT
+recorded_with: VCR 6.0.0

--- a/spec/services/nomis/oauth/client_spec.rb
+++ b/spec/services/nomis/oauth/client_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe Nomis::Oauth::Client do
 
         client.post(route)
 
-        expect(WebMock).to have_requested(:post, /\w/).
-            with(
+        expect(WebMock).to have_requested(:post, /\w/)
+            .with(
               headers: {
                 Authorization: auth_header
               }
@@ -45,8 +45,8 @@ RSpec.describe Nomis::Oauth::Client do
 
       client.get(route)
 
-      expect(WebMock).to have_requested(:get, /\w\/auth\/.well-known\/jwks.json/).
-        with { |request| expect(request.headers).not_to include('Authorization') }
+      expect(WebMock).to have_requested(:get, /\w\/auth\/.well-known\/jwks.json/)
+        .with { |request| expect(request.headers).not_to include('Authorization') }
     end
   end
 end

--- a/spec/services/nomis/oauth/client_spec.rb
+++ b/spec/services/nomis/oauth/client_spec.rb
@@ -2,34 +2,51 @@ require 'rails_helper'
 require 'base64'
 
 RSpec.describe Nomis::Oauth::Client do
-  describe 'with a valid request' do
-    let(:client_id) { 'my_client_id' }
-    let(:client_secret) { 'a_value_like_>>>_that_base64_encodes_with_plus_or_slash' }
-
+  describe '#post' do
     let(:auth_header) do
       'Basic bXlfY2xpZW50X2lkOmFfdmFsdWVfbGlrZV8+Pj5fdGhhdF9iYXNlNjRfZW5jb2Rlc193aXRoX3BsdXNfb3Jfc2xhc2g='
     end
 
-    before do
-      allow(Rails.configuration).to receive(:nomis_oauth_client_id).and_return(client_id)
-      allow(Rails.configuration).to receive(:nomis_oauth_client_secret).and_return(client_secret)
-    end
+    describe 'with a valid request' do
+      let(:client_id) { 'my_client_id' }
+      let(:client_secret) { 'a_value_like_>>>_that_base64_encodes_with_plus_or_slash' }
 
-    it 'sets the Authorization header' do
-      WebMock.stub_request(:post, /\w/).to_return(body: '{}')
+      before do
+        allow(Rails.configuration).to receive(:nomis_oauth_client_id).and_return(client_id)
+        allow(Rails.configuration).to receive(:nomis_oauth_client_secret).and_return(client_secret)
+      end
+
+      it 'sets the Authorization header' do
+        WebMock.stub_request(:post, /\w/).to_return(body: '{}')
+
+        api_host = Rails.configuration.nomis_oauth_host
+        route = '/auth/oauth/token?grant_type=client_credentials'
+        client = described_class.new(api_host)
+
+        client.post(route)
+
+        expect(WebMock).to have_requested(:post, /\w/).
+            with(
+              headers: {
+                Authorization: auth_header
+              }
+            )
+      end
+    end
+  end
+
+  describe '#get' do
+    it 'does not set the Authorization header' do
+      WebMock.stub_request(:get, /\w/).to_return(body: '{}')
 
       api_host = Rails.configuration.nomis_oauth_host
-      route = '/auth/oauth/token?grant_type=client_credentials'
+      route = '/auth/.well-known/jwks.json'
       client = described_class.new(api_host)
 
-      client.post(route)
+      client.get(route)
 
-      expect(WebMock).to have_requested(:post, /\w/)
-          .with(
-            headers: {
-              Authorization: auth_header
-            }
-          )
+      expect(WebMock).to have_requested(:get, /\w\/auth\/.well-known\/jwks.json/).
+        with { |request| expect(request.headers).not_to include('Authorization') }
     end
   end
 end

--- a/spec/services/nomis/oauth/jwks_service_spec.rb
+++ b/spec/services/nomis/oauth/jwks_service_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Nomis::Oauth::JwksService do
           "alg" => "RS256",
           "n" => "ZII/AvQAeYSKRaa77rvYP2U+8XrP4Tk0nN0gRE2i+pBqT1wNh1f3gDvdRAa5QZzQc9xY7tKD2WiTYaITjlC+hXObvQaYfsEZtZG+zd5pTtcf96ck0j44c9bdwQ23T9nKgWTMwA=="
         }]
-        )
+      )
     end
   end
 end

--- a/spec/services/nomis/oauth/jwks_service_spec.rb
+++ b/spec/services/nomis/oauth/jwks_service_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Nomis::Oauth::JwksService do
+  subject { described_class.instance }
+
+  describe '#fetch_keys' do
+    it 'returns jwks keys as JSON array', vcr: { cassette_name: 'nomis_oauth_jwks' } do
+      expect(subject.fetch_keys).to eq(
+        "keys" => [{
+          "kty" => "RSA",
+          "e" => "ABQ",
+          "use" => "sig",
+          "kid" => "user-kid",
+          "alg" => "RS256",
+          "n" => "ZII/AvQAeYSKRaa77rvYP2U+8XrP4Tk0nN0gRE2i+pBqT1wNh1f3gDvdRAa5QZzQc9xY7tKD2WiTYaITjlC+hXObvQaYfsEZtZG+zd5pTtcf96ck0j44c9bdwQ23T9nKgWTMwA=="
+        }]
+        )
+    end
+  end
+end


### PR DESCRIPTION
Validate the JWT token with the set of keys provided by the `/auth/.well-known/jwks.json` endpoint

<!--- Provide a general summary of your changes in the Title above -->

## Description

* https://github.com/jwt/ruby-jwt#json-web-key-jwk
* https://github.com/jwt/ruby-jwt/blob/695143655b95d843d03d4a98ca43709cbe8169b4/spec/jwk/decode_with_jwk_spec.rb#L22

## Motivation and Context
<!--- Why is this change required? What problem does it solve? Required if your PR is not a slot update -->
<!--- Please add a link to any relevant Trello cards, Jira pages, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Prison details update (e.g. slot updates)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask! -->
- [ ] [My commit message follows the GDS git style standards we have adopted](https://github.com/alphagov/styleguides/blob/master/git.md).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the deployment repo accordingly.
- [ ] I have added tests to cover my changes.
