### PR TITLE
Re-link Highdown Nomis connection

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -4,7 +4,7 @@ environment:
     PRISON_API_HOST: "https://prison-api-dev.prison.service.justice.gov.uk"
     NOMIS_OAUTH_HOST: "https://sign-in-dev.hmpps.service.justice.gov.uk"
     KUBERNETES_DEPLOYMENT: "true"
-    NOMIS_STAFF_SLOT_AVAILABILITY_ENABLED: "false"
+    NOMIS_STAFF_SLOT_AVAILABILITY_ENABLED: "true"
     PUBLIC_SERVICE_URL: "https://dev.prisonvisits.service.justice.gov.uk"
     PVB_TEAM_EMAIL: "pvb-team@digital.justice.gov.uk"
     RACK_ENV: "development"
@@ -16,6 +16,10 @@ environment:
     WEB_CONCURRENCY: "5"
     ZENDESK_URL: "https://ministryofjustice.zendesk.com/api/v2"
     ZENDESK_USERNAME: "pvb-technical-support+zendesk@digital.justice.gov.uk"
+    STAFF_PRISONS_WITH_SLOT_AVAILABILITY: >
+      High Down,
+    PUBLIC_PRISONS_WITH_SLOT_AVAILABILITY: >
+      High Down,
     PRODUCT_ID: "DPS031"
 
 generic-service:

--- a/helm_deploy/values-production.yaml
+++ b/helm_deploy/values-production.yaml
@@ -5,7 +5,7 @@ environment:
     PRISON_API_HOST: "https://prison-api.prison.service.justice.gov.uk"
     NOMIS_OAUTH_HOST: "https://sign-in.hmpps.service.justice.gov.uk"
     MOJSSO_URL: "https://signon.service.justice.gov.uk"
-    NOMIS_STAFF_SLOT_AVAILABILITY_ENABLED: "false"
+    NOMIS_STAFF_SLOT_AVAILABILITY_ENABLED: "true"
     PUBLIC_SERVICE_URL: "https://prisonvisits.service.gov.uk"
     PVB_TEAM_EMAIL: "pvb-team@digital.justice.gov.uk"
     RACK_ENV: "production"
@@ -17,6 +17,10 @@ environment:
     WEB_CONCURRENCY: "5"
     ZENDESK_URL: "https://ministryofjustice.zendesk.com/api/v2"
     ZENDESK_USERNAME: "pvb-technical-support+zendesk@digital.justice.gov.uk"
+    STAFF_PRISONS_WITH_SLOT_AVAILABILITY: >
+      High Down,
+    PUBLIC_PRISONS_WITH_SLOT_AVAILABILITY: >
+      High Down,
     PRODUCT_ID: "DPS031"
 
 cronJobs:

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -4,7 +4,7 @@ environment:
     PRISON_API_HOST: "https://prison-api-preprod.prison.service.justice.gov.uk"
     NOMIS_OAUTH_HOST: "https://sign-in-preprod.hmpps.service.justice.gov.uk"
     MOJSSO_URL: "https://signon.service.justice.gov.uk"
-    NOMIS_STAFF_SLOT_AVAILABILITY_ENABLED: "false"
+    NOMIS_STAFF_SLOT_AVAILABILITY_ENABLED: "true"
     PUBLIC_SERVICE_URL: "https://prison-visits-public-staging.apps.live.cloud-platform.service.justice.gov.uk"
     PVB_TEAM_EMAIL: "pvb-team@digital.justice.gov.uk"
     RACK_ENV: "production"
@@ -16,6 +16,10 @@ environment:
     WEB_CONCURRENCY: "5"
     ZENDESK_URL: "https://ministryofjustice.zendesk.com/api/v2"
     ZENDESK_USERNAME: "pvb-technical-support+zendesk@digital.justice.gov.uk"
+    STAFF_PRISONS_WITH_SLOT_AVAILABILITY: >
+      High Down,
+    PUBLIC_PRISONS_WITH_SLOT_AVAILABILITY: >
+      High Down,
     PRODUCT_ID: "DPS031"
 
 cronJobs:


### PR DESCRIPTION
Revert commit [83c12f7](https://github.com/ministryofjustice/prison-visits-2/commit/83c12f74c9f30f5059bc5137aff58afa1c886469)


Highdown require their NOMIS link to be re-enabled