### PR TITLE
Removed Saturday from timetable

### DIFF
--- a/db/seeds/prisons/CKI-cookham-wood.yml
+++ b/db/seeds/prisons/CKI-cookham-wood.yml
@@ -12,8 +12,6 @@ closed: false
 recurring:
   thu:
   - 1430-1600
-  sat:
-  - 1430-1600
   sun:
   - 1430-1600
 unbookable:


### PR DESCRIPTION
Cookham Wood have asked to remove the Saturday date from their timetable effective 7 October 2023.