### PR TITLE
VB-3234, update cronjob api version, remove refresh-views on dev

### DIFF
--- a/deploy/development/cronjob.yaml
+++ b/deploy/development/cronjob.yaml
@@ -1,40 +1,4 @@
-apiVersion: batch/v1beta1
-kind: CronJob
-metadata:
-  name: refresh-views
-spec:
-  schedule: "0 0 * * *"
-  concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 3
-  jobTemplate:
-    spec:
-      template:
-        spec:
-          containers:
-          - name: prison-visits-booking-staff-pvb-metrics-refresh
-            image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/prison-visits-booking/prison-visits-staff:latest
-            imagePullPolicy: Always
-            command: ['sh', '-c', "bundle exec rake pvb:metrics:refresh"]
-            envFrom:
-              - configMapRef:
-                  name: shared-environment
-              - secretRef:
-                  name: secrets
-            env:
-              - name: DATABASE_URL
-                valueFrom:
-                  secretKeyRef:
-                    name: prison-visits-rds-instance-output
-                    key: url
-              - name: REDIS_URL
-                valueFrom:
-                  secretKeyRef:
-                    name: elasticache-redis
-                    key: url
-          restartPolicy: OnFailure
----
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: delete-load-test-data
@@ -59,7 +23,7 @@ spec:
                   name: secrets
           restartPolicy: OnFailure
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: anonymise-data

--- a/deploy/development/load-nomis-slots.yaml
+++ b/deploy/development/load-nomis-slots.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: load-nomis-slots

--- a/deploy/production/cronjob.yaml
+++ b/deploy/production/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: refresh-views
@@ -34,7 +34,7 @@ spec:
                     key: url
           restartPolicy: OnFailure
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: anonymise-data

--- a/deploy/production/load-nomis-slots.yaml
+++ b/deploy/production/load-nomis-slots.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: load-nomis-slots

--- a/deploy/staging/cronjob.yaml
+++ b/deploy/staging/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: refresh-views
@@ -34,7 +34,7 @@ spec:
                     key: url
           restartPolicy: OnFailure
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: delete-load-test-data
@@ -59,7 +59,7 @@ spec:
                   name: secrets
           restartPolicy: OnFailure
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: anonymise-data

--- a/deploy/staging/load-nomis-slots.yaml
+++ b/deploy/staging/load-nomis-slots.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: load-nomis-slots


### PR DESCRIPTION
## Description

Update all cronjobs to use `batch/v1` instead of the currently used and soon to be deprecated `batch/v1beta1`

Remove the dev cronjob `refresh-views` as it fails on that namespace (works on other namespaces (job refreshes metrics which isn't useful for dev anyway)