### PR TITLE
Update PG version to match prod (v15 currently)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ references:
           RACK_ENV: test
           PRISON_API_HOST: https://prison-api-dev.prison.service.justice.gov.uk
           NOMIS_OAUTH_HOST: https://sign-in-dev.hmpps.service.justice.gov.uk
-      - image: cimg/postgres:12.11
+      - image: cimg/postgres:15.12
         environment:
           POSTGRES_USER: ubuntu
           POSTGRES_PASSWORD: ""

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN \
     --no-install-recommends \
     apt-transport-https \
     build-essential \
-    libpq-dev \
     netcat \
     nodejs \
   && timedatectl set-timezone Europe/London || true \
@@ -49,14 +48,17 @@ RUN \
     yarn=1.10.1-1 \
   && yarn add govuk-frontend
 
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends gnupg curl; \
+    install -d -m 0755 /etc/apt/keyrings; \
+    curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+      | gpg --dearmor -o /etc/apt/keyrings/postgresql.gpg; \
+    echo "deb [signed-by=/etc/apt/keyrings/postgresql.gpg] http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" \
+      > /etc/apt/sources.list.d/pgdg.list
 
-RUN echo "deb http://apt-archive.postgresql.org/pub/repos/apt/ stretch-pgdg main" >  /etc/apt/sources.list.d/pgdg.list && \
-    wget --no-check-certificate -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-
-# Update openssl & ca-certificates so that communication with signon can take place
-# (TODO: Remove this when base container has been updated)
 RUN apt-get update && \
-    apt-get install -y ca-certificates openssl postgresql-client-12 && \
+    apt-get install -y ca-certificates openssl postgresql-client-15 libpq-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## What does this PR do?

Update circle-ci configs and DockerFile configs to use v15 of postgresql including the client versions, to match up with the AWS DB version.

## Important Note
This doesn't tackle the local configs (docker-compose / script files). I haven't figured out what is happening with the database scripts, and local DockerFile / local docker-compose. Another PR may be raised to solve these, but for now fix the more pressing issue of misalignment in prod.