### PR TITLE
Update BRI Bure timetable

### DIFF
--- a/db/seeds/prisons/BRI-bure.yml
+++ b/db/seeds/prisons/BRI-bure.yml
@@ -11,10 +11,10 @@ private: false
 closed: false
 recurring:
   sat:
-  - 0930-1130
+  - 0915-1115
   - 1415-1615
   sun:
-  - 0930-1130
+  - 0915-1115
   - 1415-1615
 unbookable:
 - 2022-12-25


### PR DESCRIPTION
Please would you be able to update the online booking service to morning visits on Saturdays and Sundays to 9:15 – 11:15 rather than 9:30 – 11:30.
