### PR TITLE
Temporarily turn off Brixton from 19/09

### DIFF
--- a/db/seeds/prisons/BXI-brixton.yml
+++ b/db/seeds/prisons/BXI-brixton.yml
@@ -6,7 +6,7 @@ address: |-
 postcode: SW2 5XF
 email_address: socialvisits.brixton@justice.gov.uk
 phone_no: 0208 678 1433
-enabled: true
+enabled: false
 private: false
 closed: false
 recurring:


### PR DESCRIPTION
Brixton would like to shut down the online booking service for HMP Brixton from 19.09.2024 until 10.10.2024. 

This is due to staffing issues and staff who will be trained to just book visits through the telephone for this period of time.