### PR TITLE
Turn off Brixton for the holidays

### DIFF
--- a/db/seeds/prisons/BXI-brixton.yml
+++ b/db/seeds/prisons/BXI-brixton.yml
@@ -6,7 +6,7 @@ address: |-
 postcode: SW2 5XF
 email_address: socialvisits.brixton@justice.gov.uk
 phone_no: 0208 678 1433
-enabled: true
+enabled: false
 private: false
 closed: false
 recurring:


### PR DESCRIPTION
Brixton have requested we turn off the service over Christmas from 23/12 to 03/01 inclusive.

This PR is for turning Brixton OFF.

DO NOT MERGE until afternoon of 23/12