### PR TITLE
Change dev cronjob runtime to reduce sentry errors

### DIFF
--- a/deploy/development/cronjob.yaml
+++ b/deploy/development/cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: delete-load-test-data
 spec:
-  schedule: "0 1 * * *"
+  schedule: "0 8 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
@@ -28,7 +28,7 @@ kind: CronJob
 metadata:
   name: anonymise-data
 spec:
-  schedule: "0 0 * * *"
+  schedule: "0 7 * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
## Description

Change development cronjob runtime to 7 / 8 am. As the overnight shutdown is causing excessive errors in Sentry