### PR TITLE
Turns off Brixton

### DIFF
--- a/db/seeds/prisons/BXI-brixton.yml
+++ b/db/seeds/prisons/BXI-brixton.yml
@@ -6,7 +6,7 @@ address: |-
 postcode: SW2 5XF
 email_address: socialvisits.brixton@justice.gov.uk
 phone_no: 0208 678 1433
-enabled: true
+enabled: false
 private: false
 closed: false
 recurring:
@@ -32,10 +32,6 @@ recurring:
   - 1045-1145
   - 1415-1615
 unbookable:
-- 2024-12-04
-- 2024-12-18
-- 2024-12-23
-- 2024-12-25
 - 2024-12-26
 anomalous:
   2022-12-18:


### PR DESCRIPTION
> We have no staff on 21/02/2025 – 25/02/2025 

This PR turns off Brixton (BXI) - another PR will be created to turn it back on 25/02

We will merge and release this PR on evening of 20/02