### PR TITLE
still run tests, but don't require

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ workflows:
       - build_and_push_docker_image:
           requires:
             - helm_lint
-            - test
+            # - test
       - hmpps/deploy_env:
           name: deploy_dev
           context:


### PR DESCRIPTION
Make tests still run - but no longer required to deploy